### PR TITLE
fix(logs): honour --sort flag for logs list/search/query

### DIFF
--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -38,12 +38,21 @@ fn parse_storage_tier(storage: Option<String>) -> Result<Option<LogsStorageTier>
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+fn parse_logs_sort(sort: &str) -> LogsSort {
+    match sort {
+        "timestamp" | "asc" | "+timestamp" => LogsSort::TIMESTAMP_ASCENDING,
+        _ => LogsSort::TIMESTAMP_DESCENDING,
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 pub async fn search(
     cfg: &Config,
     query: String,
     from: String,
     to: String,
     limit: i32,
+    sort: String,
     storage: Option<String>,
 ) -> Result<()> {
     let dd_cfg = client::make_dd_config(cfg);
@@ -68,7 +77,7 @@ pub async fn search(
     let body = LogsListRequest::new()
         .filter(filter)
         .page(LogsListRequestPage::new().limit(limit))
-        .sort(LogsSort::TIMESTAMP_DESCENDING);
+        .sort(parse_logs_sort(&sort));
 
     let params = ListLogsOptionalParams::default().body(body);
 
@@ -107,6 +116,7 @@ pub async fn search(
     from: String,
     to: String,
     limit: i32,
+    sort: String,
     storage: Option<String>,
 ) -> Result<()> {
     let from_ms = util::parse_time_to_unix_millis(&from)?;
@@ -119,10 +129,14 @@ pub async fn search(
     if let Some(tier) = storage {
         filter["storage_tier"] = serde_json::Value::String(tier);
     }
+    let sort_value = match sort.as_str() {
+        "timestamp" | "asc" | "+timestamp" => "timestamp",
+        _ => "-timestamp",
+    };
     let body = serde_json::json!({
         "filter": filter,
         "page": { "limit": limit },
-        "sort": "-timestamp"
+        "sort": sort_value
     });
     let data = crate::api::post(cfg, "/api/v2/logs/events/search", &body).await?;
     crate::formatter::output(cfg, &data)
@@ -135,9 +149,10 @@ pub async fn list(
     from: String,
     to: String,
     limit: i32,
+    sort: String,
     storage: Option<String>,
 ) -> Result<()> {
-    search(cfg, query, from, to, limit, storage).await
+    search(cfg, query, from, to, limit, sort, storage).await
 }
 
 /// Alias for `search` with the same interface.
@@ -147,9 +162,10 @@ pub async fn query(
     from: String,
     to: String,
     limit: i32,
+    sort: String,
     storage: Option<String>,
 ) -> Result<()> {
-    search(cfg, query, from, to, limit, storage).await
+    search(cfg, query, from, to, limit, sort, storage).await
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5062,32 +5062,32 @@ async fn main_inner() -> anyhow::Result<()> {
                     from,
                     to,
                     limit,
-                    sort: _,
+                    sort,
                     index: _,
                     storage,
                 } => {
-                    commands::logs::search(&cfg, query, from, to, limit, storage).await?;
+                    commands::logs::search(&cfg, query, from, to, limit, sort, storage).await?;
                 }
                 LogActions::List {
                     query,
                     from,
                     to,
                     limit,
-                    sort: _,
+                    sort,
                     storage,
                 } => {
-                    commands::logs::list(&cfg, query, from, to, limit, storage).await?;
+                    commands::logs::list(&cfg, query, from, to, limit, sort, storage).await?;
                 }
                 LogActions::Query {
                     query,
                     from,
                     to,
                     limit,
-                    sort: _,
+                    sort,
                     storage,
                     timezone: _,
                 } => {
-                    commands::logs::query(&cfg, query, from, to, limit, storage).await?;
+                    commands::logs::query(&cfg, query, from, to, limit, sort, storage).await?;
                 }
                 LogActions::Aggregate {
                     query,

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -371,6 +371,7 @@ async fn test_logs_search() {
         "1h".into(),
         "now".into(),
         10,
+        "-timestamp".into(),
         None,
     )
     .await;
@@ -404,6 +405,7 @@ async fn test_logs_search_with_oauth() {
         "1h".into(),
         "now".into(),
         10,
+        "-timestamp".into(),
         None,
     )
     .await;
@@ -437,6 +439,7 @@ async fn test_logs_search_with_flex_storage() {
         "1h".into(),
         "now".into(),
         10,
+        "-timestamp".into(),
         Some("flex".into()),
     )
     .await;
@@ -461,6 +464,7 @@ async fn test_logs_search_with_online_archives_storage() {
         "1h".into(),
         "now".into(),
         10,
+        "-timestamp".into(),
         Some("online-archives".into()),
     )
     .await;
@@ -484,6 +488,7 @@ async fn test_logs_search_with_invalid_storage_tier() {
         "1h".into(),
         "now".into(),
         10,
+        "-timestamp".into(),
         Some("invalid-tier".into()),
     )
     .await;


### PR DESCRIPTION
## Summary

The `--sort` flag for `pup logs list`, `pup logs search`, and `pup logs query` was silently ignored — the user's value was discarded in `main.rs` (`sort: _`) and `search()` hardcoded descending order unconditionally. This meant `--sort timestamp` (ascending) had no effect.

## Changes

- `src/commands/logs.rs`: Added `sort: String` param to `search()`, `list()`, `query()`. New `parse_logs_sort()` maps `"timestamp"`, `"asc"`, `"+timestamp"` → `TIMESTAMP_ASCENDING`; everything else (including default `"-timestamp"`) → `TIMESTAMP_DESCENDING`. Both native and wasm32 paths fixed.
- `src/main.rs`: Changed `sort: _` → `sort` in all three log action branches and passed it through to the command functions.
- `src/test_commands.rs`: Updated 5 existing test call sites to include the new `sort` argument.

## Testing

- `cargo test` — 364 tests pass
- `cargo clippy -- -D warnings` — clean

Users can now use any of the following for ascending order:
```
--sort timestamp
--sort asc
--sort +timestamp
```

## Related Issues

Fixes user-reported bug: `--sort` argument to `logs list/search/query` was completely ignored.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)