### PR TITLE
fix(security): replace signals list with signals search

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ See [docs/COMMANDS.md](docs/COMMANDS.md) for detailed command reference.
 
 | API Domain | Status | Pup Commands | Notes |
 |------------|--------|--------------|-------|
-| Security Monitoring | ✅ | `security rules list`, `security signals list`, `security findings search` | Rules, signals, findings with advanced search |
+| Security Monitoring | ✅ | `security rules list`, `security signals search`, `security findings search` | Rules, signals, findings with advanced search |
 | Static Analysis | ✅ | `static-analysis ast`, `static-analysis custom-rulesets`, `static-analysis sca`, `static-analysis coverage` | Code security analysis |
 | Audit Logs | ✅ | `audit-logs list`, `audit-logs search` | Full audit log search and listing |
 | Data Governance | ✅ | `data-governance scanner-rules list` | Sensitive data scanner rules |

--- a/cmd/security_test.go
+++ b/cmd/security_test.go
@@ -93,16 +93,16 @@ func TestSecuritySignalsCmd(t *testing.T) {
 		t.Error("Short description is empty")
 	}
 
-	// Check for list subcommand
+	// Check for search subcommand
 	commands := securitySignalsCmd.Commands()
-	foundList := false
+	foundSearch := false
 	for _, cmd := range commands {
-		if cmd.Use == "list" {
-			foundList = true
+		if cmd.Use == "search" {
+			foundSearch = true
 		}
 	}
-	if !foundList {
-		t.Error("Missing signals list subcommand")
+	if !foundSearch {
+		t.Error("Missing signals search subcommand")
 	}
 }
 


### PR DESCRIPTION
## Summary
Replace the bare `security signals list` command with a proper `security signals search` command, matching the pattern already established by `security findings search`.

## Changes
- Remove `securitySignalsListCmd` using `ListSecurityMonitoringSignals` (no options) (`cmd/security.go`)
- Add `securitySignalsSearchCmd` using `SearchSecurityMonitoringSignals` with a proper request body (`cmd/security.go`)
- Add `--query` (required), `--limit` (default 100), `--sort` (`timestamp` or `-timestamp`) flags (`cmd/security.go`)
- Update test to assert `search` subcommand exists instead of `list` (`cmd/security_test.go`)
- Update README security monitoring command reference (`README.md`)

## Testing
- All security tests pass: `go test ./cmd/ -run TestSecurity`
- Manually tested: `pup security signals search --query="source:cloudtrail" --limit=1` returns live data
- Verified `--query` is enforced as required

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)