### PR TITLE
chore(deps): add dependabot configuration for grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      all:
+        patterns:
+          - "*"
+
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      all:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
Adds Dependabot configuration to automate dependency updates with grouped PRs for both GitHub Actions and Go modules.

## Changes
- Add `.github/dependabot.yml` with weekly update schedules
- Configure grouped updates for GitHub Actions dependencies
- Configure grouped updates for Go module dependencies

## Benefits
- Automated security and feature updates
- Reduced PR noise with grouped updates
- Weekly schedule balances freshness with review burden

## Testing
- Configuration validated against Dependabot schema
- Will be verified by Dependabot service once merged

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)