### PR TITLE
feat(fleet): add Fleet Automation command group

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Pup - Datadog API CLI
 
-Go-based CLI wrapper for Datadog APIs. Provides OAuth2 + API key authentication for 28 command groups with 200+ subcommands across 33 API domains.
+Go-based CLI wrapper for Datadog APIs. Provides OAuth2 + API key authentication for 29 command groups with 200+ subcommands across 34 API domains.
 
 ## Documentation Index
 
@@ -190,12 +190,12 @@ See [TESTING.md](docs/TESTING.md) for details.
 
 ## Implementation Status
 
-- **31 command files** implemented
-- **260+ subcommands** across 36 domains
+- **32 command files** implemented
+- **274+ subcommands** across 37 domains
 - **93.9% test coverage** in pkg/
-- **34/36 commands** fully working
-- **0/36 commands** blocked by API client library issues
-- **2/36 commands** placeholder (API endpoints pending)
+- **35/37 commands** fully working
+- **0/37 commands** blocked by API client library issues
+- **2/37 commands** placeholder (API endpoints pending)
 
 See [COMMANDS.md](docs/COMMANDS.md) for detailed status.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pup metrics query --query="avg:system.cpu.user{*}"   # Track the metrics tail
 
 <!-- Last updated: 2026-02-10 | API Client: v2.54.0 -->
 
-Pup implements **38 of 85+ available Datadog APIs** (44.7% coverage).
+Pup implements **39 of 85+ available Datadog APIs** (45.9% coverage).
 
 See [docs/COMMANDS.md](docs/COMMANDS.md) for detailed command reference.
 
@@ -116,7 +116,7 @@ See [docs/COMMANDS.md](docs/COMMANDS.md) for detailed command reference.
 </details>
 
 <details>
-<summary><b>🚨 Incident & Operations (6/7 implemented)</b></summary>
+<summary><b>🚨 Incident & Operations (7/8 implemented)</b></summary>
 
 | API Domain | Status | Pup Commands | Notes |
 |------------|--------|--------------|-------|
@@ -126,6 +126,7 @@ See [docs/COMMANDS.md](docs/COMMANDS.md) for detailed command reference.
 | Error Tracking | ✅ | `error-tracking issues search`, `error-tracking issues get` | Error issue search and details |
 | Service Catalog | ✅ | `service-catalog list`, `service-catalog get` | Service registry management |
 | Scorecards | ✅ | `scorecards list`, `scorecards get` | Service quality scores |
+| Fleet Automation | ✅ | `fleet agents`, `fleet deployments`, `fleet schedules` | Agent management, deployments, schedules (Preview) |
 | Incident Services/Teams | ❌ | - | Not yet implemented |
 
 </details>

