### PR TITLE
fix(release): restore id-token permission for cosign keyless signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: write
-  # id-token: write  # Required by dd-octo-sts — re-enable when org support is added
+  id-token: write  # Required for cosign keyless signing (Sigstore OIDC) and dd-octo-sts
   packages: write
 
 jobs:


### PR DESCRIPTION
## Summary
Restores the `id-token: write` permission in the release workflow so cosign can automatically obtain a Sigstore OIDC token from the GitHub Actions runtime.

Without this permission, cosign falls back to an interactive browser-based OAuth flow, requiring manual link clicks during release signing (as seen in [run #22197776076](https://github.com/datadog-labs/pup/actions/runs/22197776076/job/64202485510)).

## Changes
- Uncommented `id-token: write` in `.github/workflows/release.yml:10`
- Updated comment to clarify it's needed for both cosign keyless signing and dd-octo-sts

## Testing
- Next tag push will verify cosign signs artifacts automatically without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)