### PR TITLE
fix(workflows): fix --wait flag polling wrong status field

### DIFF
--- a/src/commands/workflows.rs
+++ b/src/commands/workflows.rs
@@ -179,16 +179,21 @@ pub async fn run(
             .data
             .as_ref()
             .and_then(|d| d.attributes.as_ref())
-            .and_then(|a| a.additional_properties.get("status"))
+            .and_then(|a| a.additional_properties.get("instanceStatus"))
+            .and_then(|v| v.get("detailsKind"))
             .and_then(|v| v.as_str())
             .unwrap_or("");
 
+        eprintln!("  status: {state}");
+
+        // Treat any state other than the known in-progress states as terminal.
+        // This avoids polling forever if the API introduces new terminal states.
         match state {
-            "COMPLETED" | "FAILED" | "CANCELED" | "CANCELLED" | "ERROR" => {
+            "" | "IN_PROGRESS" => continue,
+            _ => {
                 formatter::output(cfg, &status)?;
                 return Ok(());
             }
-            _ => continue,
         }
     }
 }


### PR DESCRIPTION
The --wait flag on `workflows run` was polling forever because it read the instance status from the wrong JSON path. Flipped the terminal-state logic to treat IN_PROGRESS as the only non-terminal state, so new terminal states from the API won't cause infinite polling.

- Fix: read status from `instanceStatus.detailsKind` instead of `status`
- Fix: match on in-progress states (continue) vs terminal (return)
