### PR TITLE
fix(client): set User-Agent header in raw HTTP helpers

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -220,6 +220,8 @@ static UNSTABLE_OPS: &[&str] = &[
 // Auth type detection
 // ---------------------------------------------------------------------------
 
+use crate::useragent;
+
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AuthType {
@@ -506,7 +508,11 @@ pub async fn raw_get(
         req = req.query(query);
     }
 
-    let resp = req.header("Accept", "application/json").send().await?;
+    let resp = req
+        .header("Accept", "application/json")
+        .header("User-Agent", useragent::get())
+        .send()
+        .await?;
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
@@ -539,6 +545,7 @@ pub async fn raw_patch(
     let resp = req
         .header("Content-Type", "application/json")
         .header("Accept", "application/json")
+        .header("User-Agent", useragent::get())
         .json(&body)
         .send()
         .await?;
@@ -574,6 +581,7 @@ pub async fn raw_post(
     let resp = req
         .header("Content-Type", "application/json")
         .header("Accept", "application/json")
+        .header("User-Agent", useragent::get())
         .json(&body)
         .send()
         .await?;


### PR DESCRIPTION
## Summary
The raw HTTP helpers (`raw_get`, `raw_patch`, `raw_post`) in `client.rs` were never setting the `User-Agent` header, causing `ddsql` and any other commands using these helpers to send reqwest's default user agent instead of pup's versioned string (`pup/<version> (rust; os ...; arch ...)`).

## Changes
- Import `useragent` in `client.rs` (src/client.rs:223)
- Add `.header("User-Agent", useragent::get())` to `raw_get`, `raw_patch`, and `raw_post` (src/client.rs:511, 548, 584)

## Testing
- `cargo fmt` — no changes
- `cargo clippy -- -D warnings` — clean
- `cargo check` — clean

## Notes
This also fixes the same missing header in `acp.rs` and `synthetics.rs` which use the same raw helpers.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)