### PR TITLE
feat(formatter): add TSV output format

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,7 @@ pub enum OutputFormat {
     Table,
     Yaml,
     Csv,
+    Tsv,
 }
 
 impl std::fmt::Display for OutputFormat {
@@ -33,6 +34,7 @@ impl std::fmt::Display for OutputFormat {
             OutputFormat::Table => write!(f, "table"),
             OutputFormat::Yaml => write!(f, "yaml"),
             OutputFormat::Csv => write!(f, "csv"),
+            OutputFormat::Tsv => write!(f, "tsv"),
         }
     }
 }
@@ -45,7 +47,8 @@ impl std::str::FromStr for OutputFormat {
             "table" => Ok(OutputFormat::Table),
             "yaml" => Ok(OutputFormat::Yaml),
             "csv" => Ok(OutputFormat::Csv),
-            _ => bail!("invalid output format: {s:?} (expected json, table, yaml, or csv)"),
+            "tsv" => Ok(OutputFormat::Tsv),
+            _ => bail!("invalid output format: {s:?} (expected json, table, yaml, csv, or tsv)"),
         }
     }
 }
@@ -386,6 +389,8 @@ mod tests {
         assert_eq!("yaml".parse::<OutputFormat>().unwrap(), OutputFormat::Yaml);
         assert_eq!("csv".parse::<OutputFormat>().unwrap(), OutputFormat::Csv);
         assert_eq!("CSV".parse::<OutputFormat>().unwrap(), OutputFormat::Csv);
+        assert_eq!("tsv".parse::<OutputFormat>().unwrap(), OutputFormat::Tsv);
+        assert_eq!("TSV".parse::<OutputFormat>().unwrap(), OutputFormat::Tsv);
         assert!("xml".parse::<OutputFormat>().is_err());
     }
 
@@ -395,6 +400,7 @@ mod tests {
         assert_eq!(OutputFormat::Table.to_string(), "table");
         assert_eq!(OutputFormat::Yaml.to_string(), "yaml");
         assert_eq!(OutputFormat::Csv.to_string(), "csv");
+        assert_eq!(OutputFormat::Tsv.to_string(), "tsv");
     }
 
     #[test]

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -81,6 +81,7 @@ pub fn format_and_print<T: Serialize>(
         OutputFormat::Yaml => print_yaml(data),
         OutputFormat::Table => print_table(data),
         OutputFormat::Csv => print_csv(data),
+        OutputFormat::Tsv => print_tsv(data),
     }
 }
 
@@ -302,6 +303,65 @@ fn print_csv<T: Serialize>(data: &T) -> Result<()> {
             .map(|h| csv_escape(&csv_cell(row.get(h.as_str()))))
             .collect::<Vec<_>>()
             .join(",");
+        println!("{line}");
+    }
+
+    Ok(())
+}
+
+/// Escape a single TSV field: literal tab characters in values are replaced with \t.
+/// No quoting is applied.
+fn tsv_escape(s: &str) -> String {
+    s.replace('\t', "\\t")
+}
+
+fn print_tsv<T: Serialize>(data: &T) -> Result<()> {
+    let value = serde_json::to_value(data)?;
+    let raw_rows = extract_rows(&value);
+
+    if raw_rows.is_empty() {
+        return Ok(());
+    }
+
+    // Deep-flatten every row so all nested sub-fields become columns.
+    let flat_rows: Vec<serde_json::Map<String, serde_json::Value>> = raw_rows
+        .iter()
+        .map(|r| {
+            let mut out = serde_json::Map::new();
+            flatten_deep(r, "", &mut out);
+            out
+        })
+        .collect();
+
+    // Collect all headers, preserving first-seen insertion order.
+    let mut header_set = std::collections::HashSet::new();
+    let mut headers: Vec<String> = Vec::new();
+    for row in &flat_rows {
+        for key in row.keys() {
+            if header_set.insert(key.clone()) {
+                headers.push(key.clone());
+            }
+        }
+    }
+    headers.sort();
+
+    // Print header row.
+    println!(
+        "{}",
+        headers
+            .iter()
+            .map(|h| tsv_escape(h))
+            .collect::<Vec<_>>()
+            .join("\t")
+    );
+
+    // Print data rows.
+    for row in &flat_rows {
+        let line = headers
+            .iter()
+            .map(|h| tsv_escape(&csv_cell(row.get(h.as_str()))))
+            .collect::<Vec<_>>()
+            .join("\t");
         println!("{line}");
     }
 
@@ -949,5 +1009,47 @@ mod tests {
         }
         let data = serde_json::json!([obj]);
         assert!(print_table(&data).is_ok());
+    }
+
+    #[test]
+    fn test_tsv_escape_plain() {
+        assert_eq!(tsv_escape("hello"), "hello");
+    }
+
+    #[test]
+    fn test_tsv_escape_with_tab() {
+        // Tab characters in values should be replaced with literal \t
+        assert_eq!(tsv_escape("a\tb"), "a\\tb");
+    }
+
+    #[test]
+    fn test_tsv_escape_no_quoting_for_comma() {
+        // Commas are not special in TSV — no quoting applied.
+        assert_eq!(tsv_escape("a,b"), "a,b");
+    }
+
+    #[test]
+    fn test_print_tsv_basic() {
+        let data = serde_json::json!([{"id": 1, "name": "test"}]);
+        assert!(print_tsv(&data).is_ok());
+    }
+
+    #[test]
+    fn test_print_tsv_empty() {
+        let data = serde_json::json!([]);
+        assert!(print_tsv(&data).is_ok());
+    }
+
+    #[test]
+    fn test_print_tsv_nested() {
+        let data = serde_json::json!([{"id": 1, "attrs": {"host": "web", "env": "prod"}}]);
+        assert!(print_tsv(&data).is_ok());
+    }
+
+    #[test]
+    fn test_format_and_print_tsv() {
+        let data = serde_json::json!([{"id": 1, "name": "test"}]);
+        let result = format_and_print(&data, &OutputFormat::Tsv, false, None);
+        assert!(result.is_ok());
     }
 }


### PR DESCRIPTION
## Summary

Adds `tsv` as a new output format alongside the existing `json`, `table`, `yaml`, and `csv` formats. TSV (tab-separated values) produces more compact, scannable output than CSV for agent consumption — no quoting overhead, tabs as delimiters, same deep-flatten logic as CSV.

## Changes

- `src/config.rs` — adds `Tsv` to `OutputFormat` enum with `"tsv"` parse/display
- `src/formatter.rs` — adds `tsv_escape()` (replaces literal tabs with `\t`), `print_tsv()` (same flatten pipeline as `print_csv` with tab delimiter), wires `OutputFormat::Tsv => print_tsv(data)` in `format_and_print`

## Usage

```bash
pup --output tsv logs search --query "status:error" --from 15m
pup --output tsv monitors list
pup --output tsv incidents list
```

## Testing

- 7 new unit tests: `tsv_escape` (plain, tab, comma), `print_tsv` (basic, empty, nested), `format_and_print` with Tsv format
- `cargo test` (all passing), `cargo clippy -- -D warnings` clean, `cargo fmt` applied

## Related

This is a companion to `feat/compact-agent-output` which adds token-budget compression for agent mode. A follow-up will apply the structural flatten step to TSV/CSV/YAML output in agent mode so `--output tsv` produces MCP-comparable compact output.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)