### PR TITLE
feat(ddsql): use async querying for DDSQL commands

### DIFF
--- a/src/commands/ddsql.rs
+++ b/src/commands/ddsql.rs
@@ -117,9 +117,12 @@ async fn execute_async_query(cfg: &Config, body: Value) -> Result<Value> {
         tokio::time::sleep(Duration::from_secs(1)).await;
 
         let fetch_body = build_fetch_request(&body, &query_id);
-        let poll_resp =
-            client::raw_post(cfg, "/api/unstable/advanced/query/tabular/fetch", fetch_body)
-                .await?;
+        let poll_resp = client::raw_post(
+            cfg,
+            "/api/unstable/advanced/query/tabular/fetch",
+            fetch_body,
+        )
+        .await?;
 
         match extract_query_status(&poll_resp)? {
             None => return Ok(poll_resp),
@@ -306,10 +309,9 @@ mod tests {
 
     #[test]
     fn test_extract_query_status_done() {
-        let resp: Value = serde_json::from_str(
-            r#"{"meta":{"queries":[{"status":"done","name":"user_query"}]}}"#,
-        )
-        .unwrap();
+        let resp: Value =
+            serde_json::from_str(r#"{"meta":{"queries":[{"status":"done","name":"user_query"}]}}"#)
+                .unwrap();
         assert!(extract_query_status(&resp).unwrap().is_none());
     }
 


### PR DESCRIPTION
## Summary
- Switch DDSQL `table` and `time_series` commands from synchronous to asynchronous query execution against the Advanced Query API
- Enables support for long-running queries that may not complete within a single HTTP request/response cycle

## Changes
- Set `use_async_querying: true` in request meta (`src/commands/ddsql.rs:61`)
- Add `extract_query_status()` to parse query status (`done` vs `running`) from the `meta.queries[0]` response field
- Add `build_fetch_request()` to construct polling requests that include the `query_id` in attributes
- Add `execute_async_query()` orchestrator that sends the initial request and polls `POST /api/unstable/advanced/query/tabular/fetch` every 1s until the query completes
- Both `table()` and `time_series()` now use `execute_async_query()` instead of calling `raw_post` directly

## Testing
- [x] 5 new unit tests for `extract_query_status` (done, running, missing meta, unexpected status) and `build_fetch_request`
- [x] Existing test updated to assert `use_async_querying: true`
- [x] All 13 ddsql tests pass (`cargo test --bin pup ddsql`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)