### PR TITLE
fix(release): update Go version to 1.25 and migrate to homebrew_casks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.21'
+          go-version: '1.25'
           cache: true
 
       - name: Install cosign

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -157,7 +157,7 @@ changelog:
       order: 999
 
 # Homebrew Tap
-brews:
+homebrew_casks:
   - name: pup
     repository:
       owner: DataDog
@@ -166,23 +166,18 @@ brews:
     homepage: https://github.com/DataDog/pup
     description: "Datadog API CLI - OAuth2 + API key authentication for Datadog APIs"
     license: Apache-2.0
-    directory: Formula
     commit_author:
       name: goreleaserbot
       email: bot@goreleaser.com
-    commit_msg_template: "chore(formula): update {{ .ProjectName }} to {{ .Tag }}"
-    install: |
-      bin.install "pup"
-    test: |
-      system "#{bin}/pup", "version"
-    dependencies:
-      - name: go
-        type: optional
-    extra_install: |
-      # Generate shell completions
-      bash_completion.install "completions/pup.bash" => "pup"
-      zsh_completion.install "completions/pup.zsh" => "_pup"
-      fish_completion.install "completions/pup.fish"
+    commit_msg_template: "chore(cask): update {{ .ProjectName }} to {{ .Tag }}"
+    binaries:
+      - pup
+    completions:
+      bash: "completions/pup.bash"
+      zsh: "completions/pup.zsh"
+      fish: "completions/pup.fish"
+    url:
+      verified: github.com/DataDog/pup/releases/download
 
 # Announce releases
 announce:


### PR DESCRIPTION
## Summary
Fixes two critical issues preventing successful releases:
1. Outdated Go version (1.21 → 1.25)
2. Deprecated GoReleaser `brews` configuration

## Problem 1: Go Version
The release workflow was using Go 1.21, which is outdated and may cause compatibility issues with newer dependencies.

## Problem 2: Deprecated `brews` Configuration
GoReleaser v2.10+ deprecated the `brews` field with warning:
```
brews is being phased out in favor of homebrew_casks
```

## Changes

### `.github/workflows/release.yml`
- Updated `go-version` from `1.21` to `1.25`

### `.goreleaser.yml`
- Migrated from `brews:` to `homebrew_casks:`
- Removed deprecated `directory: Formula` field
- Converted to modern configuration format:
  - `binaries: [pup]` - explicit binary declaration
  - Simplified `completions` structure
  - Added `url.verified` field for Homebrew audit compliance
- Updated commit message template from "formula" to "cask"

## Migration Details

The new `homebrew_casks` configuration provides:
- Better alignment with GoReleaser v2.x architecture
- Cleaner, more maintainable configuration
- Support for shell completions built-in
- Homebrew audit compliance via verified URL

## Testing
- Configuration validated against GoReleaser v2.13.3 documentation
- Syntax follows GoReleaser's own `.goreleaser.yaml` conventions
- Will be tested when release workflow runs after merge

## Related Issues
Fixes release workflow run #21914250220

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)