### PR TITLE
fix(auth): enable CGo for darwin builds to restore keychain access

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,14 +9,32 @@ before:
     - go mod tidy
 
 builds:
-  - id: pup
+  # Darwin builds must have CGO_ENABLED=1 so the keyring library's
+  # KeychainBackend (guarded by //go:build darwin && cgo) is compiled in.
+  # This build must run on a macOS CI runner.
+  - id: pup-darwin
+    binary: pup
+    main: .
+    goos:
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X github.com/datadog-labs/pup/internal/version.Version={{.Version}}
+      - -X github.com/datadog-labs/pup/internal/version.GitCommit={{.Commit}}
+      - -X github.com/datadog-labs/pup/internal/version.BuildDate={{.Date}}
+
+  # Linux and Windows builds use CGO_ENABLED=0 for cross-compilation.
+  # These platforms do not use go-keychain and are unaffected.
+  - id: pup-nix
     binary: pup
     main: .
     env:
       - CGO_ENABLED=0
     goos:
       - linux
-      - darwin
       - windows
     goarch:
       - amd64


### PR DESCRIPTION
## Summary

Homebrew-installed `pup` silently falls back to file-based token storage instead of using the macOS Keychain. The root cause is `CGO_ENABLED=0` in the goreleaser build config.

## Root Cause

The `99designs/keyring` library's macOS Keychain backend is guarded by:

```go
//go:build darwin && cgo
```

With `CGO_ENABLED=0`, the `cgo` build tag is absent, so `KeychainBackend` is never registered in `supportedBackends`. At runtime, `keyring.Open()` returns "no valid backend found", `IsKeychainAvailable()` returns false, and the storage factory falls back to file storage with a warning.

**Reproduced by:**
```bash
CGO_ENABLED=0 go build -o ./pup_nocgo . && ./pup_nocgo auth login
# ⚠️  Warning: OS keychain not available, falling back to file-based token storage.

go build -o ./pup_cgo . && ./pup_cgo auth login
# ✓ Proceeds to use macOS Keychain
```

## Changes

- `.goreleaser.yml` — Split the single build into two:
  - `pup-darwin` (`darwin/amd64`, `darwin/arm64`): no `CGO_ENABLED` override, defaults to `1` on macOS runner
  - `pup-nix` (`linux`, `windows`): retains `CGO_ENABLED=0` for cross-compilation
- `.github/workflows/release.yml` — Change goreleaser job from `ubuntu-latest` to `macos-latest` so the darwin build has the Xcode SDK available for CGo. The `pup-nix` targets cross-compile without CGo and work unchanged on macOS.

## Testing

Verified locally with `go build` (CGO_ENABLED=1 default) vs `CGO_ENABLED=0 go build`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)