### PR TITLE
chore(release): bump version to v0.28.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "pup"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pup"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 rust-version = "1.93.1"
 publish = false


### PR DESCRIPTION
## Summary
Release v0.28.0: version bump from v0.27.0 to v0.28.0.

## Changes
- Update `Cargo.toml` package version 0.27.0 → 0.28.0
- Refresh `Cargo.lock`

## Testing
- CI will run `cargo test`, `cargo clippy`, and `cargo fmt --check`
- Cross-compilation verified for all 4 targets

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)