### PR TITLE
fix(incidents): default list to active incidents sorted by most recent

### DIFF
--- a/src/commands/incidents.rs
+++ b/src/commands/incidents.rs
@@ -3,11 +3,11 @@ use anyhow::{bail, Result};
 use datadog_api_client::datadogV2::api_incidents::{
     CreateGlobalIncidentHandleOptionalParams, GetIncidentOptionalParams,
     ImportIncidentOptionalParams, IncidentsAPI, ListGlobalIncidentHandlesOptionalParams,
-    ListIncidentAttachmentsOptionalParams, ListIncidentsOptionalParams,
+    ListIncidentAttachmentsOptionalParams, SearchIncidentsOptionalParams,
     UpdateGlobalIncidentHandleOptionalParams,
 };
 #[cfg(not(target_arch = "wasm32"))]
-use datadog_api_client::datadogV2::model::IncidentImportRequest;
+use datadog_api_client::datadogV2::model::{IncidentImportRequest, IncidentSearchSortOrder};
 
 #[cfg(not(target_arch = "wasm32"))]
 use crate::client;
@@ -35,9 +35,11 @@ fn make_api(cfg: &Config) -> IncidentsAPI {
 #[cfg(not(target_arch = "wasm32"))]
 pub async fn list(cfg: &Config, limit: i64) -> Result<()> {
     let api = make_api(cfg);
-    let params = ListIncidentsOptionalParams::default().page_size(limit);
+    let params = SearchIncidentsOptionalParams::default()
+        .page_size(limit)
+        .sort(IncidentSearchSortOrder::CREATED_DESCENDING);
     let resp = api
-        .list_incidents(params)
+        .search_incidents("state:active".to_string(), params)
         .await
         .map_err(|e| anyhow::anyhow!("failed to list incidents: {:?}", e))?;
     formatter::output(cfg, &resp)?;
@@ -46,8 +48,12 @@ pub async fn list(cfg: &Config, limit: i64) -> Result<()> {
 
 #[cfg(target_arch = "wasm32")]
 pub async fn list(cfg: &Config, limit: i64) -> Result<()> {
-    let query_params = vec![("page[size]", limit.to_string())];
-    let data = crate::api::get(cfg, "/api/v2/incidents", &query_params).await?;
+    let query_params = vec![
+        ("filter[query]", "state:active".to_string()),
+        ("sort", "-created".to_string()),
+        ("page[size]", limit.to_string()),
+    ];
+    let data = crate::api::get(cfg, "/api/v2/incidents/search", &query_params).await?;
     crate::formatter::output(cfg, &data)
 }
 


### PR DESCRIPTION
## Summary

Previously `pup incidents list` used `list_incidents` which returned all incidents (including resolved) in oldest-first order. This PR changes the default behavior to show only active incidents sorted by most recent creation, making the command immediately useful for on-call workflows.

## Changes

- `src/commands/incidents.rs`: Replace `list_incidents` + `ListIncidentsOptionalParams` with `search_incidents` + `SearchIncidentsOptionalParams`, passing `"state:active"` as the search query and `IncidentSearchSortOrder::CREATED_DESCENDING` as the sort order
- `src/commands/incidents.rs` (wasm32): Update the wasm32 path to use `/api/v2/incidents/search` with `filter[query]=state:active` and `sort=-created` query parameters instead of the plain list endpoint

## Before / After

**Before:** `pup incidents list` → all incidents, oldest-first (including resolved from months ago)

**After:** `pup incidents list` → active incidents only, newest-first (relevant to current on-call)

## Testing

- `cargo build` — compiles cleanly
- `cargo test` — 444 tests pass
- `cargo fmt` — no formatting changes
- `cargo clippy -- -D warnings` — no warnings

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)