### PR TITLE
feat(cicd): add CI Visibility OAuth scopes and enable SearchFlakyTests

### DIFF
--- a/pkg/auth/types/types.go
+++ b/pkg/auth/types/types.go
@@ -97,6 +97,9 @@ func DefaultScopes() []string {
 		// Metrics
 		"metrics_read",
 		"timeseries_query",
+		// CI Visibility / Test Optimization
+		"ci_visibility_read",
+		"test_optimization_read",
 		// Usage
 		"usage_read",
 	}

--- a/pkg/auth/types/types_test.go
+++ b/pkg/auth/types/types_test.go
@@ -175,6 +175,9 @@ func TestDefaultScopes(t *testing.T) {
 		// Metrics
 		"metrics_read",
 		"timeseries_query",
+		// CI Visibility / Test Optimization
+		"ci_visibility_read",
+		"test_optimization_read",
 		// Usage
 		"usage_read",
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -172,6 +172,7 @@ func NewWithOptions(cfg *config.Config, forceAPIKeys bool) (*Client, error) {
 		"v2.CreateCaseServiceNowTicket",
 		"v2.MoveCaseToProject",
 		// Flaky Tests
+		"v2.SearchFlakyTests",
 		"v2.UpdateFlakyTests",
 	}
 	for _, op := range unstableOps {


### PR DESCRIPTION
> [!CAUTION]
> **Do not merge until the AAA team adds `test_optimization_read` to the `datadog-api-claude-plugin` registrable client.** Merging before that will break `pup auth login` for all users.

## Summary
- Add `ci_visibility_read` and `test_optimization_read` OAuth scopes to `DefaultScopes()` for CI Visibility / Test Optimization endpoint access
- Enable the unstable `v2.SearchFlakyTests` operation so `pup cicd flaky-tests search` works

## Dependency
`test_optimization_read` requires the AAA team (Delegated Authentication) to add it to the `datadog-api-claude-plugin` registrable client's `PermissionNames` in the database. Tracking via #aaa Slack.

## Test plan
- [x] `TestDefaultScopes` passes
- [ ] After AAA team updates the registrable client: `pup auth logout && pup auth login` succeeds
- [ ] `pup cicd flaky-tests search --limit 10` returns results

🤖 Generated with [Claude Code](https://claude.com/claude-code)