### PR TITLE
fix(skills): correct broken commands in built-in agent skills for v0.26.0

### DIFF
--- a/agents/error-tracking.md
+++ b/agents/error-tracking.md
@@ -23,9 +23,8 @@ You are a specialized agent for interacting with Datadog's Error Tracking API. Y
 - **View Teams**: See team ownership
 
 ### Issue Management
-- **Update State**: Change issue status (open, resolved, ignored) (with user confirmation)
-- **Assign Issues**: Assign errors to users or teams (with user confirmation)
-- **Bulk Operations**: Update multiple issues at once (with user confirmation)
+- **Update State**: Change issue status (open, resolved, ignored) via Datadog UI or API
+- **Assign Issues**: Assign errors to users or teams via Datadog UI or API
 
 ### Integration Support
 - **Create Jira Issues**: Link errors to Jira tickets
@@ -33,8 +32,6 @@ You are a specialized agent for interacting with Datadog's Error Tracking API. Y
 - **Case Management**: Link to Datadog case management
 
 ## Important Context
-
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
@@ -50,156 +47,62 @@ You are a specialized agent for interacting with Datadog's Error Tracking API. Y
 #### Search All Errors
 ```bash
 # Search errors in the last hour
-pup errors search \
+pup error-tracking issues search \
   --query="*" \
-  --from="1h" \
-  --to="now"
+  --from="1h"
 ```
 
 Search by service:
 ```bash
-pup errors search \
+pup error-tracking issues search \
   --query="service:api-gateway" \
-  --from="24h" \
-  --to="now"
+  --from="24h"
 ```
 
 Search by error type:
 ```bash
-pup errors search \
+pup error-tracking issues search \
   --query="error.type:TimeoutError" \
-  --from="7d" \
-  --to="now"
+  --from="7d"
 ```
 
 Search by status:
 ```bash
-pup errors search \
+pup error-tracking issues search \
   --query="status:open" \
-  --from="30d" \
-  --to="now"
+  --from="30d"
 ```
 
 Search by environment:
 ```bash
-pup errors search \
+pup error-tracking issues search \
   --query="env:production AND service:payment-service" \
-  --from="24h" \
-  --to="now"
+  --from="24h"
 ```
 
-#### Filter by Track
-```bash
-# Search errors from APM traces
-pup errors search \
-  --query="service:api" \
-  --track="trace" \
-  --from="1h"
-```
+#### Search with Ordering
 
-Search errors from logs:
-```bash
-pup errors search \
-  --query="*" \
-  --track="logs" \
-  --from="1h"
-```
-
-Search errors from RUM:
-```bash
-pup errors search \
-  --query="*" \
-  --track="rum" \
-  --from="1h"
-```
-
-#### Advanced Search Options
-```bash
-# Include related data in search results
-pup errors search \
-  --query="service:api" \
-  --from="24h" \
-  --include="issue,issue.assignee,issue.team_owners,issue.case"
-```
-
-Search with ordering:
 ```bash
 # Order by occurrence count (most frequent first)
-pup errors search \
+pup error-tracking issues search \
   --query="*" \
   --from="7d" \
-  --order-by="occurrence_count" \
-  --order-direction="desc"
+  --order-by="TOTAL_COUNT"
 ```
 
 Order by first seen:
 ```bash
-pup errors search \
+pup error-tracking issues search \
   --query="*" \
   --from="7d" \
-  --order-by="first_seen" \
-  --order-direction="desc"
-```
-
-Order by last seen:
-```bash
-pup errors search \
-  --query="*" \
-  --from="7d" \
-  --order-by="last_seen" \
-  --order-direction="desc"
+  --order-by="FIRST_SEEN"
 ```
 
 ### Issue Details
 
 #### Get Issue Information
 ```bash
-pup errors get <issue-id>
-```
-
-### Issue State Management
-
-#### Update Issue State
-```bash
-# Mark issue as resolved
-pup errors update-state <issue-id> \
-  --state="resolved"
-```
-
-Mark issue as ignored:
-```bash
-pup errors update-state <issue-id> \
-  --state="ignored"
-```
-
-Reopen issue:
-```bash
-pup errors update-state <issue-id> \
-  --state="open"
-```
-
-State options:
-- `open`: Issue is active and needs attention
-- `resolved`: Issue has been fixed
-- `ignored`: Issue is acknowledged but won't be fixed
-
-### Issue Assignment
-
-#### Assign Issue to User
-```bash
-pup errors assign <issue-id> \
-  --user-id="user-uuid"
-```
-
-Assign to team:
-```bash
-pup errors assign <issue-id> \
-  --team-id="team-uuid"
-```
-
-Unassign issue:
-```bash
-pup errors unassign <issue-id>
+pup error-tracking issues get <issue-id>
 ```
 
 ## Query Syntax
