### PR TITLE
fix(version): correct ldflags variable names for build metadata

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,9 +33,8 @@ builds:
     ldflags:
       - -s -w
       - -X github.com/DataDog/pup/internal/version.Version={{.Version}}
-      - -X github.com/DataDog/pup/internal/version.Commit={{.Commit}}
-      - -X github.com/DataDog/pup/internal/version.Date={{.Date}}
-      - -X github.com/DataDog/pup/internal/version.BuiltBy=goreleaser
+      - -X github.com/DataDog/pup/internal/version.GitCommit={{.Commit}}
+      - -X github.com/DataDog/pup/internal/version.BuildDate={{.Date}}
 
 archives:
   - id: pup

--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,8 @@ DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 # Build flags
 LDFLAGS := -s -w \
 	-X github.com/DataDog/pup/internal/version.Version=$(VERSION) \
-	-X github.com/DataDog/pup/internal/version.Commit=$(COMMIT) \
-	-X github.com/DataDog/pup/internal/version.Date=$(DATE) \
-	-X github.com/DataDog/pup/internal/version.BuiltBy=makefile
+	-X github.com/DataDog/pup/internal/version.GitCommit=$(COMMIT) \
+	-X github.com/DataDog/pup/internal/version.BuildDate=$(DATE)
 
 # Go build flags
 GO_BUILD_FLAGS := -trimpath -ldflags "$(LDFLAGS)"


### PR DESCRIPTION
## Summary
- Release binaries showed `Pup 0.16.0 (unknown) built on unknown` because the ldflags in `.goreleaser.yml` and `Makefile` referenced non-existent Go variables (`version.Commit`, `version.Date`, `version.BuiltBy`)
- Fixed ldflags to match the actual variables in `internal/version/version.go`: `version.GitCommit` and `version.BuildDate`

## Changes
- `.goreleaser.yml:33-37` — Fix ldflags: `Commit` → `GitCommit`, `Date` → `BuildDate`, remove orphaned `BuiltBy`
- `Makefile:18-21` — Same fixes for local `make build-quick` / `make install`

## Testing
- Built locally with `make build-quick` and verified `./pup version` outputs:
  `Pup v0.16.0 (74fcbbb) built on 2026-02-17T18:35:48Z`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)