### PR TITLE
fix(metrics): require DD_API_KEY for metrics submit command

### DIFF
--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -829,9 +829,21 @@ func runMetricsMetadataUpdate(cmd *cobra.Command, args []string) error {
 
 // runMetricsSubmit executes the metrics submit command
 func runMetricsSubmit(cmd *cobra.Command, args []string) error {
-	client, err := getClient()
+	// The metrics intake API requires an API key (DD_API_KEY).
+	// OAuth2 bearer tokens are not supported for metric submission.
+	if cfg.APIKey == "" {
+		return fmt.Errorf(
+			"metrics submit requires a Datadog API key.\n\n" +
+				"Set the DD_API_KEY environment variable:\n" +
+				"  export DD_API_KEY=\"your-api-key\"\n\n" +
+				"You can find your API key at https://app.datadoghq.com/organization-settings/api-keys\n\n" +
+				"Note: OAuth2 authentication (pup auth login) is not supported for metric submission.",
+		)
+	}
+
+	client, err := apiKeyClientFactory(cfg)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create client: %w", err)
 	}
 
 	// Parse timestamp


### PR DESCRIPTION
## Summary
The Datadog metrics intake API requires API key authentication — OAuth2 bearer tokens are not supported for metric submission. This PR adds a pre-emptive check that gives users (and agents) a clear, actionable error message when `DD_API_KEY` is not set, instead of failing later with a confusing auth error.

## Changes
- Add API key check at the start of `runMetricsSubmit` before client creation (`cmd/metrics.go:833`)
- Use `apiKeyClientFactory` instead of `getClient()` to force API key auth, skipping OAuth (`cmd/metrics.go:845`)
- Add `TestRunMetricsSubmit_RequiresAPIKey` test for the missing API key scenario (`cmd/metrics_test.go:630`)
- Mock `apiKeyClientFactory` in `setupMetricsTestClient` helper for consistent test behavior (`cmd/metrics_test.go:50`)

## Testing
- All existing metrics tests pass
- New test verifies the error message mentions `DD_API_KEY` and explains the requirement
- Full test suite passes (`go test ./...`)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)