@@ -258,12 +161,12 @@ When using `--from` and `--to` parameters:
 
 These operations execute automatically without prompting.
 
-### WRITE Operations (Confirmation Required)
+### WRITE Operations
 - Updating issue state
 - Assigning issues
 - Bulk updates
 
-These operations will display what will be changed and require user awareness.
+Write operations are available through the Datadog UI or Datadog API directly.
 
 ## Response Formatting
 
@@ -277,56 +180,46 @@ Present error tracking data in clear, user-friendly formats:
 
 ### "Show me all open errors"
 ```bash
-pup errors search \
+pup error-tracking issues search \
   --query="status:open" \
   --from="7d" \
-  --order-by="occurrence_count" \
-  --order-direction="desc"
+  --order-by="TOTAL_COUNT"
 ```
 
 ### "Find errors in production API service"
 ```bash
-pup errors search \
+pup error-tracking issues search \
   --query="env:production AND service:api-gateway" \
   --from="24h"
 ```
 
 ### "What's the most frequent error?"
 ```bash
-pup errors search \
+pup error-tracking issues search \
   --query="*" \
   --from="7d" \
-  --order-by="occurrence_count" \
-  --order-direction="desc" \
+  --order-by="TOTAL_COUNT" \
   --limit=10
 ```
 
 ### "Show me new errors in the last hour"
 ```bash
-pup errors search \
+pup error-tracking issues search \
   --query="*" \
   --from="1h" \
-  --order-by="first_seen" \
-  --order-direction="desc"
+  --order-by="FIRST_SEEN"
 ```
 
 ### "Find timeout errors"
 ```bash
-pup errors search \
+pup error-tracking issues search \
   --query="error.type:TimeoutError OR error.message:*timeout*" \
   --from="24h"
 ```
 
-### "Mark issue as resolved"
+### "Get details on a specific issue"
 ```bash
-pup errors update-state <issue-id> \
-  --state="resolved"
-```
-
-### "Assign error to platform team"
-```bash
-pup errors assign <issue-id> \
-  --team-id="platform-team-uuid"
+pup error-tracking issues get <issue-id>
 ```
 
 ## Error Tracking Concepts
@@ -381,12 +274,6 @@ Error: Invalid search query
 ```
 → Explain proper query syntax with examples
 
-**Invalid State**:
-```
-Error: Invalid state: "fixed"
-```
-→ Valid states are: open, resolved, ignored
-
 **Time Range Too Large**:
 ```
 Error: Time range exceeds maximum allowed
@@ -406,7 +293,7 @@ Error: Insufficient permissions
 3. **Assignment**: Assign issues to owners for accountability
 4. **Time Windows**: Use appropriate time ranges (24h for active monitoring, 7d for trends)
 5. **Query Specificity**: Use specific queries to reduce noise
-6. **Prioritization**: Order by occurrence count to find high-impact errors
+6. **Prioritization**: Order by `TOTAL_COUNT` to find high-impact errors
 7. **Environment Filtering**: Separate production from staging/dev errors
 
 ## Examples of Good Responses
