### PR TITLE
fix(config): skip api. prefix for on-call domains in DD_SITE

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -105,7 +105,7 @@ func NewWithOptions(cfg *config.Config, forceAPIKeys bool) (*Client, error) {
 
 	// Configure the API client
 	configuration := datadog.NewConfiguration()
-	configuration.Host = fmt.Sprintf("api.%s", cfg.Site)
+	configuration.Host = cfg.GetAPIHost()
 
 	// Set custom user agent to identify requests as coming from pup CLI
 	configuration.UserAgent = useragent.Get()
@@ -175,7 +175,7 @@ func (c *Client) RawRequest(method, path string, body io.Reader) (*http.Response
 		return nil, err
 	}
 
-	url := fmt.Sprintf("https://api.%s%s", c.config.Site, path)
+	url := fmt.Sprintf("https://%s%s", c.config.GetAPIHost(), path)
 
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {


### PR DESCRIPTION
## Summary
- On-call domains like `navy.oncall.datadoghq.com` are already fully-qualified API endpoints
- Previously, pup always prepended `api.` to `DD_SITE`, resulting in invalid URLs like `api.navy.oncall.datadoghq.com`
- Now, when `DD_SITE` contains `oncall`, the domain is used as-is

## Changes
- Added `IsOnCallSite()` to detect on-call domains (`pkg/config/config.go:48`)
- Added `GetAPIHost()` that returns the correct host — skipping `api.` for on-call sites (`pkg/config/config.go:60`)
- Updated `GetAPIURL()` to delegate to `GetAPIHost()` (`pkg/config/config.go:54`)
- Updated `client.go` to use `cfg.GetAPIHost()` instead of hardcoded `api.{site}` (`pkg/client/client.go:108,178`)
- Added tests for `IsOnCallSite`, `GetAPIHost`, and on-call domain handling in `GetAPIURL` and `Load`

## Testing
- All existing tests pass (no regressions for standard sites)
- New tests verify on-call domains are used as-is
- New tests verify standard sites still get `api.` prefix

Closes #66

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)