### PR TITLE
feat(auth): add LLM Observability OAuth scopes

### DIFF
--- a/src/auth/types.rs
+++ b/src/auth/types.rs
@@ -67,6 +67,7 @@ pub fn read_only_scopes() -> Vec<&'static str> {
         "incident_notification_settings_read",
         "incident_settings_read",
         "integrations_read",
+        "llm_observability_read",
         "logs_read_archives",
         "logs_read_config",
         "logs_read_data",
@@ -139,6 +140,9 @@ pub fn default_scopes() -> Vec<&'static str> {
         // Integrations (Jira, ServiceNow, Slack, Webhooks)
         "integrations_read",
         "manage_integrations",
+        // LLM Observability
+        "llm_observability_read",
+        "llm_observability_write",
         // Logs
         "logs_generate_metrics",
         "logs_modify_indexes",
@@ -241,7 +245,7 @@ mod tests {
     #[test]
     fn test_default_scopes() {
         let scopes = default_scopes();
-        assert_eq!(scopes.len(), 70);
+        assert_eq!(scopes.len(), 72);
         assert!(scopes.contains(&"dashboards_read"));
         assert!(scopes.contains(&"monitors_read"));
         assert!(scopes.contains(&"logs_read_data"));


### PR DESCRIPTION
## Summary
- Add `llm_observability_read` and `llm_observability_write` to the default OAuth scopes
- Add `llm_observability_read` to the read-only scope set

## Testing
- Verified OAuth login succeeds with the new scopes on datad0g.com
- All LLM Obs commands tested successfully: experiments summary, events list/get, metric-values, dimension-values, spans search
- `cargo test -- test_default_scopes` passes with updated scope count (72)