### PR TITLE
docs(idp): document new IDP commands for Service Catalog access

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,8 +194,8 @@ See [TESTING.md](docs/TESTING.md) for details.
 
 ## Implementation Status
 
-- **58 command modules** implemented
-- **320+ subcommands** across 56 command groups
+- **59 command modules** implemented
+- **325+ subcommands** across 57 command groups
 - **60 unit tests** passing
 - **155/155 API output** matches Go version exactly
 - **390/390 command descriptions** match Go version

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -45,6 +45,7 @@ pup <domain> <subgroup> <action> [options] # Nested commands
 | security | rules, signals, findings, content-packs, risk-scores | src/commands/security.rs | ✅ |
 | organizations | get, list | src/commands/organizations.rs | ✅ |
 | service-catalog | list, get | src/commands/service_catalog.rs | ✅ |
+| idp | assist, find, owner, deps, register | src/commands/idp.rs | ✅ |
 | error-tracking | issues (search, get) | src/commands/error_tracking.rs | ✅ |
 | scorecards | list, get | src/commands/scorecards.rs | ✅ |
 | usage | summary, hourly | src/commands/usage.rs | ✅ |
@@ -70,7 +71,7 @@ pup <domain> <subgroup> <action> [options] # Nested commands
 | change-requests | create, get, update, create-branch, decisions (update, delete) | src/commands/change_management.rs | ✅ |
 | app-builder | list, get, create, update, delete, delete-batch, publish, unpublish | src/commands/app_builder.rs | ✅ |
 
-**Summary:** 49 working, 0 API-blocked, 0 placeholders
+**Summary:** 50 working, 0 API-blocked, 0 placeholders
 
 **Note:** RUM command is fully operational. Apps and sessions work completely. Metrics and retention-filters support list/get operations (create/update/delete operations pending due to complex API type structures).
 
@@ -157,6 +158,7 @@ pup infrastructure hosts list
 - **error-tracking** - Error management (issues search, issues get)
 - **scorecards** - Service quality (list, get)
 - **service-catalog** - Service registry (list, get)
+- **idp** - Service Catalog agent access (assist, find, owner, deps, register)
 
 ### Operations & Incident Response
 - **incidents** - Incident management (list, get, attachments, settings, handles, postmortem-templates)
@@ -200,6 +202,15 @@ Available on all commands:
 ```
 
 ## Recent Enhancements
+
+### v0.33.4 — IDP Commands for Service Catalog
+
+- ✅ **idp** (new) — Agent-native access to the Datadog Service Catalog
+  - `assist <entity>` — full context: owner, on-call, health, dependencies, metadata gaps, and suggested next actions
+  - `find <query>` — search entities by name (defaults to `kind:service`)
+  - `owner <entity>` — ownership + on-call responders for an entity
+  - `deps <entity>` — upstream/downstream service dependencies
+  - `register <file>` — POST a `service.datadog.yaml` to the Service Definitions API
 
 ### v0.28.0 — New Command Groups and Full Pipeline Implementation
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -434,6 +434,62 @@ pup workflows instances get <workflow-id> <instance-id>
 pup workflows instances cancel <workflow-id> <instance-id>
 ```
 
+## IDP (Service Catalog)
+
+### Get Full Service Context
+```bash
+# Get owner, on-call, health, dependencies, and metadata gaps in one call
+pup idp assist my-service
+
+# Useful as a starting point for incident response or code review
+pup idp assist payments-api
+```
+
+### Find Entities
+```bash
+# Search services by name (fuzzy match)
+pup idp find payments
+
+# Use kind: prefix to search other entity types
+pup idp find "kind:team AND name:backend"
+```
+
+### Get Ownership and On-Call
+```bash
+# Show owning team and current on-call responders
+pup idp owner my-service
+```
+
+### Show Service Dependencies
+```bash
+# List upstream (callers) and downstream (callees) services
+pup idp deps my-service
+```
+
+### Register a Service Definition
+```bash
+# POST a service.datadog.yaml to the Service Definitions API
+pup idp register service.datadog.yaml
+
+# Verify after registration
+pup idp assist my-service
+```
+
+### Incident Response Workflow with IDP
+```bash
+# Get full service context immediately
+pup idp assist payments-api
+
+# Investigate alerts for the service
+pup monitors list --tag="service:payments-api"
+
+# Check who is on-call
+pup idp owner payments-api
+
+# Review upstream services that may be affected
+pup idp deps payments-api
+```
+
 ## Output Formatting
 
 ### JSON Output (Default)


### PR DESCRIPTION
## Summary

Documents the `pup idp` command group merged in #227, covering all five subcommands and updating all relevant references.

## Changes

- `docs/COMMANDS.md`: add `idp` to command index table, domain categories, and new v0.33.4 recent enhancements entry; update summary count from 49 → 50
- `docs/EXAMPLES.md`: add IDP section with examples for `assist`, `find`, `owner`, `deps`, `register`, and an incident response workflow
- `CLAUDE.md`: update implementation stats (59 modules, 325+ subcommands, 57 command groups)

## Related Issues

Follows #227

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)