### PR TITLE
fix(completions): skip auth check for completions and version commands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5896,6 +5896,24 @@ async fn main_inner() -> anyhow::Result<()> {
 
     let matches = Cli::command().get_matches();
     let cli = Cli::from_arg_matches(&matches).unwrap_or_else(|e| e.exit());
+
+    // Handle commands that do not require authentication before Config::from_env() so
+    // that sourcing completions in a shell rc (e.g. `source <(pup completions bash)`)
+    // never triggers a token refresh or prints auth-related messages.
+    #[cfg(not(target_arch = "wasm32"))]
+    if let Commands::Completions { shell, install } = cli.command {
+        if install {
+            commands::completions::install(shell)?;
+        } else {
+            commands::completions::generate(shell);
+        }
+        return Ok(());
+    }
+    if let Commands::Version = cli.command {
+        println!("{}", version::build_info());
+        return Ok(());
+    }
+
     let mut cfg = config::Config::from_env()?;
 
     // Apply flag overrides


### PR DESCRIPTION
## Summary

`pup completions` and `pup version` do not require credentials, but `Config::from_env()` was called unconditionally at startup, triggering automatic OAuth token refresh on every shell startup for users who source completions in their rc file (e.g. `source <(pup completions bash)`).

## Changes

- `src/main.rs`: Added early-exit branches for `Commands::Completions` and `Commands::Version` immediately after CLI arg parsing, before `Config::from_env()` is reached (`main.rs:5900`). Both commands complete and return without ever loading config or touching auth storage/the network.

## Testing

- `cargo build` — clean
- `cargo test` — 453 tests pass
- `cargo clippy -- -D warnings` — clean
- `cargo fmt --check` — clean

## Related Issues

Closes #222

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)