### PR TITLE
feat(logs): add storage tier support for Flex logs

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -81,6 +81,7 @@ pup slos get abc-123-def
 ### Search/Query
 ```bash
 pup logs search --query="status:error" --from="1h"
+pup logs search --query="service:api" --from="7d" --storage="flex"
 pup metrics search --query="avg:system.cpu.user{*}" --from="1h"
 pup metrics query --query="avg:system.cpu.user{*}" --from="1h"
 pup events search --query="@user.id:12345"

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -116,6 +116,21 @@ pup logs aggregate \
   --group-by="status"
 ```
 
+### Search Logs in Specific Storage Tier
+```bash
+# Search Flex logs (cost-optimized storage tier)
+pup logs search --query="service:api" --from="7d" --storage="flex"
+
+# Search online archives (long-term storage)
+pup logs search --query="status:error" --from="30d" --storage="online-archives"
+
+# Search standard indexes (default, fastest tier)
+pup logs search --query="service:web-app" --from="1h" --storage="indexes"
+
+# Search all storage tiers (default when --storage is not specified)
+pup logs search --query="status:warn" --from="1h"
+```
+
 ## Dashboards
 
 ### List Dashboards


### PR DESCRIPTION
## What does this PR do?

Adds --storage flag to all log search commands (search, list, query, aggregate) enabling users to query specific Datadog log storage tiers: indexes (standard), online-archives (long-term), and flex (cost-optimized).

Changes:
- Added logsStorage flag variable in cmd/logs_simple.go:548
- Implemented validateAndConvertStorageTier() helper function (cmd/logs_simple.go:685-705)
- Added --storage flag to logs search, list, query, aggregate commands
- Modified runLogsSearch(), runLogsList(), runLogsQuery(), runLogsAggregate() to validate and apply storage tier
- Added comprehensive test coverage with 17 test cases in cmd/logs_simple_test.go
- Updated docs/EXAMPLES.md with storage tier usage examples
- Updated docs/COMMANDS.md with Flex logs example

Features:
- Validates storage tier before API calls for fast failure
- Case-insensitive input handling (FLEX, flex, Flex all work)
- Whitespace trimming for user convenience
- Helpful error messages showing valid options
- Backward compatible: omitting --storage searches all tiers (default behavior)

Testing:
- TestValidateAndConvertStorageTier: 9 test cases covering validation logic
- TestRunLogsSearchWithStorageTier: 5 test cases for search command
- TestRunLogsQueryWithStorageTier: 2 test cases for query command
- TestRunLogsAggregateWithStorageTier: 1 test case for aggregate command
- All tests pass with existing test suite
- Full cmd package coverage maintained

## Motivation

I wanted to be able to use the command line to search flex tier logs as that's not supported at the moment.

## Checklist

- [x] The code change follows the project conventions (see [CONTRIBUTING.md](../docs/CONTRIBUTING.md))
- [x] Tests have been added/updated (if applicable)
- [x] Documentation has been updated (if applicable)
- [x] All CI checks pass
- [x] Code coverage is maintained or improved

## Related Issues

I haven't created an issue for this - let me know if you'd like that before getting the PR.
