### PR TITLE
fix(cases): pass query filter to search API

### DIFF
--- a/src/commands/cases.rs
+++ b/src/commands/cases.rs
@@ -38,9 +38,12 @@ fn make_api(cfg: &Config) -> CaseManagementAPI {
 // ---------------------------------------------------------------------------
 
 #[cfg(not(target_arch = "wasm32"))]
-pub async fn search(cfg: &Config, _query: Option<String>, page_size: i64) -> Result<()> {
+pub async fn search(cfg: &Config, query: Option<String>, page_size: i64) -> Result<()> {
     let api = make_api(cfg);
-    let params = SearchCasesOptionalParams::default().page_size(page_size);
+    let mut params = SearchCasesOptionalParams::default().page_size(page_size);
+    if let Some(q) = query {
+        params = params.filter(q);
+    }
     let resp = api
         .search_cases(params)
         .await
@@ -49,8 +52,11 @@ pub async fn search(cfg: &Config, _query: Option<String>, page_size: i64) -> Res
 }
 
 #[cfg(target_arch = "wasm32")]
-pub async fn search(cfg: &Config, _query: Option<String>, page_size: i64) -> Result<()> {
-    let q = vec![("page[size]", page_size.to_string())];
+pub async fn search(cfg: &Config, query: Option<String>, page_size: i64) -> Result<()> {
+    let mut q = vec![("page[size]", page_size.to_string())];
+    if let Some(filter) = query {
+        q.push(("filter[query]", filter));
+    }
     let data = crate::api::get(cfg, "/api/v2/cases", &q).await?;
     crate::formatter::output(cfg, &data)
 }


### PR DESCRIPTION
## Summary
The `--query` flag for `pup cases search` was silently ignored, causing all searches to
return unfiltered results. This fix passes the filter string to the API client.

## Changes
- Fix `_query` parameter being ignored in `search()` (src/commands/cases.rs:41)
- Pass filter string via `SearchCasesOptionalParams::filter()` for native build
- Pass filter string via `filter[query]` query param for wasm32 build

## Testing
- Manual test: `pup cases search --query “status:in_progress"` returns filtered results
- Manual test: invalid filter values correctly surface API error messages
- All existing tests pass (`cargo test`)

## Related Issues
Closes #162

---
Generated with [Claude Code](https://claude.com/claude-code)