### PR TITLE
fix(cmd): remove deprecated findings endpoints and broken vulnerabilities commands

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,7 +72,6 @@ func init() {
 	rootCmd.AddCommand(incidentsCmd)
 	rootCmd.AddCommand(rumCmd)
 	rootCmd.AddCommand(cicdCmd)
-	rootCmd.AddCommand(vulnerabilitiesCmd)
 	rootCmd.AddCommand(staticAnalysisCmd)
 	rootCmd.AddCommand(downtimeCmd)
 	rootCmd.AddCommand(tagsCmd)

--- a/cmd/security_test.go
+++ b/cmd/security_test.go
@@ -119,16 +119,16 @@ func TestSecurityFindingsCmd(t *testing.T) {
 		t.Error("Short description is empty")
 	}
 
-	// Check for list subcommand
+	// Check for search subcommand
 	commands := securityFindingsCmd.Commands()
-	foundList := false
+	foundSearch := false
 	for _, cmd := range commands {
-		if cmd.Use == "list" {
-			foundList = true
+		if cmd.Use == "search" {
+			foundSearch = true
 		}
 	}
-	if !foundList {
-		t.Error("Missing findings list subcommand")
+	if !foundSearch {
+		t.Error("Missing findings search subcommand")
 	}
 }
 

--- a/cmd/vulnerabilities.go
+++ b/cmd/vulnerabilities.go
@@ -7,45 +7,11 @@ package cmd
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/DataDog/pup/pkg/formatter"
 	"github.com/spf13/cobra"
 )
-
-var vulnerabilitiesCmd = &cobra.Command{
-	Use:   "vulnerabilities",
-	Short: "Manage security vulnerabilities",
-	Long: `Search and list security vulnerabilities in your applications.
-
-CAPABILITIES:
-  • Search vulnerabilities with custom queries
-  • Filter by severity, status, service, and repository
-  • Track vulnerability remediation status
-
-EXAMPLES:
-  # Search for critical vulnerabilities
-  pup vulnerabilities search --query="severity:critical"
-
-  # List all open vulnerabilities
-  pup vulnerabilities list --severity="critical,high" --status="open"
-
-AUTHENTICATION:
-  Requires either OAuth2 authentication or API keys.`,
-}
-
-var vulnerabilitiesSearchCmd = &cobra.Command{
-	Use:   "search",
-	Short: "Search vulnerabilities",
-	RunE:  runVulnerabilitiesSearch,
-}
-
-var vulnerabilitiesListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List vulnerabilities",
-	RunE:  runVulnerabilitiesList,
-}
 
 var staticAnalysisCmd = &cobra.Command{
 	Use:   "static-analysis",
@@ -139,41 +105,16 @@ var staticAnalysisCoverageGetCmd = &cobra.Command{
 }
 
 var (
-	vulnQuery      string
-	vulnSeverity   string
-	vulnStatus     string
-	vulnService    string
-	vulnRepository string
-	vulnFrom       string
-	vulnTo         string
-	vulnLimit      int32
-	vulnOffset     int32
-	saRepository   string
-	saBranch       string
-	saLanguage     string
-	saFrom         string
-	saTo           string
-	saSeverity     string
-	saStatus       string
+	saRepository string
+	saBranch     string
+	saLanguage   string
+	saFrom       string
+	saTo         string
+	saSeverity   string
+	saStatus     string
 )
 
 func init() {
-	vulnerabilitiesSearchCmd.Flags().StringVarP(&vulnQuery, "query", "q", "", "Search query (required)")
-	vulnerabilitiesSearchCmd.Flags().StringVar(&vulnFrom, "from", "", "Start time")
-	vulnerabilitiesSearchCmd.Flags().StringVar(&vulnTo, "to", "", "End time")
-	vulnerabilitiesSearchCmd.Flags().Int32Var(&vulnLimit, "limit", 100, "Maximum results")
-	vulnerabilitiesSearchCmd.Flags().Int32Var(&vulnOffset, "offset", 0, "Results offset")
-	if err := vulnerabilitiesSearchCmd.MarkFlagRequired("query"); err != nil {
-		panic(fmt.Errorf("failed to mark flag as required: %w", err))
-	}
-
-	vulnerabilitiesListCmd.Flags().StringVar(&vulnSeverity, "severity", "", "Filter by severity")
-	vulnerabilitiesListCmd.Flags().StringVar(&vulnStatus, "status", "", "Filter by status")
-	vulnerabilitiesListCmd.Flags().StringVar(&vulnService, "service", "", "Filter by service")
-	vulnerabilitiesListCmd.Flags().StringVar(&vulnRepository, "repository", "", "Filter by repository")
-	vulnerabilitiesListCmd.Flags().Int32Var(&vulnLimit, "limit", 100, "Maximum results")
-	vulnerabilitiesListCmd.Flags().Int32Var(&vulnOffset, "offset", 0, "Results offset")
-
 	staticAnalysisASTListCmd.Flags().StringVar(&saRepository, "repository", "", "Filter by repository")
 	staticAnalysisASTListCmd.Flags().StringVar(&saBranch, "branch", "", "Filter by branch")
 	staticAnalysisASTListCmd.Flags().StringVar(&saLanguage, "language", "", "Filter by language")
@@ -189,116 +130,11 @@ func init() {
 	staticAnalysisCoverageListCmd.Flags().StringVar(&saFrom, "from", "", "Start time")
 	staticAnalysisCoverageListCmd.Flags().StringVar(&saTo, "to", "", "End time")
 
-	vulnerabilitiesCmd.AddCommand(vulnerabilitiesSearchCmd, vulnerabilitiesListCmd)
 	staticAnalysisASTCmd.AddCommand(staticAnalysisASTListCmd, staticAnalysisASTGetCmd)
 	staticAnalysisCustomRulesetsCmd.AddCommand(staticAnalysisCustomRulesetsListCmd, staticAnalysisCustomRulesetsGetCmd)
 	staticAnalysisSCACmd.AddCommand(staticAnalysisSCAListCmd, staticAnalysisSCAGetCmd)
 	staticAnalysisCoverageCmd.AddCommand(staticAnalysisCoverageListCmd, staticAnalysisCoverageGetCmd)
 	staticAnalysisCmd.AddCommand(staticAnalysisASTCmd, staticAnalysisCustomRulesetsCmd, staticAnalysisSCACmd, staticAnalysisCoverageCmd)
-}
-
-func runVulnerabilitiesSearch(cmd *cobra.Command, args []string) error {
-	client, err := getClient()
-	if err != nil {
-		return err
-	}
-
-	api := datadogV2.NewSecurityMonitoringApi(client.V2())
-	body := datadogV2.SecurityMonitoringSignalListRequest{
-		Filter: &datadogV2.SecurityMonitoringSignalListRequestFilter{
-			Query: &vulnQuery,
-		},
-		Page: &datadogV2.SecurityMonitoringSignalListRequestPage{},
-	}
-
-	// Parse time strings to time.Time
-	if vulnFrom != "" {
-		fromTime, err := time.Parse(time.RFC3339, vulnFrom)
-		if err != nil {
-			return fmt.Errorf("invalid from time format (use RFC3339): %w", err)
-		}
-		body.Filter.From = &fromTime
-	}
-	if vulnTo != "" {
-		toTime, err := time.Parse(time.RFC3339, vulnTo)
-		if err != nil {
-			return fmt.Errorf("invalid to time format (use RFC3339): %w", err)
-		}
-		body.Filter.To = &toTime
-	}
-	if vulnLimit > 0 {
-		limit := int32(vulnLimit)
-		body.Page.Limit = &limit
-	}
-	// Note: Offset pagination is not supported, use cursor-based pagination instead
-
-	opts := datadogV2.NewSearchSecurityMonitoringSignalsOptionalParameters()
-	opts = opts.WithBody(body)
-	resp, r, err := api.SearchSecurityMonitoringSignals(client.Context(), *opts)
-	if err != nil {
-		if r != nil {
-			return fmt.Errorf("failed to search vulnerabilities: %w (status: %d)", err, r.StatusCode)
-		}
-		return fmt.Errorf("failed to search vulnerabilities: %w", err)
-	}
-
-	output, err := formatter.FormatOutput(resp, formatter.OutputFormat(outputFormat))
-	if err != nil {
-		return err
-	}
-	fmt.Println(output)
-	return nil
-}
-
-func runVulnerabilitiesList(cmd *cobra.Command, args []string) error {
-	client, err := getClient()
-	if err != nil {
-		return err
-	}
-
-	api := datadogV2.NewSecurityMonitoringApi(client.V2())
-	opts := datadogV2.NewListSecurityMonitoringSignalsOptionalParameters()
-
-	var queryParts []string
-	if vulnSeverity != "" {
-		queryParts = append(queryParts, fmt.Sprintf("severity:(%s)", vulnSeverity))
-	}
-	if vulnStatus != "" {
-		queryParts = append(queryParts, fmt.Sprintf("status:(%s)", vulnStatus))
-	}
-	if vulnService != "" {
-		queryParts = append(queryParts, fmt.Sprintf("service:%s", vulnService))
-	}
-	if vulnRepository != "" {
-		queryParts = append(queryParts, fmt.Sprintf("repository:%s", vulnRepository))
-	}
-
-	if len(queryParts) > 0 {
-		filterQuery := queryParts[0]
-		for i := 1; i < len(queryParts); i++ {
-			filterQuery = fmt.Sprintf("%s AND %s", filterQuery, queryParts[i])
-		}
-		opts = opts.WithFilterQuery(filterQuery)
-	}
-
-	if vulnLimit > 0 {
-		opts = opts.WithPageLimit(int32(vulnLimit))
-	}
-
-	resp, r, err := api.ListSecurityMonitoringSignals(client.Context(), *opts)
-	if err != nil {
-		if r != nil {
-			return fmt.Errorf("failed to list vulnerabilities: %w (status: %d)", err, r.StatusCode)
-		}
-		return fmt.Errorf("failed to list vulnerabilities: %w", err)
-	}
-
-	output, err := formatter.FormatOutput(resp, formatter.OutputFormat(outputFormat))
-	if err != nil {
-		return err
-	}
-	fmt.Println(output)
-	return nil
 }
 
 func runStaticAnalysisASTList(cmd *cobra.Command, args []string) error {

--- a/cmd/vulnerabilities_test.go
+++ b/cmd/vulnerabilities_test.go
@@ -9,77 +9,6 @@ import (
 	"testing"
 )
 
-func TestVulnerabilitiesCmd(t *testing.T) {
-	if vulnerabilitiesCmd == nil {
-		t.Fatal("vulnerabilitiesCmd is nil")
-	}
-
-	if vulnerabilitiesCmd.Use != "vulnerabilities" {
-		t.Errorf("Use = %s, want vulnerabilities", vulnerabilitiesCmd.Use)
-	}
-
-	if vulnerabilitiesCmd.Short == "" {
-		t.Error("Short description is empty")
-	}
-
-	if vulnerabilitiesCmd.Long == "" {
-		t.Error("Long description is empty")
-	}
-}
-
-func TestVulnerabilitiesCmd_Subcommands(t *testing.T) {
-	expectedCommands := []string{"search", "list"}
-
-	commands := vulnerabilitiesCmd.Commands()
-
-	commandMap := make(map[string]bool)
-	for _, cmd := range commands {
-		commandMap[cmd.Use] = true
-	}
-
-	for _, expected := range expectedCommands {
-		if !commandMap[expected] {
-			t.Errorf("Missing subcommand: %s", expected)
-		}
-	}
-}
-
-func TestVulnerabilitiesSearchCmd(t *testing.T) {
-	if vulnerabilitiesSearchCmd == nil {
-		t.Fatal("vulnerabilitiesSearchCmd is nil")
-	}
-
-	if vulnerabilitiesSearchCmd.Use != "search" {
-		t.Errorf("Use = %s, want search", vulnerabilitiesSearchCmd.Use)
-	}
-
-	if vulnerabilitiesSearchCmd.Short == "" {
-		t.Error("Short description is empty")
-	}
-
-	if vulnerabilitiesSearchCmd.RunE == nil {
-		t.Error("RunE is nil")
-	}
-}
-
-func TestVulnerabilitiesListCmd(t *testing.T) {
-	if vulnerabilitiesListCmd == nil {
-		t.Fatal("vulnerabilitiesListCmd is nil")
-	}
-
-	if vulnerabilitiesListCmd.Use != "list" {
-		t.Errorf("Use = %s, want list", vulnerabilitiesListCmd.Use)
-	}
-
-	if vulnerabilitiesListCmd.Short == "" {
-		t.Error("Short description is empty")
-	}
-
-	if vulnerabilitiesListCmd.RunE == nil {
-		t.Error("RunE is nil")
-	}
-}
-
 func TestStaticAnalysisCmd(t *testing.T) {
 	if staticAnalysisCmd == nil {
 		t.Fatal("staticAnalysisCmd is nil")
@@ -168,16 +97,6 @@ func TestStaticAnalysisCoverageCmd(t *testing.T) {
 
 	if staticAnalysisCoverageCmd.Short == "" {
 		t.Error("Short description is empty")
-	}
-}
-
-func TestVulnerabilitiesCmd_ParentChild(t *testing.T) {
-	commands := vulnerabilitiesCmd.Commands()
-
-	for _, cmd := range commands {
-		if cmd.Parent() != vulnerabilitiesCmd {
-			t.Errorf("Command %s parent is not vulnerabilitiesCmd", cmd.Use)
-		}
 	}
 }
 


### PR DESCRIPTION
## Summary
Remove deprecated and broken security/vulnerability commands:
- `security findings list` and `security findings get` — API endpoints being deprecated by Datadog
- `vulnerabilities search` and `vulnerabilities list` — using wrong API methods (signals API instead of vulnerabilities API)

## Changes
- Remove `security findings list` and `security findings get` commands, handlers, and flags from `cmd/security.go`
- Remove `vulnerabilities` top-level command entirely (both subcommands removed) from `cmd/vulnerabilities.go` and `cmd/root.go`
- Update tests in `cmd/security_test.go` and `cmd/vulnerabilities_test.go`
- `security findings search` and all `static-analysis` commands remain intact

## Testing
- `go build ./...` passes
- `go test ./cmd/...` passes
- `go vet ./cmd/...` passes

## Related Issues
N/A

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)