### PR TITLE
fix(monitors): use monitor_tags API parameter for --tags flag

### DIFF
--- a/cmd/monitors.go
+++ b/cmd/monitors.go
@@ -250,7 +250,7 @@ var (
 
 func init() {
 	monitorsListCmd.Flags().StringVar(&monitorName, "name", "", "Filter monitors by name")
-	monitorsListCmd.Flags().StringVar(&monitorTags, "tags", "", "Filter monitors by tags (comma-separated)")
+	monitorsListCmd.Flags().StringVar(&monitorTags, "tags", "", "Filter by monitor tags (comma-separated, e.g., team:backend,env:prod)")
 	monitorsListCmd.Flags().Int32Var(&monitorLimit, "limit", 200, "Maximum number of monitors to return (default: 200, max: 1000)")
 
 	monitorsSearchCmd.Flags().StringVar(&searchQuery, "query", "", "Search query string")
@@ -279,7 +279,7 @@ func runMonitorsList(cmd *cobra.Command, args []string) error {
 		opts.WithName(monitorName)
 	}
 	if monitorTags != "" {
-		opts.WithTags(monitorTags)
+		opts.WithMonitorTags(monitorTags)
 	}
 
 	// Set limit for results (default 200, max 1000)


### PR DESCRIPTION
## What does this PR do?

This pull request fixes `monitors list --tags` to filter by monitor tags instead of query scope tags by using the correct API parameter.

## Motivation

The `--tags` flag was wired to the Datadog API's `tags` query parameter, which filters by tags in the monitor's **query scope** (e.g., `avg:cpu{env:prod}`). But I/users expect `--tags` to filter by **monitor tags** — the organizational tags assigned to monitors for grouping.The correct API parameter for this is `monitor_tags`.

## Additional Notes

N/A

## Checklist

- [x] The code change follows the project conventions (see [CONTRIBUTING.md](../docs/CONTRIBUTING.md))
- [ ] Tests have been added/updated (if applicable)
- [ ] Documentation has been updated (if applicable)
- [ ] All CI checks pass
- [ ] Code coverage is maintained or improved

## Related Issues

<!-- Link related issues here. Use "Closes #123" to automatically close issues when the PR is merged. -->