### PR TITLE
fix(logs): use UnixMilli for v1 logs search timestamps

### DIFF
--- a/cmd/logs_simple.go
+++ b/cmd/logs_simple.go
@@ -655,8 +655,8 @@ func runLogsSearch(cmd *cobra.Command, args []string) error {
 	api := datadogV1.NewLogsApi(client.V1())
 
 	limit := int32(logsLimit)
-	fromTimeObj := time.Unix(fromTime, 0)
-	toTimeObj := time.Unix(toTime, 0)
+	fromTimeObj := time.UnixMilli(fromTime)
+	toTimeObj := time.UnixMilli(toTime)
 
 	body := datadogV1.LogsListRequest{
 		Query: &logsQuery,


### PR DESCRIPTION
## Summary
- `parseTimeString` returns milliseconds but `runLogsSearch` passed them to `time.Unix()` which expects seconds
- This produced timestamps far in the future (~year 65,000), causing `400 Bad Request` from the Datadog API
- Fixed by using `time.UnixMilli()` instead of `time.Unix()`

## Test plan
- [ ] Run `pup logs search --query="status:error" --from="1h"` and verify it returns results instead of 400
- [ ] Run `pup logs search --query="*" --from="30m" --limit=5` to confirm basic queries work

🤖 Generated with [Claude Code](https://claude.com/claude-code)