@@ -415,7 +302,7 @@ Error: Insufficient permissions
 ```
 I'll search for all open error issues in the last 7 days, ordered by occurrence count.
 
-<Execute errors search command>
+<Execute error-tracking issues search command>
 
 Found 23 open error issues:
 
@@ -456,7 +343,7 @@ Would you like details on any specific error?
 ```
 I'll search for errors in production environment in the last 24 hours.
 
-<Execute errors search command>
+<Execute error-tracking issues search command>
 
 Found 8 error issues in production:
 
@@ -483,39 +370,14 @@ Critical Actions:
 2. Investigate payment-api database timeouts
 3. Review notification-worker RabbitMQ connection
 
-View details: errors get issue-abc-123
-```
-
-**When user asks "Mark error as resolved":**
-```
-I'll mark issue issue-xyz-789 as resolved.
-
-Issue Details:
-- ID: issue-xyz-789
-- Error: ValidationError in user-service
-- Occurrences: 234
-- Status: Open → Resolved
-- Assignee: backend-team
-
-⚠️ This will mark the issue as resolved. New occurrences of this error will create a new issue.
-
-<If user confirms, execute update-state command>
-
-✓ Issue marked as resolved successfully!
-
-The error is now in "resolved" state. If this error occurs again, Datadog will create a new issue.
-
-Recommendations:
-- Monitor for recurrence in the next 24-48 hours
-- Document the fix in your tracking system
-- Review similar validation errors
+View details: pup error-tracking issues get issue-abc-123
 ```
 
 **When user asks "What's causing the most errors?":**
 ```
 I'll find the error with the highest occurrence count in the last 7 days.
 
-<Execute errors search with occurrence_count ordering>
+<Execute error-tracking issues search with TOTAL_COUNT ordering>
 
 Top Error Issue:
 Issue: issue-abc-123
@@ -529,17 +391,6 @@ Error Details:
 - Last Seen: 5 minutes ago
 - Trend: Increasing (+15% vs previous week)
 
-Stack Trace Pattern:
-```
-File "/app/payment.py", line 234, in process_payment
-  result = db.execute_query(query, timeout=30)
-TimeoutError: Query exceeded timeout limit
-```
-
-Affected Endpoints:
-- POST /api/v1/payments/process (85% of occurrences)
-- POST /api/v1/payments/refund (15% of occurrences)
-
 Impact:
 - 335 failed payment attempts per day
 - Potential revenue impact: High
@@ -551,8 +402,6 @@ Recommendations:
 3. Add query caching layer
 4. Review database indexes
 5. Monitor database server resources
-
-Assign to team: errors assign issue-abc-123 --team-id=platform-team
 ```
 
 ## Integration Notes

--- a/skills/dd-apm/SKILL.md
+++ b/skills/dd-apm/SKILL.md
@@ -19,61 +19,103 @@ Distributed tracing, service maps, and performance analysis.
 Datadog Labs Pup should be installed via:
 
 ```bash
-go install github.com/datadog-labs/pup@latest
+brew tap datadog-labs/pack
+brew install pup
 ```
 
 ## Quick Start
 
 ```bash
 pup auth login
-pup apm services list
-pup apm traces list --service api-gateway --duration 1h
+pup apm services list --env production
+pup traces search --query="service:api-gateway" --from="1h"
 ```
 
 ## Services
 
 ### List Services
 
+`--env` is **required** for all `apm services` commands.
+
 ```bash
-pup apm services list
 pup apm services list --env production
+pup apm services list --env staging
 ```
 
-### Service Details
+### Service Statistics
 
 ```bash
-pup apm services get api-gateway --json
+pup apm services stats --env production
+pup apm services stats --env production --from 4h
 ```
 
-### Service Map
+### Service Operations and Resources
 
 ```bash
