### PR TITLE
fix(test): prevent panic on missing API/App key

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -205,6 +205,13 @@ var testCmd = &cobra.Command{
 			return err
 		}
 
+		if cfg.APIKey == "" {
+			return fmt.Errorf("DD_API_KEY is required (set via environment variable or run 'pup auth login')")
+		}
+		if cfg.AppKey == "" {
+			return fmt.Errorf("DD_APP_KEY is required (set via environment variable or run 'pup auth login')")
+		}
+
 		fmt.Println("Configuration is valid:")
 		fmt.Printf("  Site: %s\n", cfg.Site)
 		fmt.Printf("  API Key: %s...%s\n", cfg.APIKey[:8], cfg.APIKey[len(cfg.APIKey)-4:])


### PR DESCRIPTION
## Summary
- `pup test` panicked with `slice bounds out of range [:8] with length 0` when `DD_APP_KEY` (or `DD_API_KEY`) was not set, because the masking code tried to slice an empty string
- Added explicit empty-key checks before the masking code, returning a clear error message

## Changes
- `cmd/root.go:208-214` - validate `APIKey` and `AppKey` are non-empty before slicing
- `cmd/root_test.go` - added `TestTestCmd_MissingKeys` (3 cases) and `TestTestCmd_ValidKeys`

## Testing
- `go test ./...` all passing
- Manually verified `pup test` with missing app key now returns a helpful error instead of panicking