### PR TITLE
feat(investigations): use unstable API for richer get response

### DIFF
--- a/src/commands/investigations.rs
+++ b/src/commands/investigations.rs
@@ -13,7 +13,7 @@ pub async fn list(cfg: &Config, page_limit: i64, page_offset: i64) -> Result<()>
 }
 
 pub async fn get(cfg: &Config, investigation_id: &str) -> Result<()> {
-    let path = format!("/api/v2/bits-ai/investigations/{investigation_id}");
+    let path = format!("/api/unstable/bits-ai/investigation/{investigation_id}");
     let data = client::raw_get(cfg, &path).await?;
     formatter::output(cfg, &data)
 }


### PR DESCRIPTION
## Summary
- Switch `investigations get` to use `/api/unstable/bits-ai/investigation/{id}` instead of `/api/v2/bits-ai/investigations/{id}`
- The unstable endpoint returns the full investigation payload including hypotheses, action results, investigation steps, remediations, and detailed conclusions with evidence
- The v2 endpoint only returns title, conclusion summary, and initial_findings (often null)

## Test plan
- [x] Manually tested `pup investigations get <id>` against a real investigation — returns full payload
- [x] Verify `list` and `trigger` still work (unchanged, still on v2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)