### PR TITLE
chore(release): bump version to v0.29.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "pup"
-version = "0.29.1"
+version = "0.29.2"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pup"
-version = "0.29.1"
+version = "0.29.2"
 edition = "2021"
 rust-version = "1.93.1"
 publish = false


### PR DESCRIPTION
## Summary
Release v0.29.2: version bump from v0.29.1 to v0.29.2.

## Changes
- Update `Cargo.toml` package version 0.29.1 → 0.29.2
- Refresh `Cargo.lock`

## Testing
- CI will run `cargo test`, `cargo clippy`, and `cargo fmt --check`
- Cross-compilation verified for all 4 targets

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)