### PR TITLE
fix(release): replace deprecated 'folder' field with 'directory' in GoReleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -166,7 +166,7 @@ brews:
     homepage: https://github.com/DataDog/pup
     description: "Datadog API CLI - OAuth2 + API key authentication for Datadog APIs"
     license: Apache-2.0
-    folder: Formula
+    directory: Formula
     commit_author:
       name: goreleaserbot
       email: bot@goreleaser.com


### PR DESCRIPTION
## Summary
Fixes the GoReleaser release workflow failure by replacing the deprecated `folder` field with `directory` in the Homebrew brew configuration.

## Problem
The release workflow was failing with error:
```
yaml: unmarshal errors:
  line 169: field folder not found in type config.Homebrew
```

The `folder` field was deprecated in GoReleaser v2.x and replaced with `directory`.

## Changes
- Updated `.goreleaser.yml:169` to use `directory` instead of `folder`

## Testing
- Configuration change validated against GoReleaser v2.13.3 documentation
- Will be tested when release workflow runs on this PR merge

## Related Issues
Fixes release workflow run #21913974032

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)