### PR TITLE
fix(events): use API key auth for events v2 search endpoint

### DIFF
--- a/cmd/events.go
+++ b/cmd/events.go
@@ -120,7 +120,8 @@ func runEventsList(cmd *cobra.Command, args []string) error {
 }
 
 func runEventsSearch(cmd *cobra.Command, args []string) error {
-	client, err := getClient()
+	// Events V2 search does not support OAuth, requires API keys
+	client, err := getClientForEndpoint("POST", "/api/v2/events/search")
 	if err != nil {
 		return err
 	}

--- a/pkg/client/auth_validator.go
+++ b/pkg/client/auth_validator.go
@@ -61,6 +61,9 @@ var endpointsWithoutOAuth = []EndpointAuthRequirement{
 	{Path: "/api/v2/app_keys/", Method: "POST", SupportsOAuth: false, RequiresAPIKeys: true, Reason: "App Keys management missing OAuth implementation in spec"},
 	{Path: "/api/v2/app_keys/", Method: "DELETE", SupportsOAuth: false, RequiresAPIKeys: true, Reason: "App Keys management missing OAuth implementation in spec"},
 
+	// Events V2 Search API - OAuth not supported
+	{Path: "/api/v2/events/search", Method: "POST", SupportsOAuth: false, RequiresAPIKeys: true, Reason: "Events V2 search API does not support OAuth authentication"},
+
 	// Error Tracking API - OAuth not working in practice
 	{Path: "/api/v2/error_tracking/issues/search", Method: "POST", SupportsOAuth: false, RequiresAPIKeys: true, Reason: "Error Tracking API requires API keys"},
 	{Path: "/api/v2/error_tracking/issues/", Method: "GET", SupportsOAuth: false, RequiresAPIKeys: true, Reason: "Error Tracking API requires API keys"},

--- a/pkg/client/auth_validator_test.go
+++ b/pkg/client/auth_validator_test.go
@@ -87,6 +87,12 @@ func TestRequiresAPIKeyFallback(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "events v2 search requires API keys",
+			method:   "POST",
+			path:     "/api/v2/events/search",
+			expected: true,
+		},
+		{
 			name:     "monitors list supports OAuth",
 			method:   "GET",
 			path:     "/api/v1/monitor",


### PR DESCRIPTION
## Summary
The `pup events search` command was returning 401 Unauthorized when using OAuth authentication because the `POST /api/v2/events/search` endpoint does not support OAuth — it requires API/App keys. This is the same class of issue already fixed for logs, RUM, notebooks, and other endpoints.

## Changes
- `pkg/client/auth_validator.go`: Add `/api/v2/events/search` (POST) to `endpointsWithoutOAuth` so the auth validator knows to fall back to API keys
- `cmd/events.go:122`: Switch `runEventsSearch` from `getClient()` to `getClientForEndpoint("POST", "/api/v2/events/search")` to trigger automatic OAuth→API key fallback
- `pkg/client/auth_validator_test.go`: Add test case asserting the events v2 search endpoint requires API key fallback

## Testing
- All existing tests pass (`go test ./...`)
- New `TestRequiresAPIKeyFallback/events_v2_search_requires_API_keys` test added and passing

## Related Issues
Closes #85

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)