-# View dependencies
-pup apm service-map --service api-gateway --json
+# List operations for a service
+pup apm services operations --env production --service api-gateway
+
+# List resources (endpoints) for an operation
+pup apm services resources --env production --service api-gateway --operation http.request
+```
+
+### Service Dependencies
+
+```bash
+pup apm dependencies list --env production
+```
+
+### Flow Map
+
+```bash
+# View service flow map (--query and --env required)
+pup apm flow-map --query "service:api-gateway" --env production
 ```
 
 ## Traces
+
+Traces are searched via the top-level `traces` command (not under `apm`).
+
+**Important:** APM durations are in **nanoseconds**: 1 second = 1,000,000,000 ns.
 
 ### Search Traces
 
 ```bash
 # By service
-pup apm traces list --service api-gateway --duration 1h
+pup traces search --query="service:api-gateway" --from="1h"
 
 # Errors only
-pup apm traces list --service api-gateway --status error
+pup traces search --query="service:api-gateway status:error" --from="1h"
 
-# Slow traces (>1s)
-pup apm traces list --service api-gateway --min-duration 1000ms
+# Slow traces (>1 second = 1000000000 ns)
+pup traces search --query="service:api-gateway @duration:>1000000000" --from="1h"
 
 # With specific tag
-pup apm traces list --query "@http.url:/api/users"
+pup traces search --query="service:api @http.url:/api/users" --from="1h"
 ```
 
-### Get Trace Detail
+### Aggregate Traces
 
 ```bash
-pup apm traces get <trace_id> --json
+# Average duration by resource
+pup traces aggregate \
+  --query="service:api-gateway" \
+  --compute="avg(@duration)" \
+  --group-by="resource_name" \
+  --from="1h"
+
+# Error count by service
+pup traces aggregate \
+  --query="status:error" \
+  --compute="count" \
+  --group-by="service" \
+  --from="1h"
+
+# p99 latency
+pup traces aggregate \
+  --query="service:api-gateway" \
+  --compute="percentile(@duration, 99)" \
+  --from="1h"
 ```
 
 ## Key Metrics
@@ -95,11 +137,6 @@ pup apm traces get <trace_id> --json
 | **Error/Slow** | All errors, slow traces |
 | **Retention** | What's indexed (billed) |
 
-```bash
-# Check retention filters
-pup apm retention-filters list
-```
-
 ### Trace Retention Costs
 
 | Retention | Cost |
@@ -114,21 +151,16 @@ pup apm retention-filters list
 Link APM to SLOs:
 
 ```bash
-pup slos create \
-  --name "API Latency p99 < 200ms" \
-  --type metric \
-  --numerator "sum:trace.http.request.hits{service:api,@duration:<200000000}" \
-  --denominator "sum:trace.http.request.hits{service:api}" \
-  --target 99.0
+pup slos create --file slo.json
 ```
 
 ## Common Queries
 
 | Goal | Query |
 |------|-------|
-| Slowest endpoints | `avg:trace.http.request.duration{*} by {resource_name}` |
-| Error rate | `sum:trace.http.request.errors{*} / sum:trace.http.request.hits{*}` |
-| Throughput | `sum:trace.http.request.hits{*}.as_rate()` |
+| Slowest endpoints | `pup traces aggregate --query="service:api" --compute="avg(@duration)" --group-by="resource_name" --from="1h"` |
+| Error rate by service | `pup traces aggregate --query="status:error" --compute="count" --group-by="service" --from="1h"` |
+| Throughput | `pup traces aggregate --query="service:api" --compute="count" --group-by="resource_name" --from="1h"` |
 
 ## Troubleshooting
 
@@ -138,6 +170,7 @@ pup slos create \
 | Missing service | Verify DD_SERVICE env var |
 | Traces not linked | Check trace headers propagated |
 | High cardinality | Don't tag with user_id/request_id |
+| `--env` required error | Always pass `--env` to `apm services` commands |
 
 ## References/Docs
 

--- a/skills/dd-pup/SKILL.md
+++ b/skills/dd-pup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dd-pup
-description: Datadog CLI (Go). OAuth2 auth with token refresh.
+description: Datadog CLI (pup). OAuth2 auth with token refresh.
 metadata:
   version: "1.0.0"
   author: datadog-labs
@@ -17,26 +17,25 @@ Pup CLI for Datadog API operations. Supports OAuth2 and API key auth.
 
 | Task | Command |
 |------|---------|
-| Search error logs | `pup logs search --query "status:error" --duration 1h` |
+| Search error logs | `pup logs search --query "status:error" --from 1h` |
 | List monitors | `pup monitors list` |
-| Mute a monitor | `pup monitors mute --id 123 --duration 1h` |
-| Find slow traces | `pup apm traces list --service api --min-duration 500ms` |
-| List active incidents | `pup incidents list --status active` |
-| Create incident | `pup incidents create --title "Issue" --severity SEV-2` |
+| Create downtime | `pup downtime create --file downtime.json` |
+| Find slow traces | `pup traces search --query="@duration:>500000000" --from="1h"` |
+| List incidents | `pup incidents list` |
 | Query metrics | `pup metrics query --query "avg:system.cpu.user{*}"` |
-| List hosts | `pup hosts list` |
+| List hosts | `pup infrastructure hosts list` |
 | Check SLOs | `pup slos list` |
-| Who's on call | `pup on-call who --team my-team` |
-| Security signals | `pup security signals list --severity critical` |
+| On-call teams | `pup on-call teams list` |
+| Security signals | `pup security signals list --from 24h` |
 | Check auth | `pup auth status` |
 | Refresh token | `pup auth refresh` |
 
 ## Prerequisites
 
 ```bash
