### PR TITLE
fix(ci): skip Datadog reporting steps on non-main branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,14 @@ jobs:
           cache: true
 
       - name: Get Datadog credentials
+        if: github.ref == 'refs/heads/main'
         id: dd-sts # Needed to be able to reference this step's output later
         uses: DataDog/dd-sts-action@main # Pin to the main branch to get auto updates for free, or to a specific commit hash if you want stability
         with:
           policy: public-datadog-pup-sts
 
       - name: Configure Datadog Test Optimization
+        if: github.ref == 'refs/heads/main'
         uses: datadog/test-visibility-github-action@v2
         with:
           languages: go
@@ -54,6 +56,7 @@ jobs:
           site: datadoghq.com
 
       - name: Install Datadog CI tools
+        if: github.ref == 'refs/heads/main'
         run: |
           # Install orchestrion for Go test instrumentation
           go install github.com/DataDog/orchestrion@latest
@@ -117,7 +120,7 @@ jobs:
           go tool cover -func=coverage.out | tail -1 >> coverage_report.txt
 
       - name: Upload coverage to Datadog
-        if: env.DD_API_KEY != ''
+        if: github.ref == 'refs/heads/main'
         env:
           DATADOG_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
           DD_SITE: datadoghq.com


### PR DESCRIPTION
## Summary
- Gate DD CI reporting steps (STS credentials, test optimization, orchestrion, coverage upload) to only run on `main`
- Fixes forked PR CI failures caused by `dd-sts-action` requiring `id-token:write` permissions unavailable to forks

## Changes
- Add `if: github.ref == 'refs/heads/main'` to "Get Datadog credentials", "Configure Datadog Test Optimization", "Install Datadog CI tools", and "Upload coverage to Datadog" steps
- Tests still run on all PRs via the existing plain `go test` fallback when `DD_API_KEY` is unset

## Test plan
- [ ] Verify CI passes on this PR (non-main branch) without hitting STS permission errors
- [ ] Verify DD reporting still works on pushes to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)