### PR TITLE
fix(auth): restore automatic OAuth token refresh lost in Rust rewrite

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -299,12 +299,14 @@ pub fn load_token_from_storage(site: &str, org: Option<&str>) -> Option<String> 
     }
 }
 
+#[cfg(all(not(feature = "browser"), not(target_arch = "wasm32")))]
 enum ResolvedToken {
     Valid(String),
     Refreshed(crate::auth::types::TokenSet),
     Expired,
 }
 
+#[cfg(all(not(feature = "browser"), not(target_arch = "wasm32")))]
 fn resolve_token<F>(
     tokens: crate::auth::types::TokenSet,
     creds: Option<&crate::auth::types::ClientCredentials>,


### PR DESCRIPTION
## What does this PR do?

Restores automatic OAuth token refresh in `load_token_from_storage()` (`src/config.rs`). When a stored access token is expired (or within the 5-minute safety buffer), the function now attempts to refresh it using the stored refresh token and client credentials before falling back to other auth methods.

## Motivation

Automatic token refresh was implemented in the Go codebase via #68 but was not ported during the Go→Rust rewrite in #103. This caused users to encounter auth failures after token expiry, requiring manual `pup auth refresh` or `pup auth login` — contradicting the documented behavior of "automatic token refresh."

## Additional Notes

- Extracted `resolve_token()` helper to separate decision logic from I/O, enabling unit testing via closure injection.
- The refresh runs via `tokio::task::block_in_place` + `Handle::block_on`, safe in the multi-thread tokio runtime used for native builds.
- The storage mutex is released before the network call and re-acquired to save new tokens.
- On any failure (no refresh token, no client credentials, network error), returns `None` silently, allowing fallback to API key auth.
- 6 unit tests cover all refresh paths: valid token, expired with no refresh token, expired with no client creds, refresh failure, refresh success, and near-expiry trigger.

## Checklist

- [x] The code change follows the project conventions (see [CONTRIBUTING.md](../docs/CONTRIBUTING.md))
- [x] Tests have been added/updated (if applicable)
- [ ] Documentation has been updated (if applicable)
- [ ] All CI checks pass
- [ ] Code coverage is maintained or improved

## Related Issues

Regression from #103 (Go→Rust rewrite). Restores behavior originally added in #68.