### PR TITLE
feat(synthetics): add `synthetics tests search` command

### DIFF
--- a/cmd/synthetics.go
+++ b/cmd/synthetics.go
@@ -22,6 +22,7 @@ monitor application performance and availability from various locations.
 
 CAPABILITIES:
   • List synthetic tests
+  • Search synthetic tests by text query
   • Get test details
   • Get test results
   • List test locations
@@ -30,6 +31,10 @@ CAPABILITIES:
 EXAMPLES:
   # List all synthetic tests
   pup synthetics tests list
+
+  # Search tests by creator or team
+  pup synthetics tests search --text='creator:"Jane Doe"'
+  pup synthetics tests search --text="team:my-team"
 
   # Get test details
   pup synthetics tests get test-id
@@ -59,6 +64,79 @@ var syntheticsTestsGetCmd = &cobra.Command{
 	RunE:  runSyntheticsTestsGet,
 }
 
+var syntheticsTestsSearchCmd = &cobra.Command{
+	Use:   "search",
+	Short: "Search synthetic tests",
+	Long: `Search synthetic tests using a text query.
+
+Search allows filtering tests by free text or by facet queries, returning
+matching tests with pagination support.
+
+QUERY SYNTAX:
+  Free text matches against test names. Facet queries use the format
+  facet:value or facet:"multi word value".
+
+  Common facets:
+    creator              Test creator name (e.g., creator:"Jane Doe")
+    team                 Team tag (e.g., team:synthetics)
+    env                  Environment tag (e.g., env:prod, env:staging)
+    type                 Test type (api, api-multi, api-ssl, api-tcp, browser)
+    state                Test state (live, paused)
+    status               Monitor status (OK, Alert, "No Data")
+    tag                  Any tag (e.g., tag:terraform:true)
+    region               Test location (e.g., region:aws:us-east-2)
+    domain               Target domain
+    http_method          HTTP method (GET, POST, DELETE, PATCH)
+    http_path            Request path
+    muted                Muted state (0, 1)
+    ci_execution_rule    CI rule (blocking, non_blocking, skipped)
+    creation_source      How the test was created (e.g., terraform, templates)
+    mobile_platform      Mobile platform (android, ios)
+    notification         Notification handle
+    endpoint             Full endpoint URL
+    step_count           Number of test steps
+
+  Use --facets-only to discover all available facets and their values
+  for your organization.
+
+FLAGS:
+  --text                 Search text or facet query
+  --include-full-config  Include full test configuration in results
+  --facets-only          Return only facets (no test results)
+  --start                Pagination offset (default: 0)
+  --count                Number of results to return (default: 50)
+  --sort                 Sort order (e.g., "name,asc")
+
+EXAMPLES:
+  # Search tests by name
+  pup synthetics tests search --text="checkout"
+
+  # Find tests by creator
+  pup synthetics tests search --text='creator:"Jane Doe"'
+
+  # Find tests for a team
+  pup synthetics tests search --text="team:my-team"
+
+  # Filter by type and environment
+  pup synthetics tests search --text="type:browser env:prod"
+
+  # Search with pagination
+  pup synthetics tests search --text="api" --start=0 --count=100
+
+  # Discover available facets and values for your org
+  pup synthetics tests search --facets-only`,
+	RunE: runSyntheticsTestsSearch,
+}
+
+var (
+	syntheticsSearchText              string
+	syntheticsSearchIncludeFullConfig bool
+	syntheticsSearchFacetsOnly        bool
+	syntheticsSearchStart             int64
+	syntheticsSearchCount             int64
+	syntheticsSearchSort              string
+)
+
 var syntheticsLocationsCmd = &cobra.Command{
 	Use:   "locations",
 	Short: "Manage test locations",
@@ -71,7 +149,14 @@ var syntheticsLocationsListCmd = &cobra.Command{
 }
 
 func init() {
-	syntheticsTestsCmd.AddCommand(syntheticsTestsListCmd, syntheticsTestsGetCmd)
+	syntheticsTestsSearchCmd.Flags().StringVar(&syntheticsSearchText, "text", "", "Search text query")
+	syntheticsTestsSearchCmd.Flags().BoolVar(&syntheticsSearchIncludeFullConfig, "include-full-config", false, "Include full test configuration in results")
+	syntheticsTestsSearchCmd.Flags().BoolVar(&syntheticsSearchFacetsOnly, "facets-only", false, "Return only facets (no test results)")
+	syntheticsTestsSearchCmd.Flags().Int64Var(&syntheticsSearchStart, "start", 0, "Pagination offset")
+	syntheticsTestsSearchCmd.Flags().Int64Var(&syntheticsSearchCount, "count", 50, "Number of results to return")
+	syntheticsTestsSearchCmd.Flags().StringVar(&syntheticsSearchSort, "sort", "", "Sort order")
+
+	syntheticsTestsCmd.AddCommand(syntheticsTestsListCmd, syntheticsTestsGetCmd, syntheticsTestsSearchCmd)
 	syntheticsLocationsCmd.AddCommand(syntheticsLocationsListCmd)
 	syntheticsCmd.AddCommand(syntheticsTestsCmd, syntheticsLocationsCmd)
 }
@@ -108,6 +193,42 @@ func runSyntheticsTestsGet(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to get synthetic test: %w (status: %d)", err, r.StatusCode)
 		}
 		return fmt.Errorf("failed to get synthetic test: %w", err)
+	}
+
+	return formatAndPrint(resp, nil)
+}
+
+func runSyntheticsTestsSearch(cmd *cobra.Command, args []string) error {
+	client, err := getClient()
+	if err != nil {
+		return err
+	}
+
+	api := datadogV1.NewSyntheticsApi(client.V1())
+	opts := datadogV1.SearchTestsOptionalParameters{}
+
+	if syntheticsSearchText != "" {
+		opts.WithText(syntheticsSearchText)
+	}
+	if syntheticsSearchIncludeFullConfig {
+		opts.WithIncludeFullConfig(syntheticsSearchIncludeFullConfig)
+	}
+	if syntheticsSearchFacetsOnly {
+		opts.WithFacetsOnly(syntheticsSearchFacetsOnly)
+	}
+	if cmd.Flags().Changed("start") {
+		opts.WithStart(syntheticsSearchStart)
+	}
+	if cmd.Flags().Changed("count") {
+		opts.WithCount(syntheticsSearchCount)
+	}
+	if syntheticsSearchSort != "" {
+		opts.WithSort(syntheticsSearchSort)
+	}
+
+	resp, r, err := api.SearchTests(client.Context(), opts)
+	if err != nil {
+		return formatAPIError("search synthetic tests", err, r)
 	}
 
 	return formatAndPrint(resp, nil)

--- a/cmd/synthetics_test.go
+++ b/cmd/synthetics_test.go
@@ -56,6 +56,18 @@ func TestRunSyntheticsTestsGet(t *testing.T) {
 	}
 }
 
