### PR TITLE
fix(auth): add --site flag to pup auth login

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -401,6 +401,7 @@ enum Commands {
     ///   pup auth logout
     ///
     ///   # Login to different Datadog site
+    ///   pup auth login --site datadoghq.eu
     ///   DD_SITE=datadoghq.eu pup auth login
     ///
     ///   # Login to a child org (multi-org support)
@@ -420,11 +421,13 @@ enum Commands {
     /// MULTI-SITE SUPPORT:
     ///   Each Datadog site maintains separate credentials:
     ///
-    ///   DD_SITE=datadoghq.com pup auth login     # US1 (default)
-    ///   DD_SITE=datadoghq.eu pup auth login      # EU1
-    ///   DD_SITE=us3.datadoghq.com pup auth login # US3
-    ///   DD_SITE=us5.datadoghq.com pup auth login # US5
-    ///   DD_SITE=ap1.datadoghq.com pup auth login # AP1
+    ///   pup auth login --site datadoghq.com     # US1 (default)
+    ///   pup auth login --site datadoghq.eu      # EU1
+    ///   pup auth login --site us3.datadoghq.com # US3
+    ///   pup auth login --site us5.datadoghq.com # US5
+    ///   pup auth login --site ap1.datadoghq.com # AP1
+    ///   DD_SITE=datadoghq.com pup auth login     # US1 (via env var)
+    ///   DD_SITE=datadoghq.eu pup auth login      # EU1 (via env var)
     ///
     /// MULTI-ORG SUPPORT:
     ///   Datadog parent/child sub-organizations each get their own session:
@@ -4988,6 +4991,10 @@ enum AuthActions {
         /// Shorthand: --ro
         #[arg(long, alias = "ro", visible_alias = "ro")]
         read_only: bool,
+        /// Datadog site to authenticate against (e.g. datadoghq.eu, us3.datadoghq.com).
+        /// Overrides DD_SITE env var and config file. Defaults to datadoghq.com.
+        #[arg(long, value_name = "SITE")]
+        site: Option<String>,
     },
     /// Logout and clear tokens
     Logout,
@@ -7410,7 +7417,14 @@ async fn main_inner() -> anyhow::Result<()> {
         }
         // --- Auth ---
         Commands::Auth { action } => match action {
-            AuthActions::Login { scopes, read_only } => {
+            AuthActions::Login {
+                scopes,
+                read_only,
+                site,
+            } => {
+                if let Some(s) = site {
+                    cfg.site = s;
+                }
                 let is_read_only = read_only || cfg.read_only;
                 let resolved =
                     resolve_login_scopes(scopes.as_deref(), cfg.org.as_deref(), is_read_only);


### PR DESCRIPTION
## Summary

Adds `--site <SITE>` flag to `pup auth login` so users can specify the Datadog site directly on the command line without setting `DD_SITE` in the environment. Fixes the `invalid_grant` error reported in #198, where EU-region users would open the browser on `datadoghq.com`, switch to `datadoghq.eu` in the UI, and get a token exchange failure because the OAuth callback was sent back to the wrong site's endpoint.

## Changes

- `src/main.rs:4990` — Added `--site <SITE>` flag to `AuthActions::Login`
- `src/main.rs:7413` — Applied site override to `cfg.site` before calling `auth::login()` when `--site` is provided
- Updated `auth` command docs to show `--site` as the preferred multi-site example

## Testing

- `cargo build` passes
- `cargo clippy -- -D warnings` passes
- `cargo test` — all 432 tests pass
- `pup auth login --help` (agent schema) confirms `--site` flag is present with correct description

## Related Issues

Closes #198

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)