### PR TITLE
Fix Homebrew install command for pup

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ See [docs/COMMANDS.md](docs/COMMANDS.md) for detailed command reference.
 
 ```bash
 brew tap datadog/pack
-brew install datadog/tap/pup
+brew install datadog/pack/pup
 ```
 
 ### Go Install


### PR DESCRIPTION
`pup` is already a [brew formula](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/p/pup.rb), so there is a conflict and `brew install pup` installs the upstream `pup` by default:

```sh
➜  ~ brew tap datadog/pack
➜  ~ brew install pup
Warning: Treating pup as a formula. For the cask, use datadog/tap/pup or specify the `--cask` flag. To silence this message, use the `--formula` flag.
Warning: pup 0.4.0 is already installed and up-to-date.
To reinstall 0.4.0, run:
  brew reinstall pup
➜  ~ brew info pup
Warning: Treating pup as a formula. For the cask, use datadog/tap/pup or specify the `--cask` flag. To silence this message, use the `--formula` flag.
==> pup ✔: stable 0.4.0 (bottled), HEAD
Parse HTML at the command-line
https://github.com/EricChiang/pup
Deprecated because it is not maintained upstream! It was disabled on 2025-02-24.
Installed
/opt/homebrew/Cellar/pup/0.4.0 (6 files, 4.3MB) *
  Poured from bottle using the formulae.brew.sh API on 2026-02-11 at 14:07:44
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/p/pup.rb
License: MIT
==> Dependencies
Build: go ✔, gox ✘
==> Options
--HEAD
        Install HEAD version
==> Downloading https://formulae.brew.sh/api/formula/pup.json
==> Analytics
install: 134 (30 days), 367 (90 days), 1,739 (365 days)
install-on-request: 134 (30 days), 367 (90 days), 1,739 (365 days)
build-error: 0 (30 days)
```

Using `brew install datadog/pack/pup` works:


```sh
➜  ~ brew uninstall pup
Warning: Treating pup as a formula. For the cask, use datadog/tap/pup or specify the `--cask` flag. To silence this message, use the `--formula` flag.
Warning: Formula postgresql was renamed to postgresql@14.
Warning: Formula postgresql was renamed to postgresql@14.
Uninstalling /opt/homebrew/Cellar/pup/0.4.0... (6 files, 4.3MB)
Warning: Formula postgresql was renamed to postgresql@14.
➜  ~ brew install datadog/pack/pup
==> Fetching downloads for: pup
✔︎ Formula pup (0.7.0)                                                                                                                                   Verified    184.5KB/184.5KB
==> Installing pup from datadog/pack
==> go build -ldflags=-s -w
🍺  /opt/homebrew/Cellar/pup/0.7.0: 9 files, 21.6MB, built in 2 seconds
==> Running `brew cleanup pup`...
Disable this behaviour by setting `HOMEBREW_NO_INSTALL_CLEANUP=1`.
Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
➜  ~ pup --help
Pup is a Go-based command-line wrapper that provides easy interaction
with Datadog APIs. It supports both API key and OAuth2 authentication.
```