+func TestRunSyntheticsTestsSearch(t *testing.T) {
+	cleanup := setupSyntheticsTestClient(t)
+	defer cleanup()
+	var buf bytes.Buffer
+	outputWriter = &buf
+	defer func() { outputWriter = os.Stdout }()
+	err := runSyntheticsTestsSearch(syntheticsTestsSearchCmd, []string{})
+	if err == nil {
+		t.Error("Expected error with mock client")
+	}
+}
+
 func TestRunSyntheticsLocationsList(t *testing.T) {
 	cleanup := setupSyntheticsTestClient(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary

Wires up the `SearchTests` API endpoint (`GET /api/v1/synthetics/tests/search`) as a new `pup synthetics tests search` subcommand. The endpoint was already available in `datadog-api-client-go` but not exposed in pup — currently `synthetics tests list` dumps all tests with no server-side filtering.

## Motivation

`synthetics tests list` returns all tests in an org with no filtering. The search endpoint supports facet-based queries (`creator`, `team`, `env`, `type`, etc.) making it practical to find specific tests without client-side filtering.

## Changes

- **Add `synthetics tests search` subcommand** (`cmd/synthetics.go`) — calls `datadogV1.SyntheticsApi.SearchTests` with all optional parameters:
  - `--text` for free text and facet queries (e.g., `creator:"Jane Doe"`, `team:my-team`, `type:browser env:prod`)
  - `--facets-only` to discover available facets and values for the org
  - `--include-full-config` to return full test configuration in results
  - `--start` / `--count` for pagination
  - `--sort` for result ordering
- **Document all search facets** with values verified against the live API: `creator`, `team`, `env`, `type`, `state`, `status`, `tag`, `region`, `domain`, `http_method`, `http_path`, `muted`, `ci_execution_rule`, `creation_source`, `mobile_platform`, `notification`, `endpoint`, `step_count`
- **Update parent command** help to mention search capability
- **Add test** (`cmd/synthetics_test.go`) for the new search handler

## Testing

```bash
go test ./cmd -run TestRunSynthetics -v   # All pass

# Manual verification against live API
pup synthetics tests search --text='creator:"Tim Brown"' --count=5
pup synthetics tests search --text="team:applied-ai-experiences"
pup synthetics tests search --text="type:browser env:prod" --count=10
pup synthetics tests search --facets-only
```

## Checklist

- [x] The code change follows the project conventions
- [x] Tests have been added/updated
- [x] Documentation has been updated
- [x] All CI checks pass
- [x] Code coverage is maintained or improved