### PR TITLE
fix(main): honour --agent flag when intercepting --help for schema output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4831,7 +4831,8 @@ async fn main_inner() -> anyhow::Result<()> {
     // In agent mode, intercept --help to return a JSON schema instead of plain text.
     let args: Vec<String> = std::env::args().collect();
     let has_help = args.iter().any(|a| a == "--help" || a == "-h");
-    if has_help && useragent::is_agent_mode() {
+    let has_agent_flag = args.iter().any(|a| a == "--agent");
+    if has_help && (useragent::is_agent_mode() || has_agent_flag) {
         let cmd = Cli::command();
         // Collect subcommand path from args (skip binary name, flags, and --help/-h)
         let sub_path: Vec<&str> = args


### PR DESCRIPTION
## Summary
`pup --agent --help` was outputting human-readable clap help instead of the JSON schema. The `--help` intercept in `main_inner()` fires before `Cli::parse()`, so the `--agent` CLI flag was invisible to `useragent::is_agent_mode()` (which only reads env vars). The fix also checks for `--agent` in the raw args list.

## Changes
- `src/main.rs:4834` — scan raw args for `--agent` before `Cli::parse()` runs, so the agent-mode help intercept fires when `--agent` is present, matching `FORCE_AGENT_MODE=1 pup --help` behaviour

## Testing
- `pup --agent --help` now produces JSON schema output
- `diff <(pup --agent --help) <(FORCE_AGENT_MODE=1 pup --help)` returns no differences
- All 307 unit tests pass (`cargo test`)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)