### PR TITLE
fix(cicd): always include data key in flaky-tests search request body

### DIFF
--- a/src/commands/cicd.rs
+++ b/src/commands/cicd.rs
@@ -474,19 +474,19 @@ pub async fn flaky_tests_search(cfg: &Config, query: Option<String>) -> Result<(
         None => TestOptimizationAPI::with_config(dd_cfg),
     };
 
-    let mut body = FlakyTestsSearchRequest::new();
+    use datadog_api_client::datadogV2::model::{
+        FlakyTestsSearchFilter, FlakyTestsSearchRequestAttributes, FlakyTestsSearchRequestData,
+        FlakyTestsSearchRequestDataType,
+    };
+    let mut attrs = FlakyTestsSearchRequestAttributes::new();
     if let Some(q) = query {
-        use datadog_api_client::datadogV2::model::{
-            FlakyTestsSearchFilter, FlakyTestsSearchRequestAttributes, FlakyTestsSearchRequestData,
-            FlakyTestsSearchRequestDataType,
-        };
         let filter = FlakyTestsSearchFilter::new().query(q);
-        let attrs = FlakyTestsSearchRequestAttributes::new().filter(filter);
-        let data = FlakyTestsSearchRequestData::new()
-            .attributes(attrs)
-            .type_(FlakyTestsSearchRequestDataType::SEARCH_FLAKY_TESTS_REQUEST);
-        body = body.data(data);
+        attrs = attrs.filter(filter);
     }
+    let data = FlakyTestsSearchRequestData::new()
+        .attributes(attrs)
+        .type_(FlakyTestsSearchRequestDataType::SEARCH_FLAKY_TESTS_REQUEST);
+    let body = FlakyTestsSearchRequest::new().data(data);
 
     let params = SearchFlakyTestsOptionalParams::default().body(body);
     let resp = api
@@ -498,19 +498,16 @@ pub async fn flaky_tests_search(cfg: &Config, query: Option<String>) -> Result<(
 
 #[cfg(target_arch = "wasm32")]
 pub async fn flaky_tests_search(cfg: &Config, query: Option<String>) -> Result<()> {
-    let mut body = serde_json::json!({});
+    let mut attrs = serde_json::json!({});
     if let Some(q) = query {
-        body = serde_json::json!({
-            "data": {
-                "attributes": {
-                    "filter": {
-                        "query": q
-                    }
-                },
-                "type": "search_flaky_tests_request"
-            }
-        });
+        attrs = serde_json::json!({ "filter": { "query": q } });
     }
+    let body = serde_json::json!({
+        "data": {
+            "attributes": attrs,
+            "type": "search_flaky_tests_request"
+        }
+    });
     let data = crate::api::post(cfg, "/api/v2/ci/tests/flaky", &body).await?;
     crate::formatter::output(cfg, &data)
 }


### PR DESCRIPTION
## Summary
When `pup cicd flaky-tests search` is run with no `--query`, the code sent an empty `{}` body that the API rejected with a 400 error. Fix by always constructing the `data` object with the required type field, adding the filter only when a query is supplied.

## Changes
- `src/commands/cicd.rs:477` — restructured `flaky_tests_search` (non-wasm32) to always build `FlakyTestsSearchRequestData` with `type_` set; filter is added only when `query` is `Some`
- `src/commands/cicd.rs:501` — same fix for the wasm32 path using `serde_json`

## Testing
- `cargo build` compiles cleanly
- `cargo clippy -- -D warnings` passes with no warnings
- `cargo test` passes all 342 tests

## Related Issues
Closes #150

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)