### PR TITLE
docs: simplify installation instructions to use go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,15 +157,7 @@ See [docs/COMMANDS.md](docs/COMMANDS.md) for detailed command reference.
 ## Installation
 
 ```bash
-# Clone the repository
-git clone https://github.com/DataDog/pup.git
-cd pup
-
-# Build
-go build -o pup .
-
-# Install (optional)
-go install
+go install github.com/DataDog/pup@latest
 ```
 
 ## Authentication


### PR DESCRIPTION
## Summary
- Replace multi-step clone-and-build installation instructions with a single `go install github.com/DataDog/pup@latest` command

## Test plan
- [x] Verify `go install github.com/DataDog/pup@latest` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)