-# Install pup
-go install github.com/datadog-labs/pup@latest
-export PATH="$HOME/go/bin:$PATH"
+# Install pup via Homebrew (recommended)
+brew tap datadog-labs/pack
+brew install pup
 ```
 
 ## Auth
@@ -70,126 +69,128 @@ export DD_SITE=datadoghq.com    # or datadoghq.eu, etc.
 ```bash
 pup monitors list --limit 10
 pup monitors list --tags "env:prod"
-pup monitors get --id 12345
-pup monitors mute --id 12345 --duration 1h
-pup monitors unmute --id 12345
-pup monitors create --name "High CPU" --type "metric alert" \
-  --query "avg(last_5m):avg:system.cpu.user{*} > 80" \
-  --message "CPU high @slack-ops"
+pup monitors get 12345
+pup monitors search --query "High CPU"
+pup monitors create --file monitor.json
+pup monitors update 12345 --file monitor.json
+pup monitors delete 12345
 ```
 
 ### Logs
 ```bash
-pup logs search --query "status:error" --duration 1h
-pup logs search --query "service:payment-api" --duration 1h --limit 100
-pup logs search --query "@http.status_code:5*" --duration 24h
-pup logs search --query "env:prod level:error" --duration 1h --json
+pup logs search --query "status:error" --from 1h
+pup logs search --query "service:payment-api" --from 1h --limit 100
+pup logs search --query "@http.status_code:5*" --from 24h
+pup logs aggregate --query "service:api" --compute count --from 1h
 ```
 
 ### Metrics
 ```bash
-pup metrics query --query "avg:system.cpu.user{*}" --duration 1h
-pup metrics query --query "sum:trace.express.request.hits{service:api}" --duration 1h
+pup metrics query --query "avg:system.cpu.user{*}" --from 1h
+pup metrics query --query "sum:trace.express.request.hits{service:api}" --from 1h
 pup metrics list --filter "system.*"
 ```
 
-### APM / Traces
+### APM / Services
 ```bash
-pup apm services list
-pup apm traces list --service my-service --duration 1h
-pup apm traces list --service api --min-duration 500ms --duration 1h
-pup apm traces list --service api --status error --duration 1h
-pup apm traces get abc123def456
+pup apm services list --env production
+pup apm services stats --env production
+pup apm services operations --env production --service my-service
+pup apm services resources --env production --service my-service --operation http.request
+pup apm dependencies list --env production
+```
+
+### Traces
+```bash
+# Search traces (duration in nanoseconds: 1s = 1000000000)
+pup traces search --query="service:api-gateway" --from="1h"
+pup traces search --query="service:api @duration:>1000000000" --from="1h"
+pup traces search --query="service:api status:error" --from="1h"
+pup traces aggregate --query="service:api" --compute="avg(@duration)" --group-by="resource_name" --from="1h"
 ```
 
 ### Incidents
 ```bash
