### PR TITLE
fix(formatter): respect -o flag in agent mode

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -58,7 +58,7 @@ pub fn format_and_print<T: Serialize>(
     agent_mode: bool,
     meta: Option<&Metadata>,
 ) -> Result<()> {
-    if agent_mode {
+    if agent_mode && *format == OutputFormat::Json {
         let sorted_data = sort_json_value(serde_json::to_value(data)?);
         // Hoist: when the API wraps its list/object in a nested "data" key,
         // use that inner value directly so agents see .data[*] instead of .data.data[*].
@@ -665,6 +665,22 @@ mod tests {
     fn test_format_and_print_agent_mode_no_meta() {
         let data = serde_json::json!({"name": "test"});
         let result = format_and_print(&data, &OutputFormat::Json, true, None);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_format_and_print_agent_mode_respects_yaml_flag() {
+        // In agent mode, -o yaml should bypass the agent envelope and use YAML output.
+        let data = serde_json::json!({"name": "test"});
+        let result = format_and_print(&data, &OutputFormat::Yaml, true, None);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_format_and_print_agent_mode_respects_table_flag() {
+        // In agent mode, -o table should bypass the agent envelope and use table output.
+        let data = serde_json::json!([{"id": 1, "name": "test"}]);
+        let result = format_and_print(&data, &OutputFormat::Table, true, None);
         assert!(result.is_ok());
     }
 


### PR DESCRIPTION
## Summary

When pup runs in agent mode, the `-o yaml` and `-o table` flags were silently ignored — the agent envelope JSON was always emitted regardless. Now the agent envelope is only used when the output format is the default JSON, so explicit `-o` flags are always honoured.

## Changes

- `src/formatter.rs:61` — guard the agent-envelope path with `&& *format == OutputFormat::Json`
- `src/formatter.rs:668-681` — two new unit tests: agent mode + yaml, agent mode + table

## Testing

- `cargo test`: 375 tests pass (2 new tests added)
- `cargo clippy -- -D warnings`: clean

## Related Issues

Closes #170

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)