### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/datadog-labs/pup/security/code-scanning/17](https://github.com/datadog-labs/pup/security/code-scanning/17)

The problem is that the workflow does not explicitly restrict the `GITHUB_TOKEN` permissions, so GitHub falls back to repository/organization defaults, which may be overly permissive. The optimal fix is to add an explicit `permissions` block following the principle of least privilege.

The best fix without changing functionality is to add a `permissions` block at the workflow root level (just under `name: CI` or under `on:`), setting `contents: read`. This will apply to all jobs that do not define their own `permissions`, including the `wasm` job on line 224, and is sufficient for typical build/test workflows that only need to read the code and use the token implicitly for `actions/checkout`. None of the shown jobs perform operations that require write access to repository contents or other GitHub resources.

Concretely, in `.github/workflows/ci.yml`, add:

```yaml
permissions:
  contents: read
```

near the top of the file, so it becomes a workflow-wide default. No additional imports, methods, or other code changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
