### PR TITLE
fix(ci): replace cargo-binstall action with brew install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,10 +46,8 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
-      - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@main
       - name: Install build tools
-        run: cargo binstall --no-confirm cargo-zigbuild wasm-pack
+        run: brew install cargo-zigbuild wasm-pack
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
       - name: Install syft


### PR DESCRIPTION
## Summary

- Removes `cargo-bins/cargo-binstall@main` action, which is blocked by enterprise policy requiring actions to be GitHub-owned or verified in the Marketplace
- Replaces `cargo binstall cargo-zigbuild wasm-pack` with `brew install cargo-zigbuild wasm-pack` — both packages are available on Homebrew and the release job already runs on `macos-latest`

## Test plan
- [x] Trigger a release tag to verify the workflow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)