### PR TITLE
fix(deps): upgrade yamux to v0.13.10 (CVE-2026-32314)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4607,9 +4607,9 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yamux"
-version = "0.13.9"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c650efd29044140aa63caaf80129996a9e2659a2ab7045a7e061807d02fc8549"
+checksum = "1991f6690292030e31b0144d73f5e8368936c58e45e7068254f7138b23b00672"
 dependencies = [
  "futures",
  "log",


### PR DESCRIPTION
## Summary
Upgrades `yamux` from v0.13.9 to v0.13.10 to resolve Dependabot alert #4 (GHSA-vxx9-2994-q338 / CVE-2026-32314), a high-severity remote panic vulnerability.

## Changes
- `Cargo.lock`: bumped `yamux` 0.13.9 → 0.13.10

## Security Details
`yamux < 0.13.10` panics when processing a crafted inbound Data frame with SYN set and body length > `DEFAULT_CREDIT` (262145). The panic is remotely reachable without authentication and can crash the process.

- **GHSA**: [GHSA-vxx9-2994-q338](https://github.com/libp2p/rust-yamux/security/advisories/GHSA-vxx9-2994-q338)
- **CVE**: CVE-2026-32314
- **CVSS v4**: 8.7 (High)
- **Fix**: upgrade to `yamux` v0.13.10

## Testing
- All 447 unit tests pass (`cargo test`)

## Related Issues
Closes https://github.com/datadog-labs/pup/security/dependabot/4

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)