### PR TITLE
fix(auth): add teams_manage scope and SearchFlakyTests unstable op

### DIFF
--- a/src/auth/types.rs
+++ b/src/auth/types.rs
@@ -133,6 +133,7 @@ pub fn default_scopes() -> Vec<&'static str> {
         "synthetics_write",
         "synthetics_private_location_read",
         // Teams
+        "teams_manage",
         "teams_read",
         // Timeseries
         "timeseries_query",
@@ -186,7 +187,7 @@ mod tests {
     #[test]
     fn test_default_scopes() {
         let scopes = default_scopes();
-        assert_eq!(scopes.len(), 69);
+        assert_eq!(scopes.len(), 70);
         assert!(scopes.contains(&"dashboards_read"));
         assert!(scopes.contains(&"monitors_read"));
         assert!(scopes.contains(&"logs_read_data"));

--- a/src/client.rs
+++ b/src/client.rs
@@ -187,7 +187,8 @@ static UNSTABLE_OPS: &[&str] = &[
     "v2.list_findings",
     // SLO Status (1)
     "v2.get_slo_status",
-    // Flaky Tests (1)
+    // Flaky Tests (2)
+    "v2.search_flaky_tests",
     "v2.update_flaky_tests",
 ];
 
@@ -537,7 +538,7 @@ mod tests {
 
     #[test]
     fn test_unstable_ops_count() {
-        assert_eq!(UNSTABLE_OPS.len(), 64);
+        assert_eq!(UNSTABLE_OPS.len(), 65);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Remaining changes from PR #144 (by @wzoom) that weren't included in PR #153.

## Changes

- **`src/auth/types.rs`** — Add `teams_manage` OAuth scope for team create/update/delete operations (70 scopes total)
- **`src/client.rs`** — Enable `v2.search_flaky_tests` as an unstable operation (65 total)

## Context

PR #153 expanded OAuth coverage to 69 scopes but didn't include these two items from #144:
- `teams_manage` — needed for `on-call teams create/update/delete`
- `v2.search_flaky_tests` — needed for `cicd flaky-tests search`

## Testing

- `cargo test` — 342 passed
- `cargo clippy -- -D warnings` — clean
- `cargo fmt --check` — clean

Closes #144

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)