--- a/cmd/fleet.go
+++ b/cmd/fleet.go
@@ -1,0 +1,517 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+	"github.com/spf13/cobra"
+)
+
+var fleetCmd = &cobra.Command{
+	Use:   "fleet",
+	Short: "Manage Fleet Automation",
+	Long: `Manage Datadog Fleet Automation for remote agent management at scale.
+
+Fleet Automation enables listing agents, deploying configuration changes,
+upgrading agent packages, and scheduling automated operations.
+
+NOTE: Fleet Automation APIs are in Preview and may introduce breaking changes.
+
+CAPABILITIES:
+  • List and inspect fleet agents and versions
+  • Create and manage configuration and upgrade deployments
+  • Schedule, trigger, and manage automated operations
+
+EXAMPLES:
+  # List fleet agents
+  pup fleet agents list
+
+  # Get agent details
+  pup fleet agents get <agent-key>
+
+  # List deployments
+  pup fleet deployments list
+
+  # Deploy a configuration change
+  pup fleet deployments configure --file=config.json
+
+  # List schedules
+  pup fleet schedules list
+
+AUTHENTICATION:
+  Requires either OAuth2 authentication or API keys.`,
+}
+
+// Agents subcommands
+var fleetAgentsCmd = &cobra.Command{
+	Use:   "agents",
+	Short: "Manage fleet agents",
+}
+
+var fleetAgentsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List fleet agents",
+	RunE:  runFleetAgentsList,
+}
+
+var fleetAgentsGetCmd = &cobra.Command{
+	Use:   "get [agent-key]",
+	Short: "Get fleet agent details",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runFleetAgentsGet,
+}
+
+var fleetAgentsVersionsCmd = &cobra.Command{
+	Use:   "versions",
+	Short: "List available agent versions",
+	RunE:  runFleetAgentsVersions,
+}
+
+// Deployments subcommands
+var fleetDeploymentsCmd = &cobra.Command{
+	Use:   "deployments",
+	Short: "Manage fleet deployments",
+}
+
+var fleetDeploymentsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List fleet deployments",
+	RunE:  runFleetDeploymentsList,
+}
+
+var fleetDeploymentsGetCmd = &cobra.Command{
+	Use:   "get [deployment-id]",
+	Short: "Get fleet deployment details",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runFleetDeploymentsGet,
+}
+
+var fleetDeploymentsConfigureCmd = &cobra.Command{
+	Use:   "configure",
+	Short: "Create a configuration deployment",
+	RunE:  runFleetDeploymentsConfigure,
+}
+
+var fleetDeploymentsUpgradeCmd = &cobra.Command{
+	Use:   "upgrade",
+	Short: "Create an upgrade deployment",
+	RunE:  runFleetDeploymentsUpgrade,
+}
+
+var fleetDeploymentsCancelCmd = &cobra.Command{
+	Use:   "cancel [deployment-id]",
+	Short: "Cancel a fleet deployment",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runFleetDeploymentsCancel,
+}
+
+// Schedules subcommands
+var fleetSchedulesCmd = &cobra.Command{
+	Use:   "schedules",
+	Short: "Manage fleet schedules",
+}
+
+var fleetSchedulesListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List fleet schedules",
+	RunE:  runFleetSchedulesList,
+}
+
+var fleetSchedulesGetCmd = &cobra.Command{
+	Use:   "get [schedule-id]",
+	Short: "Get fleet schedule details",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runFleetSchedulesGet,
+}
+
+var fleetSchedulesCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a fleet schedule",
+	RunE:  runFleetSchedulesCreate,
+}
+
+var fleetSchedulesUpdateCmd = &cobra.Command{
+	Use:   "update [schedule-id]",
+	Short: "Update a fleet schedule",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runFleetSchedulesUpdate,
+}
+
+var fleetSchedulesDeleteCmd = &cobra.Command{
+	Use:   "delete [schedule-id]",
+	Short: "Delete a fleet schedule",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runFleetSchedulesDelete,
+}
+
+var fleetSchedulesTriggerCmd = &cobra.Command{
+	Use:   "trigger [schedule-id]",
+	Short: "Trigger a fleet schedule",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runFleetSchedulesTrigger,
+}
+
+var (
+	fleetFile     string
+	fleetPageSize int64
+	fleetTags     string
+	fleetFilter   string
+	fleetSort     string
+	fleetDesc     bool
+)
+
+func init() {
+	// Agents list flags
+	fleetAgentsListCmd.Flags().Int64Var(&fleetPageSize, "page-size", 0, "Number of results per page")
+	fleetAgentsListCmd.Flags().StringVar(&fleetTags, "tags", "", "Comma-separated tags to filter by")
+	fleetAgentsListCmd.Flags().StringVar(&fleetFilter, "filter", "", "Filter query")
+	fleetAgentsListCmd.Flags().StringVar(&fleetSort, "sort", "", "Sort attribute")
+	fleetAgentsListCmd.Flags().BoolVar(&fleetDesc, "desc", false, "Sort in descending order")
+
+	// Deployments list flags
+	fleetDeploymentsListCmd.Flags().Int64Var(&fleetPageSize, "page-size", 0, "Number of results per page")
+
+	// Deployments file flags
+	fleetDeploymentsConfigureCmd.Flags().StringVar(&fleetFile, "file", "", "JSON file with request body (required)")
+	_ = fleetDeploymentsConfigureCmd.MarkFlagRequired("file")
+	fleetDeploymentsUpgradeCmd.Flags().StringVar(&fleetFile, "file", "", "JSON file with request body (required)")
+	_ = fleetDeploymentsUpgradeCmd.MarkFlagRequired("file")
+
+	// Schedules file flags
+	fleetSchedulesCreateCmd.Flags().StringVar(&fleetFile, "file", "", "JSON file with request body (required)")
+	_ = fleetSchedulesCreateCmd.MarkFlagRequired("file")
+	fleetSchedulesUpdateCmd.Flags().StringVar(&fleetFile, "file", "", "JSON file with request body (required)")
+	_ = fleetSchedulesUpdateCmd.MarkFlagRequired("file")
+
+	// Build command hierarchy
+	fleetAgentsCmd.AddCommand(fleetAgentsListCmd, fleetAgentsGetCmd, fleetAgentsVersionsCmd)
+	fleetDeploymentsCmd.AddCommand(
+		fleetDeploymentsListCmd,
+		fleetDeploymentsGetCmd,
+		fleetDeploymentsConfigureCmd,
+		fleetDeploymentsUpgradeCmd,
+		fleetDeploymentsCancelCmd,
+	)
+	fleetSchedulesCmd.AddCommand(
+		fleetSchedulesListCmd,
+		fleetSchedulesGetCmd,
+		fleetSchedulesCreateCmd,
+		fleetSchedulesUpdateCmd,
+		fleetSchedulesDeleteCmd,
+		fleetSchedulesTriggerCmd,
+	)
+	fleetCmd.AddCommand(fleetAgentsCmd, fleetDeploymentsCmd, fleetSchedulesCmd)
+}
+
+// Agents implementations
+
+func runFleetAgentsList(cmd *cobra.Command, args []string) error {
+	client, err := getClientForEndpoint("GET", "/api/v2/fleet/agents")
+	if err != nil {
+		return err
+	}
+
+	api := datadogV2.NewFleetAutomationApi(client.V2())
+	opts := datadogV2.NewListFleetAgentsOptionalParameters()
+	if fleetPageSize > 0 {
+		opts = opts.WithPageSize(fleetPageSize)
+	}
+	if fleetTags != "" {
+		opts = opts.WithTags(fleetTags)
+	}
+	if fleetFilter != "" {
+		opts = opts.WithFilter(fleetFilter)
+	}
+	if fleetSort != "" {
+		opts = opts.WithSortAttribute(fleetSort)
+	}
+	if fleetDesc {
+		opts = opts.WithSortDescending(true)
+	}
+
+	resp, r, err := api.ListFleetAgents(client.Context(), *opts)
+	if err != nil {
+		return formatAPIError("list fleet agents", err, r)
+	}
+
+	return formatAndPrint(resp, nil)
+}
+
+func runFleetAgentsGet(cmd *cobra.Command, args []string) error {
+	client, err := getClientForEndpoint("GET", "/api/v2/fleet/agents/")
+	if err != nil {
+		return err
+	}
+
+	api := datadogV2.NewFleetAutomationApi(client.V2())
+	resp, r, err := api.GetFleetAgentInfo(client.Context(), args[0])
+	if err != nil {
+		return formatAPIError("get fleet agent info", err, r)
+	}
+
+	return formatAndPrint(resp, nil)
+}
+
+func runFleetAgentsVersions(cmd *cobra.Command, args []string) error {
+	client, err := getClientForEndpoint("GET", "/api/v2/fleet/agents/versions")
+	if err != nil {
+		return err
+	}
+
+	api := datadogV2.NewFleetAutomationApi(client.V2())
+	resp, r, err := api.ListFleetAgentVersions(client.Context())
+	if err != nil {
+		return formatAPIError("list fleet agent versions", err, r)
+	}
+
+	return formatAndPrint(resp, nil)
+}
+
+// Deployments implementations
+
+func runFleetDeploymentsList(cmd *cobra.Command, args []string) error {
+	client, err := getClientForEndpoint("GET", "/api/v2/fleet/deployments")
+	if err != nil {
+		return err
+	}
+
+	api := datadogV2.NewFleetAutomationApi(client.V2())
+	opts := datadogV2.NewListFleetDeploymentsOptionalParameters()
+	if fleetPageSize > 0 {
+		opts = opts.WithPageSize(fleetPageSize)
+	}
+
+	resp, r, err := api.ListFleetDeployments(client.Context(), *opts)
+	if err != nil {
+		return formatAPIError("list fleet deployments", err, r)
+	}
+
+	return formatAndPrint(resp, nil)
+}
+
+func runFleetDeploymentsGet(cmd *cobra.Command, args []string) error {
+	client, err := getClientForEndpoint("GET", "/api/v2/fleet/deployments/")
+	if err != nil {
+		return err
+	}
+
+	api := datadogV2.NewFleetAutomationApi(client.V2())
+	resp, r, err := api.GetFleetDeployment(client.Context(), args[0])
+	if err != nil {
+		return formatAPIError("get fleet deployment", err, r)
+	}
+
+	return formatAndPrint(resp, nil)
+}
+
+func runFleetDeploymentsConfigure(cmd *cobra.Command, args []string) error {
+	data, err := os.ReadFile(fleetFile)
+	if err != nil {
+		return fmt.Errorf("failed to read file: %w", err)
+	}
+
+	var body datadogV2.FleetDeploymentConfigureCreateRequest
+	if err := json.Unmarshal(data, &body); err != nil {
+		return fmt.Errorf("failed to parse JSON: %w", err)
+	}
+
+	client, err := getClientForEndpoint("POST", "/api/v2/fleet/deployments/configure")
+	if err != nil {
+		return err
+	}
+
+	api := datadogV2.NewFleetAutomationApi(client.V2())
+	resp, r, err := api.CreateFleetDeploymentConfigure(client.Context(), body)
+	if err != nil {
+		return formatAPIError("create fleet deployment configure", err, r)
+	}
+
+	return formatAndPrint(resp, nil)
+}
+
+func runFleetDeploymentsUpgrade(cmd *cobra.Command, args []string) error {
+	data, err := os.ReadFile(fleetFile)
+	if err != nil {
+		return fmt.Errorf("failed to read file: %w", err)
+	}
+
+	var body datadogV2.FleetDeploymentPackageUpgradeCreateRequest
+	if err := json.Unmarshal(data, &body); err != nil {
+		return fmt.Errorf("failed to parse JSON: %w", err)
+	}
+
+	client, err := getClientForEndpoint("POST", "/api/v2/fleet/deployments/upgrade")
+	if err != nil {
+		return err
+	}
+
+	api := datadogV2.NewFleetAutomationApi(client.V2())
+	resp, r, err := api.CreateFleetDeploymentUpgrade(client.Context(), body)
+	if err != nil {
+		return formatAPIError("create fleet deployment upgrade", err, r)
+	}
+
+	return formatAndPrint(resp, nil)
+}
+
+func runFleetDeploymentsCancel(cmd *cobra.Command, args []string) error {
+	if !cfg.AutoApprove {
+		printOutput("WARNING: This will cancel deployment '%s'.\n", args[0])
+		printOutput("Are you sure you want to continue? [y/N]: ")
+		response, err := readConfirmation()
+		if err != nil {
+			return fmt.Errorf("failed to read confirmation: %w", err)
+		}
+		if response != "y" && response != "Y" && response != "yes" {
+			printOutput("Operation cancelled.\n")
+			return nil
+		}
+	}
+
+	client, err := getClientForEndpoint("DELETE", "/api/v2/fleet/deployments/")
+	if err != nil {
+		return err
+	}
+
+	api := datadogV2.NewFleetAutomationApi(client.V2())
+	r, err := api.CancelFleetDeployment(client.Context(), args[0])
+	if err != nil {
+		return formatAPIError("cancel fleet deployment", err, r)
+	}
+
+	printOutput("Deployment '%s' cancelled successfully.\n", args[0])
+	return nil
+}
+
+// Schedules implementations
+
+func runFleetSchedulesList(cmd *cobra.Command, args []string) error {
+	client, err := getClientForEndpoint("GET", "/api/v2/fleet/schedules")
+	if err != nil {
+		return err
+	}
+
+	api := datadogV2.NewFleetAutomationApi(client.V2())
+	resp, r, err := api.ListFleetSchedules(client.Context())
+	if err != nil {
+		return formatAPIError("list fleet schedules", err, r)
+	}
+
+	return formatAndPrint(resp, nil)
+}
+
+func runFleetSchedulesGet(cmd *cobra.Command, args []string) error {
+	client, err := getClientForEndpoint("GET", "/api/v2/fleet/schedules/")
+	if err != nil {
+		return err
+	}
+
+	api := datadogV2.NewFleetAutomationApi(client.V2())
+	resp, r, err := api.GetFleetSchedule(client.Context(), args[0])
+	if err != nil {
+		return formatAPIError("get fleet schedule", err, r)
+	}
+
+	return formatAndPrint(resp, nil)
+}
+
+func runFleetSchedulesCreate(cmd *cobra.Command, args []string) error {
+	data, err := os.ReadFile(fleetFile)
+	if err != nil {
+		return fmt.Errorf("failed to read file: %w", err)
+	}
+
+	var body datadogV2.FleetScheduleCreateRequest
+	if err := json.Unmarshal(data, &body); err != nil {
+		return fmt.Errorf("failed to parse JSON: %w", err)
+	}
+
+	client, err := getClientForEndpoint("POST", "/api/v2/fleet/schedules")
+	if err != nil {
+		return err
+	}
+
+	api := datadogV2.NewFleetAutomationApi(client.V2())
+	resp, r, err := api.CreateFleetSchedule(client.Context(), body)
+	if err != nil {
+		return formatAPIError("create fleet schedule", err, r)
+	}
+
+	return formatAndPrint(resp, nil)
+}
+
+func runFleetSchedulesUpdate(cmd *cobra.Command, args []string) error {
+	data, err := os.ReadFile(fleetFile)
+	if err != nil {
+		return fmt.Errorf("failed to read file: %w", err)
+	}
+
+	var body datadogV2.FleetSchedulePatchRequest
+	if err := json.Unmarshal(data, &body); err != nil {
+		return fmt.Errorf("failed to parse JSON: %w", err)
+	}
+
+	client, err := getClientForEndpoint("PATCH", "/api/v2/fleet/schedules/")
+	if err != nil {
+		return err
+	}
+
+	api := datadogV2.NewFleetAutomationApi(client.V2())
+	resp, r, err := api.UpdateFleetSchedule(client.Context(), args[0], body)
+	if err != nil {
+		return formatAPIError("update fleet schedule", err, r)
+	}
+
+	return formatAndPrint(resp, nil)
+}
+
+func runFleetSchedulesDelete(cmd *cobra.Command, args []string) error {
+	if !cfg.AutoApprove {
+		printOutput("WARNING: This will permanently delete schedule '%s'.\n", args[0])
+		printOutput("Are you sure you want to continue? [y/N]: ")
+		response, err := readConfirmation()
+		if err != nil {
+			return fmt.Errorf("failed to read confirmation: %w", err)
+		}
+		if response != "y" && response != "Y" && response != "yes" {
+			printOutput("Operation cancelled.\n")
+			return nil
+		}
+	}
+
+	client, err := getClientForEndpoint("DELETE", "/api/v2/fleet/schedules/")
+	if err != nil {
+		return err
+	}
+
+	api := datadogV2.NewFleetAutomationApi(client.V2())
+	r, err := api.DeleteFleetSchedule(client.Context(), args[0])
+	if err != nil {
+		return formatAPIError("delete fleet schedule", err, r)
+	}
+
+	printOutput("Schedule '%s' deleted successfully.\n", args[0])
+	return nil
+}
+
+func runFleetSchedulesTrigger(cmd *cobra.Command, args []string) error {
+	client, err := getClientForEndpoint("POST", "/api/v2/fleet/schedules/")
+	if err != nil {
+		return err
+	}
+
+	api := datadogV2.NewFleetAutomationApi(client.V2())
+	resp, r, err := api.TriggerFleetSchedule(client.Context(), args[0])
+	if err != nil {
+		return formatAPIError("trigger fleet schedule", err, r)
+	}
+
+	return formatAndPrint(resp, nil)
+}

