### PR TITLE
fix(synthetics): add pagination to tests list, fix tests search params

### DIFF
--- a/src/commands/synthetics.rs
+++ b/src/commands/synthetics.rs
@@ -19,22 +19,30 @@ use crate::config::Config;
 use crate::formatter;
 
 #[cfg(not(target_arch = "wasm32"))]
-pub async fn tests_list(cfg: &Config) -> Result<()> {
+pub async fn tests_list(cfg: &Config, page_size: i64, page_number: i64) -> Result<()> {
     let dd_cfg = client::make_dd_config(cfg);
     let api = match client::make_bearer_client(cfg) {
         Some(c) => SyntheticsAPI::with_client_and_config(dd_cfg, c),
         None => SyntheticsAPI::with_config(dd_cfg),
     };
     let resp = api
-        .list_tests(ListTestsOptionalParams::default())
+        .list_tests(
+            ListTestsOptionalParams::default()
+                .page_size(page_size)
+                .page_number(page_number),
+        )
         .await
         .map_err(|e| anyhow::anyhow!("failed to list tests: {e:?}"))?;
     formatter::output(cfg, &resp)
 }
 
 #[cfg(target_arch = "wasm32")]
-pub async fn tests_list(cfg: &Config) -> Result<()> {
-    let data = crate::api::get(cfg, "/api/v1/synthetics/tests", &[]).await?;
+pub async fn tests_list(cfg: &Config, page_size: i64, page_number: i64) -> Result<()> {
+    let query = [
+        ("page_size", page_size.to_string()),
+        ("page_number", page_number.to_string()),
+    ];
+    let data = crate::api::get(cfg, "/api/v1/synthetics/tests", &query).await?;
     crate::formatter::output(cfg, &data)
 }
 
@@ -63,8 +71,11 @@ pub async fn tests_get(cfg: &Config, public_id: &str) -> Result<()> {
 pub async fn tests_search(
     cfg: &Config,
     text: Option<String>,
+    facets_only: bool,
+    include_full_config: bool,
     count: i64,
     start: i64,
+    sort: Option<String>,
 ) -> Result<()> {
     let dd_cfg = client::make_dd_config(cfg);
     let api = match client::make_bearer_client(cfg) {
@@ -76,11 +87,20 @@ pub async fn tests_search(
     if let Some(t) = text {
         params = params.text(t);
     }
+    if facets_only {
+        params = params.facets_only(true);
+    }
+    if include_full_config {
+        params = params.include_full_config(true);
+    }
     if count != 50 {
         params = params.count(count);
     }
     if start != 0 {
         params = params.start(start);
+    }
+    if let Some(s) = sort {
+        params = params.sort(s);
     }
 
     let resp = api
@@ -94,18 +114,30 @@ pub async fn tests_search(
 pub async fn tests_search(
     cfg: &Config,
     text: Option<String>,
+    facets_only: bool,
+    include_full_config: bool,
     count: i64,
     start: i64,
+    sort: Option<String>,
 ) -> Result<()> {
     let mut query: Vec<(&str, String)> = Vec::new();
     if let Some(t) = text {
         query.push(("text", t));
+    }
+    if facets_only {
+        query.push(("facets_only", "true".to_string()));
+    }
+    if include_full_config {
+        query.push(("include_full_config", "true".to_string()));
     }
     if count != 50 {
         query.push(("count", count.to_string()));
     }
     if start != 0 {
         query.push(("start", start.to_string()));
+    }
+    if let Some(s) = sort {
+        query.push(("sort", s));
     }
     let data = crate::api::get(cfg, "/api/v1/synthetics/tests/search", &query).await?;
     crate::formatter::output(cfg, &data)

--- a/src/main.rs
+++ b/src/main.rs
@@ -2288,12 +2288,10 @@ enum SyntheticsActions {
 enum SyntheticsTestActions {
     /// List synthetic tests
     List {
-        #[arg(long, help = "Return only facets (no test results)")]
-        facets_only: bool,
-        #[arg(long, help = "Include full test configuration in results")]
-        include_full_config: bool,
-        #[arg(long, help = "Sort order")]
-        sort: Option<String>,
+        #[arg(long, default_value_t = 10, help = "Results per page")]
+        page_size: i64,
+        #[arg(long, default_value_t = 0, help = "Page number")]
+        page_number: i64,
     },
     /// Get test details
     Get { public_id: String },
@@ -2301,10 +2299,24 @@ enum SyntheticsTestActions {
     Search {
         #[arg(long, help = "Search text query")]
         text: Option<String>,
-        #[arg(long, default_value_t = 50)]
+        #[arg(long, help = "Return only facets (no test results)")]
+        facets_only: bool,
+        #[arg(long, help = "Include full test configuration in results")]
+        include_full_config: bool,
+        #[arg(
+            long,
+            default_value_t = 50,
+            help = "Maximum number of results to return"
+        )]
         count: i64,
-        #[arg(long, default_value_t = 0)]
+        #[arg(
+            long,
+            default_value_t = 0,
+            help = "Offset from which to start returning results"
+        )]
         start: i64,
+        #[arg(long, help = "Sort order")]
+        sort: Option<String>,
     },
 }
 
@@ -5673,14 +5685,31 @@ async fn main_inner() -> anyhow::Result<()> {
             cfg.validate_auth()?;
             match action {
                 SyntheticsActions::Tests { action } => match action {
-                    SyntheticsTestActions::List { .. } => {
-                        commands::synthetics::tests_list(&cfg).await?
-                    }
+                    SyntheticsTestActions::List {
+                        page_size,
+                        page_number,
+                    } => commands::synthetics::tests_list(&cfg, page_size, page_number).await?,
                     SyntheticsTestActions::Get { public_id } => {
                         commands::synthetics::tests_get(&cfg, &public_id).await?;
                     }
-                    SyntheticsTestActions::Search { text, count, start } => {
-                        commands::synthetics::tests_search(&cfg, text, count, start).await?;
+                    SyntheticsTestActions::Search {
+                        text,
+                        facets_only,
+                        include_full_config,
+                        count,
+                        start,
+                        sort,
+                    } => {
+                        commands::synthetics::tests_search(
+                            &cfg,
+                            text,
+                            facets_only,
+                            include_full_config,
+                            count,
+                            start,
+                            sort,
+                        )
+                        .await?;
                     }
                 },
                 SyntheticsActions::Locations { action } => match action {

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -1516,7 +1516,7 @@ async fn test_synthetics_tests_list() {
     let mut s = mockito::Server::new_async().await;
     let cfg = test_config(&s.url());
     mock_all(&mut s, r#"{"tests": []}"#).await;
-    let _ = crate::commands::synthetics::tests_list(&cfg).await;
+    let _ = crate::commands::synthetics::tests_list(&cfg, 10, 0).await;
     cleanup_env();
 }
 #[tokio::test]


### PR DESCRIPTION
## What does this PR do?

Fix `synthetics tests list` to support pagination via `--page-size` and `--page-number`. Fix `synthetics tests search` to expose `--facets-only`, `--include-full-config`, and `--sort` params that were previously missing.

## Motivation

The `synthetics tests list` command had no pagination support. The `--facets-only` flag on `tests list` was wired to the wrong endpoint (list instead of search) and did nothing. Moving search-specific params to the `search` subcommand and adding proper pagination to `list` fixes both issues.

## Additional Notes

- `tests list` uses the `list_tests` (v1) endpoint with `page_size`/`page_number`
- `tests search` uses the `search_tests` (v1) endpoint with `text`, `facets_only`, `include_full_config`, `count`, `start`, `sort`

## Checklist

- [x] The code change follows the project conventions (see [CONTRIBUTING.md](../docs/CONTRIBUTING.md))
- [x] Tests have been added/updated (if applicable)
- [x] All CI checks pass

## Related Issues

<!-- Link related issues here. Use "Closes #123" to automatically close issues when the PR is merged. -->