### PR TITLE
docs: update references to removed security commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,7 @@ See [docs/COMMANDS.md](docs/COMMANDS.md) for detailed command reference.
 
 | API Domain | Status | Pup Commands | Notes |
 |------------|--------|--------------|-------|
-| Security Monitoring | ✅ | `security rules list`, `security signals list`, `security findings list/get/search` | Rules, signals, findings with advanced search |
-| Vulnerabilities | ✅ | `vulnerabilities search`, `vulnerabilities list` | Vulnerability tracking and management |
+| Security Monitoring | ✅ | `security rules list`, `security signals list`, `security findings search` | Rules, signals, findings with advanced search |
 | Static Analysis | ✅ | `static-analysis ast`, `static-analysis custom-rulesets`, `static-analysis sca`, `static-analysis coverage` | Code security analysis |
 | Audit Logs | ✅ | `audit-logs list`, `audit-logs search` | Full audit log search and listing |
 | Data Governance | ✅ | `data-governance scanner-rules list` | Sensitive data scanner rules |

--- a/TEST_COVERAGE_SUMMARY.md
+++ b/TEST_COVERAGE_SUMMARY.md
@@ -69,9 +69,8 @@ Created 26 test files with 163 test functions covering command structure, flags,
 11. **security_test.go** - Security monitoring
     - Tests: Rules, signals, findings management
 
-12. **vulnerabilities_test.go** - Security vulnerabilities
-    - Tests: Search, list, static analysis commands
-    - Includes: AST, custom rulesets, SCA, coverage subcommands
+12. **vulnerabilities_test.go** - Static analysis
+    - Tests: Static analysis commands (AST, custom rulesets, SCA, coverage)
 
 ### User & Organization Commands
 13. **users_test.go** - User management
@@ -160,8 +159,7 @@ Several command implementations have compilation errors due to datadog-api-clien
 3. **events.go** - Missing WithStart and WithEnd methods
 4. **tags.go** - Type mismatch with Tags field
 5. **usage.go** - Missing WithEndHr method
-6. **vulnerabilities.go** - Type and method signature mismatches
-7. **rum.go** - Missing ListRUMApplications and NewRUMMetricsApi
+6. **rum.go** - Missing ListRUMApplications and NewRUMMetricsApi
 
 **Impact**: These are structural issues in the API client library, not test issues. The command structure and test patterns are correct and will work once the API client is updated.
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -29,7 +29,6 @@ pup <domain> <subgroup> <action> [options] # Nested commands
 | incidents | list, get, attachments | cmd/incidents.go | ✅ |
 | rum | apps, sessions | cmd/rum.go | ✅ |
 | cicd | pipelines, events | cmd/cicd.go | ✅ |
-| vulnerabilities | search, list | cmd/vulnerabilities.go | ✅ |
 | static-analysis | custom-rulesets | cmd/vulnerabilities.go | ✅ |
 | downtime | list, get, cancel | cmd/downtime.go | ✅ |
 | tags | list, get, add, update, delete | cmd/tags.go | ✅ |
@@ -42,7 +41,7 @@ pup <domain> <subgroup> <action> [options] # Nested commands
 | synthetics | tests, locations | cmd/synthetics.go | ✅ |
 | users | list, get, roles | cmd/users.go | ✅ |
 | notebooks | list, get, delete | cmd/notebooks.go | ✅ |
-| security | rules, signals, findings (list, get, search) | cmd/security.go | ✅ |
+| security | rules, signals, findings (search) | cmd/security.go | ✅ |
 | organizations | get, list | cmd/organizations.go | ✅ |
 | service-catalog | list, get | cmd/service_catalog.go | ✅ |
 | error-tracking | issues (list, get) | cmd/error_tracking.go | ✅ |
@@ -125,8 +124,7 @@ pup infrastructure hosts list
 - **tags** - Host tag management (list, get, add, update, delete)
 
 ### Security & Compliance
-- **security** - Security monitoring (rules, signals, findings)
-- **vulnerabilities** - Vulnerability management (search, list)
+- **security** - Security monitoring (rules, signals, findings search)
 - **static-analysis** - Code security (ast, custom-rulesets, sca, coverage)
 - **audit-logs** - Audit trail (list, search)
 - **data-governance** - Sensitive data scanning (scanner-rules list)
@@ -184,7 +182,6 @@ All 7 previously blocked commands now work:
 - ✅ **events** - Infrastructure event management
 - ✅ **tags** - Host tag operations
 - ✅ **usage** - Usage and billing metrics
-- ✅ **vulnerabilities** - Security vulnerability tracking
 - ✅ **static-analysis** - Code security analysis
 
 ### New Command Groups

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -242,9 +242,8 @@ pup security signals list --from="1h"
 
 ### Search Security Findings
 ```bash
-pup security findings list \
-  --filter="severity:high" \
-  --from="24h"
+pup security findings search \
+  --query="@severity:high"
 ```
 
 ## Infrastructure
@@ -433,7 +432,7 @@ pup security signals list --from="24h"
 pup security rules list
 
 # Search security findings
-pup security findings list --filter="severity:critical"
+pup security findings search --query="@severity:critical"
 
 # Review audit logs
 pup audit-logs list --from="7d"


### PR DESCRIPTION
## Summary
Follow-up to PR #24. Update documentation to reflect the removal of deprecated `security findings list/get` and `vulnerabilities search/list` commands.

## Changes
- **README.md** — Remove Vulnerabilities row from API coverage table, update Security Monitoring commands
- **docs/COMMANDS.md** — Remove vulnerabilities from command table and category listing
- **docs/EXAMPLES.md** — Replace `findings list` examples with `findings search` syntax
- **TEST_COVERAGE_SUMMARY.md** — Update vulnerabilities_test.go description, remove from known issues

## Test plan
- [ ] Docs-only change, no code impact

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)