-pup incidents list --status active
-pup incidents list --status resolved --duration 7d
-pup incidents create --title "API Degradation" --severity SEV-2
-pup incidents update --id abc-123 --status stable
-pup incidents resolve --id abc-123
+pup incidents list
+pup incidents list --limit 20
+pup incidents get <incident-id>
 ```
 
 ### Dashboards
 ```bash
 pup dashboards list
-pup dashboards list --tags "team:platform"
-pup dashboards get --id abc-123
-pup dashboards create --title "My Dashboard" --description "..." --widgets '[...]'
+pup dashboards get abc-123
+pup dashboards create --file dashboard.json
+pup dashboards update abc-123 --file dashboard.json
+pup dashboards delete abc-123
 ```
 
 ### SLOs
 ```bash
 pup slos list
-pup slos get --id slo-123
-pup slos history --id slo-123 --duration 30d
+pup slos get slo-123
+pup slos status slo-123 --from 30d --to now
+pup slos create --file slo.json
 ```
 
 ### Synthetics
 ```bash
-pup synthetics list
-pup synthetics results --test-id abc-123
-pup synthetics trigger --test-id abc-123
-```
-
-### On-Call
-```bash
-pup on-call teams list
-pup on-call schedules list
-pup on-call who --team platform-team
-```
-
-### Hosts / Infrastructure
-```bash
-pup hosts list --limit 50
-pup hosts list --filter "env:prod"
-pup hosts mute --hostname web-01 --duration 1h
-pup hosts get --hostname web-01
-```
-
-### Events
-```bash
-pup events list --duration 24h
-pup events list --tags "source:deploy"
-pup events post --title "Deploy started" --text "v1.2.3" --tags "env:prod"
+pup synthetics tests list
+pup synthetics tests get abc-123
+pup synthetics tests search --text "login"
+pup synthetics locations list
 ```
 
 ### Downtimes
 ```bash
 pup downtime list
-pup downtime create --scope "env:staging" --duration 2h --message "Maintenance"
-pup downtime cancel --id 12345
+pup downtime get abc-123-def
+pup downtime create --file downtime.json
+pup downtime cancel abc-123-def
+```
+
+### Infrastructure / Hosts
+```bash
+pup infrastructure hosts list
+pup infrastructure hosts list --filter "env:prod"
+pup infrastructure hosts list --count
+pup infrastructure hosts get <host-id>
+```
+
+### Events
+```bash
+pup events list --from 24h
+pup events list --tags "source:deploy" --from 24h
+pup events search --query "deploy" --from 24h
+pup events get <event-id>
 ```
 
 ### Users / Teams
 ```bash
 pup users list
-pup teams list
+pup users get <user-id>
+pup on-call teams list
+pup on-call teams get <team-id>
 ```
 
 ### Security
 ```bash
-pup security signals list --duration 24h
-pup security signals list --severity critical
+pup security signals list --from 24h
+pup security signals list --query "severity:critical" --from 24h
+pup security rules list
 ```
 
 ### Service Catalog
 ```bash
-pup services list
-pup services get --name payment-api
+pup service-catalog list
+pup service-catalog get <service-name>
 ```
 
 ### Notebooks
 ```bash
 pup notebooks list
-pup notebooks get --id 12345
-```
-
-### Workflows
-```bash
-pup workflows list
-pup workflows trigger --id workflow-123 --input '{"key": "value"}'
+pup notebooks get 12345
+pup notebooks create --file notebook.json
 ```
 
 ## Subcommand Discovery
@@ -211,79 +212,19 @@ pup <command> --help    # Command-specific help
 ## Install
 
 ```bash
-go install github.com/DataDog/pup@latest
+# Homebrew (recommended)
+brew tap datadog-labs/pack
+brew install pup
+
+# Or build from source
+cargo install --git https://github.com/datadog-labs/pup
 ```
 
 ### Verify Installation
 
 ```bash