--- a/cmd/fleet_test.go
+++ b/cmd/fleet_test.go
@@ -1,0 +1,474 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/datadog-labs/pup/pkg/client"
+	"github.com/datadog-labs/pup/pkg/config"
+)
+
+func TestFleetCmd(t *testing.T) {
+	if fleetCmd == nil {
+		t.Fatal("fleetCmd is nil")
+	}
+
+	if fleetCmd.Use != "fleet" {
+		t.Errorf("Use = %s, want fleet", fleetCmd.Use)
+	}
+
+	if fleetCmd.Short == "" {
+		t.Error("Short description is empty")
+	}
+
+	if fleetCmd.Long == "" {
+		t.Error("Long description is empty")
+	}
+}
+
+func TestFleetCmd_Subcommands(t *testing.T) {
+	expectedCommands := []string{"agents", "deployments", "schedules"}
+
+	commands := fleetCmd.Commands()
+	commandMap := make(map[string]bool)
+	for _, cmd := range commands {
+		commandMap[cmd.Name()] = true
+	}
+
+	for _, expected := range expectedCommands {
+		if !commandMap[expected] {
+			t.Errorf("Missing subcommand: %s", expected)
+		}
+	}
+}
+
+func TestFleetAgentsCmd_Subcommands(t *testing.T) {
+	expectedCommands := []string{"list", "get", "versions"}
+
+	commands := fleetAgentsCmd.Commands()
+	commandMap := make(map[string]bool)
+	for _, cmd := range commands {
+		commandMap[cmd.Name()] = true
+	}
+
+	for _, expected := range expectedCommands {
+		if !commandMap[expected] {
+			t.Errorf("Missing agents subcommand: %s", expected)
+		}
+	}
+}
+
+func TestFleetDeploymentsCmd_Subcommands(t *testing.T) {
+	expectedCommands := []string{"list", "get", "configure", "upgrade", "cancel"}
+
+	commands := fleetDeploymentsCmd.Commands()
+	commandMap := make(map[string]bool)
+	for _, cmd := range commands {
+		commandMap[cmd.Name()] = true
+	}
+
+	for _, expected := range expectedCommands {
+		if !commandMap[expected] {
+			t.Errorf("Missing deployments subcommand: %s", expected)
+		}
+	}
+}
+
+func TestFleetSchedulesCmd_Subcommands(t *testing.T) {
+	expectedCommands := []string{"list", "get", "create", "update", "delete", "trigger"}
+
+	commands := fleetSchedulesCmd.Commands()
+	commandMap := make(map[string]bool)
+	for _, cmd := range commands {
+		commandMap[cmd.Name()] = true
+	}
+
+	for _, expected := range expectedCommands {
+		if !commandMap[expected] {
+			t.Errorf("Missing schedules subcommand: %s", expected)
+		}
+	}
+}
+
+func TestFleetAgentsListCmd_Flags(t *testing.T) {
+	flags := fleetAgentsListCmd.Flags()
+
+	expectedFlags := []string{"page-size", "tags", "filter", "sort", "desc"}
+	for _, flag := range expectedFlags {
+		if flags.Lookup(flag) == nil {
+			t.Errorf("Missing --%s flag on agents list", flag)
+		}
+	}
+}
+
+func TestFleetDeploymentsListCmd_Flags(t *testing.T) {
+	flags := fleetDeploymentsListCmd.Flags()
+
+	if flags.Lookup("page-size") == nil {
+		t.Error("Missing --page-size flag on deployments list")
+	}
+}
+
+func TestFleetDeploymentsConfigureCmd_Flags(t *testing.T) {
+	flags := fleetDeploymentsConfigureCmd.Flags()
+
+	if flags.Lookup("file") == nil {
+		t.Error("Missing --file flag on deployments configure")
+	}
+}
+
+func TestFleetDeploymentsUpgradeCmd_Flags(t *testing.T) {
+	flags := fleetDeploymentsUpgradeCmd.Flags()
+
+	if flags.Lookup("file") == nil {
+		t.Error("Missing --file flag on deployments upgrade")
+	}
+}
+
+func TestFleetSchedulesCreateCmd_Flags(t *testing.T) {
+	flags := fleetSchedulesCreateCmd.Flags()
+
+	if flags.Lookup("file") == nil {
+		t.Error("Missing --file flag on schedules create")
+	}
+}
+
+func TestFleetSchedulesUpdateCmd_Flags(t *testing.T) {
+	flags := fleetSchedulesUpdateCmd.Flags()
+
+	if flags.Lookup("file") == nil {
+		t.Error("Missing --file flag on schedules update")
+	}
+}
+
+func TestFleetAgentsGetCmd_Args(t *testing.T) {
+	if fleetAgentsGetCmd.Args == nil {
+		t.Error("Args validator is nil")
+	}
+}
+
+func TestFleetDeploymentsGetCmd_Args(t *testing.T) {
+	if fleetDeploymentsGetCmd.Args == nil {
+		t.Error("Args validator is nil")
+	}
+}
+
+func TestFleetDeploymentsCancelCmd_Args(t *testing.T) {
+	if fleetDeploymentsCancelCmd.Args == nil {
+		t.Error("Args validator is nil")
+	}
+}
+
+func TestFleetSchedulesGetCmd_Args(t *testing.T) {
+	if fleetSchedulesGetCmd.Args == nil {
+		t.Error("Args validator is nil")
+	}
+}
+
+func TestFleetSchedulesUpdateCmd_Args(t *testing.T) {
+	if fleetSchedulesUpdateCmd.Args == nil {
+		t.Error("Args validator is nil")
+	}
+}
+
+func TestFleetSchedulesDeleteCmd_Args(t *testing.T) {
+	if fleetSchedulesDeleteCmd.Args == nil {
+		t.Error("Args validator is nil")
+	}
+}
+
+func TestFleetSchedulesTriggerCmd_Args(t *testing.T) {
+	if fleetSchedulesTriggerCmd.Args == nil {
+		t.Error("Args validator is nil")
+	}
+}
+
+func setupFleetTestClient(t *testing.T) func() {
+	t.Helper()
+
+	origClient := ddClient
+	origCfg := cfg
+	origFactory := clientFactory
+	origAPIKeyFactory := apiKeyClientFactory
+
+	cfg = &config.Config{
+		Site:        "datadoghq.com",
+		APIKey:      "test-api-key-12345678",
+		AppKey:      "test-app-key-12345678",
+		AutoApprove: false,
+	}
+
+	mockErr := func(c *config.Config) (*client.Client, error) {
+		return nil, fmt.Errorf("mock client: no real API connection in tests")
+	}
+	clientFactory = mockErr
+	apiKeyClientFactory = mockErr
+
+	ddClient = nil
+
+	return func() {
+		ddClient = origClient
+		cfg = origCfg
+		clientFactory = origFactory
+		apiKeyClientFactory = origAPIKeyFactory
+	}
+}
+
+func TestRunFleetAgentsList(t *testing.T) {
+	cleanup := setupFleetTestClient(t)
+	defer cleanup()
+
+	tests := []struct {
+		name    string
+		wantErr bool
+	}{
+		{
+			name:    "fails on client creation",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			outputWriter = &buf
+			defer func() { outputWriter = os.Stdout }()
+
+			err := runFleetAgentsList(fleetAgentsListCmd, []string{})
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("runFleetAgentsList() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRunFleetAgentsGet(t *testing.T) {
+	cleanup := setupFleetTestClient(t)
+	defer cleanup()
+
+	var buf bytes.Buffer
+	outputWriter = &buf
+	defer func() { outputWriter = os.Stdout }()
+
+	err := runFleetAgentsGet(fleetAgentsGetCmd, []string{"agent-key-123"})
+	if err == nil {
+		t.Error("expected error due to mock client, got nil")
+	}
+}
+
+func TestRunFleetAgentsVersions(t *testing.T) {
+	cleanup := setupFleetTestClient(t)
+	defer cleanup()
+
+	var buf bytes.Buffer
+	outputWriter = &buf
+	defer func() { outputWriter = os.Stdout }()
+
+	err := runFleetAgentsVersions(fleetAgentsVersionsCmd, []string{})
+	if err == nil {
+		t.Error("expected error due to mock client, got nil")
+	}
+}
+
+func TestRunFleetDeploymentsList(t *testing.T) {
+	cleanup := setupFleetTestClient(t)
+	defer cleanup()
+
+	var buf bytes.Buffer
+	outputWriter = &buf
+	defer func() { outputWriter = os.Stdout }()
+
+	err := runFleetDeploymentsList(fleetDeploymentsListCmd, []string{})
+	if err == nil {
+		t.Error("expected error due to mock client, got nil")
+	}
+}
+
+func TestRunFleetDeploymentsGet(t *testing.T) {
+	cleanup := setupFleetTestClient(t)
+	defer cleanup()
+
+	var buf bytes.Buffer
+	outputWriter = &buf
+	defer func() { outputWriter = os.Stdout }()
+
+	err := runFleetDeploymentsGet(fleetDeploymentsGetCmd, []string{"deploy-123"})
+	if err == nil {
+		t.Error("expected error due to mock client, got nil")
+	}
+}
+
+func TestRunFleetDeploymentsCancel_AutoApprove(t *testing.T) {
+	cleanup := setupFleetTestClient(t)
+	defer cleanup()
+
+	cfg.AutoApprove = true
+
+	var buf bytes.Buffer
+	outputWriter = &buf
+	defer func() { outputWriter = os.Stdout }()
+
+	err := runFleetDeploymentsCancel(fleetDeploymentsCancelCmd, []string{"deploy-123"})
+	if err == nil {
+		t.Error("expected error due to mock client, got nil")
+	}
+}
+
+func TestRunFleetDeploymentsCancel_WithConfirmation(t *testing.T) {
+	cleanup := setupFleetTestClient(t)
+	defer cleanup()
+
+	cfg.AutoApprove = false
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:    "user declines",
+			input:   "n\n",
+			wantErr: false,
+		},
+		{
+			name:    "user confirms - fails on client creation",
+			input:   "yes\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			outputWriter = &buf
+			defer func() { outputWriter = os.Stdout }()
+
+			inputReader = strings.NewReader(tt.input)
+			defer func() { inputReader = os.Stdin }()
+
+			err := runFleetDeploymentsCancel(fleetDeploymentsCancelCmd, []string{"deploy-123"})
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("runFleetDeploymentsCancel() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRunFleetSchedulesList(t *testing.T) {
+	cleanup := setupFleetTestClient(t)
+	defer cleanup()
+
+	var buf bytes.Buffer
+	outputWriter = &buf
+	defer func() { outputWriter = os.Stdout }()
+
+	err := runFleetSchedulesList(fleetSchedulesListCmd, []string{})
+	if err == nil {
+		t.Error("expected error due to mock client, got nil")
+	}
+}
+
+func TestRunFleetSchedulesGet(t *testing.T) {
+	cleanup := setupFleetTestClient(t)
+	defer cleanup()
+
+	var buf bytes.Buffer
+	outputWriter = &buf
+	defer func() { outputWriter = os.Stdout }()
+
+	err := runFleetSchedulesGet(fleetSchedulesGetCmd, []string{"sched-123"})
+	if err == nil {
+		t.Error("expected error due to mock client, got nil")
+	}
+}
+
+func TestRunFleetSchedulesDelete_AutoApprove(t *testing.T) {
+	cleanup := setupFleetTestClient(t)
+	defer cleanup()
+
+	cfg.AutoApprove = true
+
+	var buf bytes.Buffer
+	outputWriter = &buf
+	defer func() { outputWriter = os.Stdout }()
+
+	err := runFleetSchedulesDelete(fleetSchedulesDeleteCmd, []string{"sched-123"})
+	if err == nil {
+		t.Error("expected error due to mock client, got nil")
+	}
+}
+
+func TestRunFleetSchedulesDelete_WithConfirmation(t *testing.T) {
+	cleanup := setupFleetTestClient(t)
+	defer cleanup()
+
+	cfg.AutoApprove = false
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:    "user declines",
+			input:   "n\n",
+			wantErr: false,
+		},
+		{
+			name:    "user confirms - fails on client creation",
+			input:   "yes\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			outputWriter = &buf
+			defer func() { outputWriter = os.Stdout }()
+
+			inputReader = strings.NewReader(tt.input)
+			defer func() { inputReader = os.Stdin }()
+
+			err := runFleetSchedulesDelete(fleetSchedulesDeleteCmd, []string{"sched-123"})
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("runFleetSchedulesDelete() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRunFleetSchedulesTrigger(t *testing.T) {
+	cleanup := setupFleetTestClient(t)
+	defer cleanup()
+
+	var buf bytes.Buffer
+	outputWriter = &buf
+	defer func() { outputWriter = os.Stdout }()
+
+	err := runFleetSchedulesTrigger(fleetSchedulesTriggerCmd, []string{"sched-123"})
+	if err == nil {
+		t.Error("expected error due to mock client, got nil")
+	}
+}
+
+func TestFleetCmd_ParentChild(t *testing.T) {
+	commands := fleetCmd.Commands()
+
+	for _, cmd := range commands {
+		if cmd.Parent() != fleetCmd {
+			t.Errorf("Command %s parent is not fleetCmd", cmd.Use)
+		}
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -282,6 +282,7 @@ func init() {
 	rootCmd.AddCommand(statusPagesCmd)
 	rootCmd.AddCommand(codeCoverageCmd)
 	rootCmd.AddCommand(hamrCmd)
+	rootCmd.AddCommand(fleetCmd)
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,6 +1,6 @@
 # Command Reference
 
-Complete reference for all 41 command groups in Pup.
+Complete reference for all 42 command groups in Pup.
 
 ## Command Pattern
 
@@ -60,8 +60,9 @@ pup <domain> <subgroup> <action> [options] # Nested commands
 | status-pages | pages, components, degradations | cmd/status_pages.go | ✅ |
 | code-coverage | branch-summary, commit-summary | cmd/code_coverage.go | ✅ |
 | hamr | connections (get, create) | cmd/hamr.go | ✅ |
+| fleet | agents (list, get, versions), deployments (list, get, configure, upgrade, cancel), schedules (list, get, create, update, delete, trigger) | cmd/fleet.go | ✅ |
 
-**Summary:** 37 working, 0 API-blocked, 2 placeholders
+**Summary:** 38 working, 0 API-blocked, 2 placeholders
 
 **Note:** RUM command (cmd/rum.go) is fully operational. Apps and sessions work completely. Metrics and retention-filters support list/get operations (create/update/delete operations pending due to complex API type structures).
 
@@ -151,6 +152,7 @@ pup infrastructure hosts list
 - **on-call** - Team management (create, update, delete teams; manage memberships with roles)
 - **cases** - Case management (create, search, assign, archive, projects, jira, servicenow, move)
 - **hamr** - High Availability Multi-Region connections
+- **fleet** - Fleet Automation (agents, deployments, schedules)
 
 ### Organization & Access
 - **users** - User management (list, get, roles)

--- a/pkg/client/auth_validator.go
+++ b/pkg/client/auth_validator.go
@@ -68,6 +68,23 @@ var endpointsWithoutOAuth = []EndpointAuthRequirement{
 	{Path: "/api/v2/error_tracking/issues/search", Method: "POST", SupportsOAuth: false, RequiresAPIKeys: true, Reason: "Error Tracking API requires API keys"},
 	{Path: "/api/v2/error_tracking/issues/", Method: "GET", SupportsOAuth: false, RequiresAPIKeys: true, Reason: "Error Tracking API requires API keys"},
 
+	// Fleet Automation API - missing OAuth implementation
+	{Path: "/api/v2/fleet/agents", Method: "GET", SupportsOAuth: false, RequiresAPIKeys: true, Reason: "Fleet Automation API does not support OAuth authentication"},
+	{Path: "/api/v2/fleet/agents/", Method: "GET", SupportsOAuth: false, RequiresAPIKeys: true, Reason: "Fleet Automation API does not support OAuth authentication"},
+	{Path: "/api/v2/fleet/agents/versions", Method: "GET", SupportsOAuth: false, RequiresAPIKeys: true, Reason: "Fleet Automation API does not support OAuth authentication"},
+	{Path: "/api/v2/fleet/deployments", Method: "GET", SupportsOAuth: false, RequiresAPIKeys: true, Reason: "Fleet Automation API does not support OAuth authentication"},
+	{Path: "/api/v2/fleet/deployments/", Method: "GET", SupportsOAuth: false, RequiresAPIKeys: true, Reason: "Fleet Automation API does not support OAuth authentication"},
+	{Path: "/api/v2/fleet/deployments/configure", Method: "POST", SupportsOAuth: false, RequiresAPIKeys: true, Reason: "Fleet Automation API does not support OAuth authentication"},
+	{Path: "/api/v2/fleet/deployments/upgrade", Method: "POST", SupportsOAuth: false, RequiresAPIKeys: true, Reason: "Fleet Automation API does not support OAuth authentication"},
+	{Path: "/api/v2/fleet/deployments/", Method: "POST", SupportsOAuth: false, RequiresAPIKeys: true, Reason: "Fleet Automation API does not support OAuth authentication"},
+	{Path: "/api/v2/fleet/deployments/", Method: "DELETE", SupportsOAuth: false, RequiresAPIKeys: true, Reason: "Fleet Automation API does not support OAuth authentication"},
+	{Path: "/api/v2/fleet/schedules", Method: "GET", SupportsOAuth: false, RequiresAPIKeys: true, Reason: "Fleet Automation API does not support OAuth authentication"},
+	{Path: "/api/v2/fleet/schedules/", Method: "GET", SupportsOAuth: false, RequiresAPIKeys: true, Reason: "Fleet Automation API does not support OAuth authentication"},
+	{Path: "/api/v2/fleet/schedules", Method: "POST", SupportsOAuth: false, RequiresAPIKeys: true, Reason: "Fleet Automation API does not support OAuth authentication"},
+	{Path: "/api/v2/fleet/schedules/", Method: "PATCH", SupportsOAuth: false, RequiresAPIKeys: true, Reason: "Fleet Automation API does not support OAuth authentication"},
+	{Path: "/api/v2/fleet/schedules/", Method: "DELETE", SupportsOAuth: false, RequiresAPIKeys: true, Reason: "Fleet Automation API does not support OAuth authentication"},
+	{Path: "/api/v2/fleet/schedules/", Method: "POST", SupportsOAuth: false, RequiresAPIKeys: true, Reason: "Fleet Automation API does not support OAuth authentication"},
+
 	// Notebooks API (V1) - missing OAuth scopes in spec
 	{Path: "/api/v1/notebooks", Method: "GET", SupportsOAuth: false, RequiresAPIKeys: true, Reason: "Notebooks API missing OAuth implementation in spec"},
 	{Path: "/api/v1/notebooks", Method: "POST", SupportsOAuth: false, RequiresAPIKeys: true, Reason: "Notebooks API missing OAuth implementation in spec"},

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -173,6 +173,21 @@ func NewWithOptions(cfg *config.Config, forceAPIKeys bool) (*Client, error) {
 		"v2.MoveCaseToProject",
 		// Flaky Tests
 		"v2.UpdateFlakyTests",
+		// Fleet Automation
+		"v2.ListFleetAgents",
+		"v2.GetFleetAgentInfo",
+		"v2.ListFleetAgentVersions",
+		"v2.ListFleetDeployments",
+		"v2.GetFleetDeployment",
+		"v2.CreateFleetDeploymentConfigure",
+		"v2.CreateFleetDeploymentUpgrade",
+		"v2.CancelFleetDeployment",
+		"v2.ListFleetSchedules",
+		"v2.GetFleetSchedule",
+		"v2.CreateFleetSchedule",
+		"v2.UpdateFleetSchedule",
+		"v2.DeleteFleetSchedule",
+		"v2.TriggerFleetSchedule",
 	}
 	for _, op := range unstableOps {
 		configuration.SetUnstableOperationEnabled(op, true)


### PR DESCRIPTION
## Summary
Add support for Datadog Fleet Automation APIs (Preview) with 14 subcommands across 3 subgroups — agents, deployments, and schedules — enabling remote management of Datadog Agents at scale.

## Changes
- Add `cmd/fleet.go` with 14 commands: agents (list, get, versions), deployments (list, get, configure, upgrade, cancel), schedules (list, get, create, update, delete, trigger)
- Add `cmd/fleet_test.go` with 19 test cases covering structure, flags, args, RunE error paths, and confirmation flows
- Enable 14 unstable operations in `pkg/client/client.go` for Fleet Automation APIs
- Register Fleet Automation endpoints as API-key-only in `pkg/client/auth_validator.go` (no OAuth support)
- Register `fleetCmd` in `cmd/root.go`
- Update `docs/COMMANDS.md`, `CLAUDE.md`, `README.md` with new command counts and documentation

## Testing
- 19 fleet-specific tests pass (`go test ./cmd/ -run TestFleet -v`)
- Full test suite passes with race detection (`go test ./... -race`)
- Manual verification: `pup fleet --help`, `pup fleet agents list --help`
- Build compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)