### PR TITLE
fix(app-keys): replace Action Connection API with standard Application Keys API

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -66,6 +66,24 @@ pub fn make_dd_config(_cfg: &Config) -> datadog_api_client::datadog::Configurati
             .server_variables
             .insert("protocol".into(), protocol.into());
         dd_cfg.server_variables.insert("name".into(), url.into());
+    } else {
+        // Server index 0 only accepts production sites (datadoghq.com, us3, us5,
+        // ap1, ap2, eu, gov). Server index 2 uses the same URL template but with
+        // no enum restriction, so it works for any site including staging
+        // (datad0g.com). Use index 2 for non-standard sites.
+        static STANDARD_SITES: &[&str] = &[
+            "datadoghq.com",
+            "us3.datadoghq.com",
+            "us5.datadoghq.com",
+            "ap1.datadoghq.com",
+            "ap2.datadoghq.com",
+            "datadoghq.eu",
+            "ddog-gov.com",
+        ];
+        let site = std::env::var("DD_SITE").unwrap_or_default();
+        if !site.is_empty() && !STANDARD_SITES.contains(&site.as_str()) {
+            dd_cfg.server_index = 2;
+        }
     }
 
     dd_cfg

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -1404,7 +1404,16 @@ async fn test_app_keys_list() {
     let mut s = mockito::Server::new_async().await;
     let cfg = test_config(&s.url());
     mock_all(&mut s, r#"{"data": []}"#).await;
-    let _ = crate::commands::app_keys::list(&cfg, 10, 0).await;
+    let _ = crate::commands::app_keys::list(&cfg, 10, 0, "", "").await;
+    cleanup_env();
+}
+#[tokio::test]
+async fn test_app_keys_list_all() {
+    let _lock = lock_env();
+    let mut s = mockito::Server::new_async().await;
+    let cfg = test_config(&s.url());
+    mock_all(&mut s, r#"{"data": []}"#).await;
+    let _ = crate::commands::app_keys::list_all(&cfg, 10, 0, "", "").await;
     cleanup_env();
 }
 #[tokio::test]
@@ -1417,12 +1426,30 @@ async fn test_app_keys_get() {
     cleanup_env();
 }
 #[tokio::test]
-async fn test_app_keys_unregister() {
+async fn test_app_keys_create() {
+    let _lock = lock_env();
+    let mut s = mockito::Server::new_async().await;
+    let cfg = test_config(&s.url());
+    mock_all(&mut s, r#"{"data": {}}"#).await;
+    let _ = crate::commands::app_keys::create(&cfg, "test-key", "").await;
+    cleanup_env();
+}
+#[tokio::test]
+async fn test_app_keys_update() {
+    let _lock = lock_env();
+    let mut s = mockito::Server::new_async().await;
+    let cfg = test_config(&s.url());
+    mock_all(&mut s, r#"{"data": {}}"#).await;
+    let _ = crate::commands::app_keys::update(&cfg, "k1", "new-name", "").await;
+    cleanup_env();
+}
+#[tokio::test]
+async fn test_app_keys_delete() {
     let _lock = lock_env();
     let mut s = mockito::Server::new_async().await;
     let cfg = test_config(&s.url());
     mock_all(&mut s, r#"{}"#).await;
-    let _ = crate::commands::app_keys::unregister(&cfg, "k1").await;
+    let _ = crate::commands::app_keys::delete(&cfg, "k1").await;
     cleanup_env();
 }
 


### PR DESCRIPTION
## Summary
The `app-keys` command was incorrectly using the `ActionConnectionAPI` (register/unregister endpoints for Action Platform) instead of the `KeyManagementAPI` for application key management. This is the same bug that was fixed in the Go version (#101) but reintroduced during the Rust rewrite.

## Changes
- Replace `ActionConnectionAPI` with `KeyManagementAPI` using `current_user` endpoints (`src/commands/app_keys.rs`)
- Change subcommands from `register`/`unregister` to `create`/`update`/`delete`
- Add `--all` flag on `list` to use org-wide endpoint (requires API keys)
- Add `--name`, `--scopes` flags for create/update operations
- Add `--filter`, `--sort` flags for list operations
- Update wasm32 fallback paths from `/api/v2/integration/action_connections/app-keys` to `/api/v2/current_user/application_keys`
- Update CLI help text and descriptions to reflect actual functionality (`src/main.rs`)

## Testing
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] Manual E2E tests cover all patterns in the help test for `pup app-keys`

## Related Issues
Regression of fix from #101

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)