-# Check if pup is in PATH
-which pup
-
-# If not found, check if it was installed
-ls ~/go/bin/pup
-```
-
-### PATH Troubleshooting
-
-If `pup` is installed but `which pup` returns nothing, Go's bin directory isn't in your PATH.
-
-**Check where pup is:**
-```bash
-ls ~/go/bin/pup           # Standard location
-ls $GOPATH/bin/pup        # If GOPATH is set
-ls $GOBIN/pup             # If GOBIN is set
-```
-
-**Add to PATH (pick your shell):**
-
-For **zsh** (macOS default):
-```bash
-# Add this line to ~/.zshrc
-export PATH="$HOME/go/bin:$PATH"
-
-# Then reload
-source ~/.zshrc
-```
-
-For **bash**:
-```bash
-# Add this line to ~/.bashrc or ~/.bash_profile
-export PATH="$HOME/go/bin:$PATH"
-
-# Then reload
-source ~/.bashrc
-```
-
-For **fish**:
-```fish
-# Add this line to ~/.config/fish/config.fish
-fish_add_path $HOME/go/bin
-
-# Or set permanently
-set -Ux fish_user_paths $HOME/go/bin $fish_user_paths
-
-# Then reload
-source ~/.config/fish/config.fish
-```
-
-**Verify:**
-```bash
-which pup        # Should show path
-pup --version    # Should show version
-```
-
-### Alternative: Full Path
-
-If you don't want to modify PATH, use the full path:
-```bash
-~/go/bin/pup auth login
-~/go/bin/pup monitors list
-```
-
-Or create an alias:
-```bash
-alias pup="$HOME/go/bin/pup"
+pup --version
+pup auth status
 ```
 
 ## Sites


### PR DESCRIPTION
## Summary

Fixes broken pup commands in the built-in agent skills (`pup skills install`). Multiple skill files referenced subcommands, flags, and argument patterns that don't exist in v0.26.0, causing AI agents to generate invalid CLI invocations.

## Changes

**`skills/dd-pup/SKILL.md`** — comprehensive audit and fix:
- `pup monitors get --id N` → `pup monitors get N` (positional arg)
- `pup dashboards get --id X` → `pup dashboards get X` (positional arg)
- `pup slos get --id X` → `pup slos get X` (positional arg)
- `pup slos history --id X --duration 30d` → `pup slos status X --from 30d --to now`
- `pup apm traces list` (non-existent subcommand) → `pup traces search`
- `pup incidents list --status active` → `pup incidents list` (no `--status` flag)
- Removed non-existent `pup incidents create/update/resolve`
- `pup monitors mute/unmute` (non-existent) → `pup downtime create/cancel`
- `pup hosts *` → `pup infrastructure hosts *`
- `pup services list/get` → `pup service-catalog list/get`
- `pup apm services list` → added required `--env production`
- `pup events post` (non-existent) → `pup events list/search`
- `pup downtime create --scope --duration --message` → `--file`
- `pup security signals list --duration` → `--from`
- Install instructions: `go install` → Homebrew

**`skills/dd-apm/SKILL.md`**:
- All `pup apm services list` examples now include required `--env`
- Removed non-existent `pup apm services get`
- `pup apm service-map` → `pup apm flow-map --query ... --env ...`
- `pup apm traces list/get` → `pup traces search/aggregate`
- Removed `pup apm retention-filters list` (non-existent)
- Install instructions: `go install` → Homebrew

**`agents/error-tracking.md`**:
- All `pup errors *` → `pup error-tracking issues *`
- Removed non-existent `pup errors update-state/assign/unassign`
- Fixed `--order-by` values to match CLI enum (TOTAL_COUNT, FIRST_SEEN)
- Removed unsupported flags (`--track`, `--include`, `--order-direction`)

## Testing

- `cargo test` — 364 tests pass
- All corrected commands verified against `pup <cmd> --help` JSON output

Closes #157

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)