### PR TITLE
feat: support `FORCE_AGENT_MODE=0` to force-disable agent mode

### DIFF
--- a/src/useragent.rs
+++ b/src/useragent.rs
@@ -87,7 +87,17 @@ pub fn detect_agent_info() -> AgentInfo {
     }
 }
 
+fn is_env_falsy(key: &str) -> bool {
+    match std::env::var(key) {
+        Ok(val) => matches!(val.to_lowercase().as_str(), "0" | "false"),
+        Err(_) => false,
+    }
+}
+
 pub fn is_agent_mode() -> bool {
+    if is_env_falsy("FORCE_AGENT_MODE") {
+        return false;
+    }
     is_env_truthy("FORCE_AGENT_MODE") || detect_agent_info().detected
 }
 
@@ -187,6 +197,15 @@ mod tests {
         std::env::set_var("FORCE_AGENT_MODE", "1");
         assert!(is_agent_mode());
         std::env::remove_var("FORCE_AGENT_MODE");
+    }
+
+    #[test]
+    fn test_is_agent_mode_force_disable() {
+        std::env::set_var("CLAUDE_CODE", "1");
+        std::env::set_var("FORCE_AGENT_MODE", "0");
+        assert!(!is_agent_mode());
+        std::env::remove_var("FORCE_AGENT_MODE");
+        std::env::remove_var("CLAUDE_CODE");
     }
 
     #[test]


### PR DESCRIPTION
## What does this PR do?

Adds support for `FORCE_AGENT_MODE=0` (or `false`) to explicitly disable agent mode, even when agent environment variables are detected.

## Motivation

Previously `FORCE_AGENT_MODE` only supported `=1` to force-enable agent mode. This adds the symmetric `=0` case, useful when running pup inside an AI agent environment but wanting to suppress agent-mode behavior.

## Additional Notes

The check is evaluated before any detector runs, so `FORCE_AGENT_MODE=0` takes full precedence.

## Checklist

- [x] The code change follows the project conventions (see [CONTRIBUTING.md](../docs/CONTRIBUTING.md))
- [x] Tests have been added/updated (if applicable)
- [ ] Documentation has been updated (if applicable)
- [ ] All CI checks pass
- [x] Code coverage is maintained or improved

## Related Issues

<!-- Link related issues here. Use "Closes #123" to automatically close issues when the PR is merged. -->