### PR TITLE
feat(status-pages): restore third-party visual table with sparkline

### DIFF
--- a/src/commands/status_pages.rs
+++ b/src/commands/status_pages.rs
@@ -500,11 +500,214 @@ pub async fn components_create(cfg: &Config, page_id: &str, file: &str) -> Resul
 // Third-party status pages (fetched from updog.ai, no DD auth needed)
 // ---------------------------------------------------------------------------
 
-pub async fn third_party_list(cfg: &Config) -> Result<()> {
-    let url = "https://updog.ai/data/third-party-outages.json";
+use serde::Deserialize;
+
+const THIRD_PARTY_OUTAGES_URL: &str = "https://updog.ai/data/third-party-outages.json";
+const SPARKLINE_WIDTH: usize = 30;
+const DAY_MS: i64 = 86_400_000;
+
+const ANSI_GREEN: &str = "\x1b[32m";
+const ANSI_RED: &str = "\x1b[31m";
+const ANSI_DIM: &str = "\x1b[2m";
+const ANSI_RESET: &str = "\x1b[0m";
+
+#[derive(Deserialize, serde::Serialize, Clone)]
+struct ThirdPartyOutagesResponse {
+    data: ThirdPartyOutagesData,
+}
+
+#[derive(Deserialize, serde::Serialize, Clone)]
+struct ThirdPartyOutagesData {
+    attributes: ThirdPartyOutagesAttributes,
+}
+
+#[derive(Deserialize, serde::Serialize, Clone)]
+struct ThirdPartyOutagesAttributes {
+    provider_data: Vec<ThirdPartyProvider>,
+}
+
+#[derive(Deserialize, serde::Serialize, Clone)]
+struct ThirdPartyProvider {
+    provider_name: String,
+    #[serde(default)]
+    provider_service: String,
+    display_name: String,
+    #[serde(default)]
+    outages: Vec<ThirdPartyOutage>,
+    monitoring_start_date: i64,
+    // Remaining fields kept for JSON/YAML passthrough
+    #[serde(skip_serializing_if = "Option::is_none")]
+    integration_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    status_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    monitored_api_patterns: Vec<String>,
+}
+
+#[derive(Deserialize, serde::Serialize, Clone)]
+struct ThirdPartyOutage {
+    start: i64,
+    #[serde(default)]
+    end: i64,
+    status: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    impacted_region: String,
+}
+
+fn filter_providers(
+    providers: Vec<ThirdPartyProvider>,
+    search: Option<&str>,
+    active_only: bool,
+) -> Vec<ThirdPartyProvider> {
+    providers
+        .into_iter()
+        .filter(|p| {
+            if let Some(q) = search {
+                let q = q.to_lowercase();
+                if !p.provider_name.to_lowercase().contains(&q)
+                    && !p.display_name.to_lowercase().contains(&q)
+                {
+                    return false;
+                }
+            }
+            if active_only {
+                let has_active = p.outages.iter().any(|o| o.status != "resolved");
+                if !has_active {
+                    return false;
+                }
+            }
+            true
+        })
+        .collect()
+}
+
+fn provider_current_status(provider: &ThirdPartyProvider) -> &str {
+    for outage in &provider.outages {
+        if outage.status != "resolved" {
+            return &outage.status;
+        }
+    }
+    "operational"
+}
+
+fn build_sparkline(provider: &ThirdPartyProvider, now_ms: i64) -> String {
+    let mut s = String::new();
+    for i in (0..SPARKLINE_WIDTH).rev() {
+        let bucket_start = now_ms - (i as i64 + 1) * DAY_MS;
+        let bucket_end = now_ms - i as i64 * DAY_MS;
+
+        if bucket_end <= provider.monitoring_start_date {
+            s.push_str(ANSI_DIM);
+            s.push('·');
+            s.push_str(ANSI_RESET);
+            continue;
+        }
+
+        let has_outage = provider.outages.iter().any(|o| {
+            let outage_end = if o.end == 0 { now_ms } else { o.end };
+            o.start < bucket_end && outage_end > bucket_start
+        });
+
+        if has_outage {
+            s.push_str(ANSI_RED);
+        } else {
+            s.push_str(ANSI_GREEN);
+        }
+        s.push('█');
+        s.push_str(ANSI_RESET);
+    }
+    s
+}
+
+fn format_third_party_table(providers: &[ThirdPartyProvider]) -> String {
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64;
+
+    // Compute visible column widths (ANSI codes must not influence these).
+    let wp = providers
+        .iter()
+        .map(|p| p.provider_name.len())
+        .max()
+        .unwrap_or(0)
+        .max("PROVIDER".len());
+    let wd = providers
+        .iter()
+        .map(|p| p.display_name.len())
+        .max()
+        .unwrap_or(0)
+        .max("DISPLAY NAME".len());
+    let ws = providers
+        .iter()
+        .map(|p| p.provider_service.len())
+        .max()
+        .unwrap_or(0)
+        .max("SERVICE".len());
+    let wst = providers
+        .iter()
+        .map(|p| provider_current_status(p).len())
+        .max()
+        .unwrap_or(0)
+        .max("STATUS".len());
+    // UPTIME column is always exactly SPARKLINE_WIDTH visible chars.
+    let wu = SPARKLINE_WIDTH;
+
+    let sep = format!(
+        "+-{}-+-{}-+-{}-+-{}-+-{}-+",
+        "-".repeat(wp),
+        "-".repeat(wd),
+        "-".repeat(ws),
+        "-".repeat(wu),
+        "-".repeat(wst),
+    );
+    let hsep = sep.replace('-', "=");
+
+    let mut s = String::new();
+    s.push_str(&sep);
+    s.push('\n');
+    s.push_str(&format!(
+        "| {:<wp$} | {:<wd$} | {:<ws$} | {:<wu$} | {:<wst$} |\n",
+        "PROVIDER",
+        "DISPLAY NAME",
+        "SERVICE",
+        "UPTIME",
+        "STATUS",
+        wp = wp,
+        wd = wd,
+        ws = ws,
+        wu = wu,
+        wst = wst,
+    ));
+    s.push_str(&hsep);
+    s.push('\n');
+
+    for p in providers {
+        let sparkline = build_sparkline(p, now_ms);
+        let status = provider_current_status(p);
+        // The sparkline is exactly `wu` visible chars; ANSI bytes are invisible so
+        // we cannot use a format-width specifier for it — assemble that column manually.
+        s.push_str(&format!(
+            "| {:<wp$} | {:<wd$} | {:<ws$} | {sparkline} | {:<wst$} |\n",
+            p.provider_name,
+            p.display_name,
+            p.provider_service,
+            status,
+            wp = wp,
+            wd = wd,
+            ws = ws,
+            wst = wst,
+        ));
+    }
+
+    s.push_str(&sep);
+    s
+}
+
+pub async fn third_party_list(cfg: &Config, search: Option<&str>, active: bool) -> Result<()> {
     let client = reqwest::Client::new();
     let resp = client
-        .get(url)
+        .get(THIRD_PARTY_OUTAGES_URL)
         .header("Accept", "application/json")
         .send()
         .await?;
@@ -512,6 +715,215 @@ pub async fn third_party_list(cfg: &Config) -> Result<()> {
         let status = resp.status();
         bail!("failed to fetch third-party outages from updog.ai (HTTP {status})");
     }
-    let data: serde_json::Value = resp.json().await?;
-    formatter::output(cfg, &data)
+    let parsed: ThirdPartyOutagesResponse = resp.json().await?;
+    let providers = filter_providers(parsed.data.attributes.provider_data, search, active);
+
+    if cfg.output_format == crate::config::OutputFormat::Table {
+        if providers.is_empty() {
+            println!("No results found");
+        } else {
+            println!("{}", format_third_party_table(&providers));
+        }
+        return Ok(());
+    }
+
+    formatter::output(cfg, &providers)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_provider(
+        name: &str,
+        display: &str,
+        monitoring_start: i64,
+        outages: Vec<ThirdPartyOutage>,
+    ) -> ThirdPartyProvider {
+        ThirdPartyProvider {
+            provider_name: name.to_string(),
+            display_name: display.to_string(),
+            provider_service: String::new(),
+            outages,
+            monitoring_start_date: monitoring_start,
+            integration_id: None,
+            status_url: None,
+            monitored_api_patterns: vec![],
+        }
+    }
+
+    fn make_outage(start: i64, end: i64, status: &str) -> ThirdPartyOutage {
+        ThirdPartyOutage {
+            start,
+            end,
+            status: status.to_string(),
+            impacted_region: String::new(),
+        }
+    }
+
+    #[test]
+    fn test_provider_current_status_operational() {
+        let p = make_provider("a", "A", 0, vec![make_outage(1, 2, "resolved")]);
+        assert_eq!(provider_current_status(&p), "operational");
+    }
+
+    #[test]
+    fn test_provider_current_status_active() {
+        let p = make_provider("a", "A", 0, vec![make_outage(1, 0, "active")]);
+        assert_eq!(provider_current_status(&p), "active");
+    }
+
+    #[test]
+    fn test_provider_current_status_no_outages() {
+        let p = make_provider("a", "A", 0, vec![]);
+        assert_eq!(provider_current_status(&p), "operational");
+    }
+
+    #[test]
+    fn test_filter_no_filter() {
+        let providers = vec![
+            make_provider("aws-s3", "Amazon S3", 0, vec![]),
+            make_provider("stripe", "Stripe", 0, vec![]),
+        ];
+        let result = filter_providers(providers, None, false);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_filter_by_provider_name() {
+        let providers = vec![
+            make_provider("aws-s3", "Amazon S3", 0, vec![]),
+            make_provider("stripe", "Stripe", 0, vec![]),
+        ];
+        let result = filter_providers(providers, Some("aws"), false);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].provider_name, "aws-s3");
+    }
+
+    #[test]
+    fn test_filter_by_display_name() {
+        let providers = vec![
+            make_provider("aws-s3", "Amazon S3", 0, vec![]),
+            make_provider("stripe", "Stripe", 0, vec![]),
+        ];
+        let result = filter_providers(providers, Some("amazon"), false);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].provider_name, "aws-s3");
+    }
+
+    #[test]
+    fn test_filter_active_only() {
+        let providers = vec![
+            make_provider("aws-s3", "Amazon S3", 0, vec![make_outage(1, 0, "active")]),
+            make_provider("stripe", "Stripe", 0, vec![make_outage(1, 2, "resolved")]),
+        ];
+        let result = filter_providers(providers, None, true);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].provider_name, "aws-s3");
+    }
+
+    #[test]
+    fn test_filter_no_match() {
+        let providers = vec![make_provider("aws-s3", "Amazon S3", 0, vec![])];
+        let result = filter_providers(providers, Some("nonexistent"), false);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_sparkline_all_green() {
+        let now_ms = 1_705_276_800_000i64; // 2024-01-15 00:00:00 UTC
+        let p = make_provider("test", "Test", now_ms - 60 * DAY_MS, vec![]);
+        let sparkline = build_sparkline(&p, now_ms);
+        assert!(!sparkline.contains(ANSI_RED));
+        assert!(sparkline.contains(ANSI_GREEN));
+        assert!(!sparkline.contains('·'));
+    }
+
+    #[test]
+    fn test_sparkline_with_active_outage() {
+        let now_ms = 1_705_276_800_000i64;
+        let p = make_provider(
+            "test",
+            "Test",
+            now_ms - 60 * DAY_MS,
+            vec![make_outage(now_ms - DAY_MS / 2, 0, "active")],
+        );
+        let sparkline = build_sparkline(&p, now_ms);
+        assert!(sparkline.contains(ANSI_RED));
+    }
+
+    #[test]
+    fn test_sparkline_dim_dots_before_monitoring() {
+        let now_ms = 1_705_276_800_000i64;
+        // Monitoring started 10 days ago → first 20 buckets should be dim dots
+        let p = make_provider("test", "Test", now_ms - 10 * DAY_MS, vec![]);
+        let sparkline = build_sparkline(&p, now_ms);
+        let plain: String = {
+            let mut out = String::new();
+            let mut in_escape = false;
+            for c in sparkline.chars() {
+                if c == '\x1b' {
+                    in_escape = true;
+                    continue;
+                }
+                if in_escape {
+                    if c == 'm' {
+                        in_escape = false;
+                    }
+                    continue;
+                }
+                out.push(c);
+            }
+            out
+        };
+        let dot_count = plain.chars().filter(|&c| c == '·').count();
+        assert!(dot_count >= 19, "expected ≥19 dim dots, got {dot_count}");
+        assert!(sparkline.contains(ANSI_DIM));
+    }
+
+    #[test]
+    fn test_sparkline_outage_outside_window() {
+        let now_ms = 1_705_276_800_000i64;
+        // Outage 45 days ago — outside 30-day window
+        let p = make_provider(
+            "test",
+            "Test",
+            now_ms - 60 * DAY_MS,
+            vec![make_outage(
+                now_ms - 45 * DAY_MS,
+                now_ms - 44 * DAY_MS,
+                "resolved",
+            )],
+        );
+        let sparkline = build_sparkline(&p, now_ms);
+        assert!(!sparkline.contains(ANSI_RED));
+    }
+
+    #[test]
+    fn test_format_third_party_table_headers() {
+        let providers = vec![make_provider("aws-s3", "Amazon S3", 0, vec![])];
+        let output = format_third_party_table(&providers);
+        for header in &["PROVIDER", "DISPLAY NAME", "SERVICE", "UPTIME", "STATUS"] {
+            assert!(output.contains(header), "missing header: {header}");
+        }
+    }
+
+    #[test]
+    fn test_format_third_party_table_data() {
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as i64;
+        let providers = vec![make_provider(
+            "aws-s3",
+            "Amazon S3",
+            now_ms - 60 * DAY_MS,
+            vec![make_outage(now_ms - DAY_MS / 2, 0, "active")],
+        )];
+        let output = format_third_party_table(&providers);
+        assert!(output.contains("aws-s3"));
+        assert!(output.contains("Amazon S3"));
+        assert!(output.contains("active"));
+        assert!(output.contains('█'));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5844,8 +5844,9 @@ async fn main_inner() -> anyhow::Result<()> {
                     }
                 },
                 StatusPageActions::ThirdParty { action } => match action {
-                    StatusPageThirdPartyActions::List { .. } => {
-                        commands::status_pages::third_party_list(&cfg).await?;
+                    StatusPageThirdPartyActions::List { active, search } => {
+                        commands::status_pages::third_party_list(&cfg, search.as_deref(), active)
+                            .await?;
                     }
                 },
             }

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -1089,7 +1089,7 @@ async fn test_status_pages_third_party_list() {
     let mut s = mockito::Server::new_async().await;
     let cfg = test_config(&s.url());
     mock_all(&mut s, r#"{"data": []}"#).await;
-    let _ = crate::commands::status_pages::third_party_list(&cfg).await;
+    let _ = crate::commands::status_pages::third_party_list(&cfg, None, false).await;
     cleanup_env();
 }
 


### PR DESCRIPTION
## Summary

Restores the visual table output for `pup status-pages third-party list` that was present in the Go implementation (PR #83) but lost in the Rust port — the Rust code was dumping raw JSON and silently ignoring `--search` and `--active` flags.

## Changes

- **`src/commands/status_pages.rs`** — typed deserialization structs for updog.ai response; `filter_providers()` (case-insensitive search on `provider_name`/`display_name`, active-only filter); `build_sparkline()` (30-day ANSI-colored chart); hand-rolled ASCII table renderer; updated `third_party_list()` signature to accept `search` and `active` params
- **`src/main.rs`** — wire `--search`/`--active` flags through to `third_party_list()` instead of ignoring them with `..`
- **`src/test_commands.rs`** — update call site for new function signature

## Why hand-rolled table instead of comfy-table

`comfy-table` uses `unicode_width` to measure cell content, which counts ANSI escape sequences as visible bytes. A 30-char sparkline decorated with color codes measured as ~270 chars, producing a massively inflated UPTIME column:

```
# Before (broken)
+-----------+----------------------------------------------...------+
| PROVIDER  | UPTIME                                       ...       |
| anthropic | ██████████████████████████████               ...       |

# After (fixed)
+-----------+--------------+---------+--------------------------------+-------------+
| PROVIDER  | DISPLAY NAME | SERVICE | UPTIME                         | STATUS      |
+===========+==============+=========+================================+=============+
| anthropic | Anthropic    |         | ██████████████████████████████ | operational |
+-----------+--------------+---------+--------------------------------+-------------+
```

The fix computes column widths from plain string lengths and inserts the sparkline verbatim without a format-width specifier, so ANSI bytes are never counted.

## Testing

- 14 new unit tests: filtering (5), sparkline edge cases (4), table output (2), status (3)
- All 291 existing tests continue to pass
- `cargo clippy -- -D warnings` clean
- `cargo fmt --check` clean

## Related

Closes gap left by #83 (Go → Rust port)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)