### PR TITLE
chore(workflows): enforce API+APP key auth for all workflow commands

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -68,6 +68,8 @@ pup <domain> <subgroup> <action> [options] # Nested commands
 
 **Note:** RUM command is fully operational. Apps and sessions work completely. Metrics and retention-filters support list/get operations (create/update/delete operations pending due to complex API type structures).
 
+**Auth note:** All workflow commands require `DD_API_KEY` + `DD_APP_KEY`. OAuth2 bearer tokens are not supported for workflow operations.
+
 ## Common Patterns
 
 ### List Operations

--- a/src/commands/workflows.rs
+++ b/src/commands/workflows.rs
@@ -13,16 +13,13 @@ use crate::formatter::{self, Metadata};
 use crate::util;
 
 // ---------------------------------------------------------------------------
-// Helper: build a WorkflowAutomationAPI with bearer-token support
+// Helper: build a WorkflowAutomationAPI (API key auth only)
 // ---------------------------------------------------------------------------
 
 #[cfg(not(target_arch = "wasm32"))]
 fn make_api(cfg: &Config) -> WorkflowAutomationAPI {
     let dd_cfg = client::make_dd_config(cfg);
-    match client::make_bearer_client(cfg) {
-        Some(c) => WorkflowAutomationAPI::with_client_and_config(dd_cfg, c),
-        None => WorkflowAutomationAPI::with_config(dd_cfg),
-    }
+    WorkflowAutomationAPI::with_config(dd_cfg)
 }
 
 // ---------------------------------------------------------------------------
@@ -113,8 +110,6 @@ pub async fn run(
     wait: bool,
     timeout: &str,
 ) -> Result<()> {
-    cfg.validate_api_and_app_keys()?;
-
     let dd_cfg = client::make_dd_config(cfg);
     let api = WorkflowAutomationAPI::with_config(dd_cfg);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1864,9 +1864,8 @@ enum Commands {
     ///   pup workflows instances cancel <workflow-id> <instance-id>
     ///
     /// AUTHENTICATION:
-    ///   Most commands accept either OAuth2 or API keys.
-    ///   The 'run' command requires DD_API_KEY + DD_APP_KEY (OAuth is not supported
-    ///   for API trigger execution).
+    ///   All workflow commands require DD_API_KEY + DD_APP_KEY.
+    ///   OAuth2 bearer tokens are not supported for workflow operations at this time.
     #[command(verbatim_doc_comment)]
     Workflows {
         #[command(subcommand)]
@@ -7421,7 +7420,13 @@ async fn main_inner() -> anyhow::Result<()> {
         },
         // --- Workflows ---
         Commands::Workflows { action } => {
-            cfg.validate_auth()?;
+            cfg.validate_api_and_app_keys().map_err(|_| {
+                anyhow::anyhow!(
+                    "workflow commands require DD_API_KEY and DD_APP_KEY with workflow_* scopes\n\
+                     OAuth2 bearer tokens are not supported for workflow operations.\n\
+                     See: https://docs.datadoghq.com/api/latest/workflow-automation"
+                )
+            })?;
             match action {
                 WorkflowActions::Get { workflow_id } => {
                     commands::workflows::get(&cfg, &workflow_id).await?;


### PR DESCRIPTION
## Summary
All workflow API endpoints require API+APP key auth — OAuth2 tokens get a confusing 403. Previously only the `run` subcommand enforced this; now all workflow commands fail fast with a clear message pointing to docs.

We will look to add support for other auth types in the future.

## Changes
- Enforce `validate_api_and_app_keys()` at workflow dispatch level in `main.rs` instead of per-command
- Custom error message with `workflow_*` scopes guidance and link to docs
- Remove redundant validation from `run()` — now handled at dispatch
- Simplify `make_api()` helper — no longer needs bearer client logic
- Update help text and COMMANDS.md with auth requirements

## Test plan
- [x] `cargo test` — 432 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] Verified OAuth-only → clear error with docs link
- [x] Verified API keys → all workflow commands succeed (get, instances list, instances get)

🤖 Generated with [Claude Code](https://claude.com/claude-code)