### PR TITLE
fix: complete rename from fetch to pup in remaining code references

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -31,7 +31,7 @@ API keys. It uses PKCE (Proof Key for Code Exchange) and Dynamic Client
 Registration for maximum security.
 
 AUTHENTICATION METHODS:
-  Fetch supports two authentication methods:
+  Pup supports two authentication methods:
 
   1. OAuth2 (RECOMMENDED):
      - Browser-based login flow

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -14,5 +14,5 @@ var (
 
 // BuildInfo returns formatted build information
 func BuildInfo() string {
-	return "Fetch " + Version + " (" + GitCommit + ") built on " + BuildDate
+	return "Pup " + Version + " (" + GitCommit + ") built on " + BuildDate
 }

--- a/pkg/auth/storage/factory.go
+++ b/pkg/auth/storage/factory.go
@@ -119,7 +119,7 @@ func detectBackend() (BackendType, error) {
 	if !fallbackWarningShown {
 		fmt.Fprintln(os.Stderr,
 			"⚠️  Warning: OS keychain not available, falling back to file-based token storage.\n"+
-				"   Tokens will be stored in ~/.config/fetch/ with file permissions 0600.\n"+
+				"   Tokens will be stored in ~/.config/pup/ with file permissions 0600.\n"+
 				"   Set DD_TOKEN_STORAGE=file to suppress this warning.")
 		fallbackWarningShown = true
 	}


### PR DESCRIPTION
## Summary
Complete the project rename from "fetch" to "pup" started in commit 2901608.

## Changes
- `internal/version/version.go:17` - Change "Fetch" to "Pup" in BuildInfo()
- `pkg/auth/storage/factory.go:122` - Fix path in warning message
- `cmd/auth.go:34` - Fix help text

## Testing
- Built and ran `pup version` - shows "Pup" correctly
- All existing tests pass
- No functional changes, only display text

## Related
This cleanup enables PR #2 for user agent enhancement to stay focused.