### PR TITLE
feat(useragent): add generic AGENT env var for agent mode detection

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -150,8 +150,8 @@ pup/v0.1.0 (rust; os darwin; arch arm64; ai-agent claude-code)  # With agent
 
 **AI Agent Detection** (`src/useragent.rs`):
 
-Table-driven registry detecting 11 agents via environment variables. First match wins:
-- Claude Code (`CLAUDECODE`, `CLAUDE_CODE`), Cursor (`CURSOR_AGENT`), Codex (`CODEX`, `OPENAI_CODEX`), OpenCode (`OPENCODE`), Aider (`AIDER`), Cline (`CLINE`), Windsurf (`WINDSURF_AGENT`), GitHub Copilot (`GITHUB_COPILOT`), Amazon Q (`AMAZON_Q`, `AWS_Q_DEVELOPER`), Gemini Code Assist (`GEMINI_CODE_ASSIST`), Sourcegraph Cody (`SRC_CODY`)
+Table-driven registry detecting 12 agents via environment variables. First match wins:
+- Claude Code (`CLAUDECODE`, `CLAUDE_CODE`), Cursor (`CURSOR_AGENT`), Codex (`CODEX`, `OPENAI_CODEX`), OpenCode (`OPENCODE`), Aider (`AIDER`), Cline (`CLINE`), Windsurf (`WINDSURF_AGENT`), GitHub Copilot (`GITHUB_COPILOT`), Amazon Q (`AMAZON_Q`, `AWS_Q_DEVELOPER`), Gemini Code Assist (`GEMINI_CODE_ASSIST`), Sourcegraph Cody (`SRC_CODY`), Generic Agent (`AGENT`)
 - Manual override: `FORCE_AGENT_MODE=1` or `--agent` flag
 
 **Agent Mode Behavior** (when detected):

--- a/docs/LLM_GUIDE.md
+++ b/docs/LLM_GUIDE.md
@@ -10,7 +10,7 @@ Pup auto-detects AI coding agents and switches to **agent mode**, which changes 
 
 | Method | Example |
 |--------|---------|
-| Auto-detect | `CLAUDECODE=1`, `CLAUDE_CODE=1`, `CURSOR_AGENT=1`, `CODEX=1`, `OPENAI_CODEX=1`, `OPENCODE=1`, `AIDER=1`, `CLINE=1`, `WINDSURF_AGENT=1`, `GITHUB_COPILOT=1`, `AMAZON_Q=1`, `AWS_Q_DEVELOPER=1`, `GEMINI_CODE_ASSIST=1`, `SRC_CODY=1` |
+| Auto-detect | `CLAUDECODE=1`, `CLAUDE_CODE=1`, `CURSOR_AGENT=1`, `CODEX=1`, `OPENAI_CODEX=1`, `OPENCODE=1`, `AIDER=1`, `CLINE=1`, `WINDSURF_AGENT=1`, `GITHUB_COPILOT=1`, `AMAZON_Q=1`, `AWS_Q_DEVELOPER=1`, `GEMINI_CODE_ASSIST=1`, `SRC_CODY=1`, `AGENT=1` |
 | Explicit flag | `pup --agent <command>` |
 | Environment override | `FORCE_AGENT_MODE=1` |
 
@@ -338,7 +338,7 @@ Error responses in agent mode:
 
 | File | Purpose |
 |------|---------|
-| `src/useragent.rs` | Agent detection (11 agents + FORCE_AGENT_MODE) |
+| `src/useragent.rs` | Agent detection (12 agents + FORCE_AGENT_MODE) |
 | `src/commands/agent.rs` | Schema generation, `pup agent schema`, `pup agent guide` |
 | `src/formatter.rs` | Agent envelope and structured errors |
 | `src/config.rs` | `agent_mode` field on Config |

--- a/src/useragent.rs
+++ b/src/useragent.rs
@@ -57,6 +57,10 @@ static AGENT_DETECTORS: &[AgentDetector] = &[
         name: "sourcegraph-cody",
         env_vars: &["SRC_CODY"],
     },
+    AgentDetector {
+        name: "generic-agent",
+        env_vars: &["AGENT"],
+    },
 ];
 
 fn is_env_truthy(key: &str) -> bool {
@@ -228,6 +232,20 @@ mod tests {
             "ua should not contain agent info: {ua}"
         );
         assert!(ua.ends_with(')'));
+    }
+
+    #[test]
+    fn test_detect_agent_info_generic_agent() {
+        for det in AGENT_DETECTORS {
+            for var in det.env_vars {
+                std::env::remove_var(var);
+            }
+        }
+        std::env::set_var("AGENT", "1");
+        let info = detect_agent_info();
+        assert!(info.detected);
+        assert_eq!(info.name, "generic-agent");
+        std::env::remove_var("AGENT");
     }
 
     #[test]


### PR DESCRIPTION
Support Bun's AGENT=1 convention for AI agent detection. Added as lowest priority so it won't override more specific detectors. This lets me just use one single AGENT=1 env var in my project and have it JustWork™️ 

## Motivation

Piling on to yet another thing these trillion dollar companies refuse to align on--Bun has a similar AGENT_MODE feature that respects the `AGENT` env var as a generic agent mode. fwiw it also respects `CLAUDECODE` so this isn't completely necessary but feels like an innocent enough request. 

## Additional Notes

this was all slopus 

## Checklist

- [x] The code change follows the project conventions (see [CONTRIBUTING.md](../docs/CONTRIBUTING.md))
- [x] Tests have been added/updated (if applicable)
- [x] Documentation has been updated (if applicable)
- [x] All CI checks pass
- [x] Code coverage is maintained or improved

## Related Issues

<!-- Link related issues here. Use "Closes #123" to automatically close issues when the PR is merged. -->
