### PR TITLE
fix(util): second-aligned millisecond timestamps for all Datadog APIs

### DIFF
--- a/pkg/util/time.go
+++ b/pkg/util/time.go
@@ -89,11 +89,14 @@ func ParseTimeToUnix(timeStr string) (int64, error) {
 	return t.Unix(), nil
 }
 
-// ParseTimeToUnixMilli parses time string and returns Unix timestamp in milliseconds
+// ParseTimeToUnixMilli parses time string and returns Unix timestamp in milliseconds.
+// Uses Unix()*1000 instead of UnixMilli() to produce second-aligned timestamps.
+// time.Now() and duration arithmetic produce nanosecond precision, and UnixMilli()
+// preserves the sub-second component which some Datadog APIs reject or misinterpret.
 func ParseTimeToUnixMilli(timeStr string) (int64, error) {
 	t, err := ParseTimeParam(timeStr)
 	if err != nil {
 		return 0, err
 	}
-	return t.UnixMilli(), nil
+	return t.Unix() * 1000, nil
 }


### PR DESCRIPTION
## Summary
- Picks up the fix from #58 and applies second-aligned millisecond timestamps broadly via `ParseTimeToUnixMilli`
- Fixes the CI build failure in #58 (`undefined: parseTimeParam`)
- All callers of `ParseTimeToUnixMilli` (logs, RUM, error tracking, metrics) now produce second-aligned timestamps by default

## Changes
- `pkg/util/time.go`: Change `ParseTimeToUnixMilli` to use `Unix()*1000` instead of `UnixMilli()` — the central fix
- `cmd/metrics.go`: Simplify V2 timeseries query to use `ParseTimeToUnixMilli` directly instead of `ParseTimeParam` + manual conversion
- `cmd/metrics_test.go`: Fix broken `parseTimeParam` references → `util.ParseTimeToUnixMilli`; tighten test to validate the actual function used in production

## Context
`ParseTimeParam` returns `time.Time` values with nanosecond precision (from `time.Now()` and `time.Duration` arithmetic). `UnixMilli()` preserves the sub-second millisecond component, producing timestamps not on clean second boundaries. Some Datadog APIs reject or misinterpret these. `Unix()*1000` truncates sub-second precision at the source so every callsite benefits.

## Test plan
- [x] `TestV2TimeseriesTimestampConversion` — validates second-aligned output for all input formats
- [x] `TestV2TimestampUnixMilliVsUnixTimes1000` — demonstrates the difference between the two approaches
- [x] `TestParseTimeToUnixMilli` — existing unit tests pass unchanged
- [x] Full `go test ./...` passes (only pre-existing keychain test failure on macOS)

## Related Issues
Supersedes #58

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)