### PR TITLE
fix(config): preserve custom subdomains in normalize_site

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -88,15 +88,6 @@ impl Config {
 
         let access_token = env_or("DD_ACCESS_TOKEN", file_cfg.access_token);
         let raw_site = env_or("DD_SITE", file_cfg.site).unwrap_or_else(|| "datadoghq.com".into());
-        if is_custom_subdomain(&raw_site) {
-            eprintln!(
-                "Warning: DD_SITE '{}' contains a custom subdomain. Assuming US1 region \
-                 (datadoghq.com). If you meant a standard region, use one of: \
-                 datadoghq.com (US1), us3.datadoghq.com (US3), us5.datadoghq.com (US5), \
-                 ap1.datadoghq.com (AP1), datadoghq.eu (EU), ddog-gov.com (US1-FED).",
-                raw_site
-            );
-        }
         let site = normalize_site(&raw_site);
         let org = env_or("DD_ORG", file_cfg.org); // flag override applied in main_inner
 
@@ -376,73 +367,31 @@ where
 
 /// Normalize a raw site value from user input into a canonical form.
 ///
-/// Rules (applied in order):
-/// 1. Oncall sites (`navy.oncall.datadoghq.com`) are passed through unchanged —
-///    they are already fully-qualified API hosts.
-/// 2. Split the domain into labels and determine how many trailing labels to keep:
-///    - If the 3rd-from-last label matches `[a-z]{2}[0-9]+` (a regional prefix
-///      like `us3`, `eu1`, `ap1`) keep the last **3** labels.
-///    - Otherwise keep the last **2** labels.
+/// Strips leading UI prefixes (`www`, `api`, `app`) and passes everything else
+/// through unchanged — including custom subdomains and regional prefixes like
+/// `us3`, `ap1`, etc.
+///
+/// Oncall sites (containing `oncall`) are always passed through unchanged.
 ///
 /// Examples:
-///   `app.datadoghq.com`     → `datadoghq.com`
-///   `app.us3.datadoghq.com` → `us3.datadoghq.com`
-///   `us3.datadoghq.com`     → `us3.datadoghq.com`
-///   `datadoghq.com`         → `datadoghq.com`
+///   `app.datadoghq.com`        → `datadoghq.com`
+///   `www.datadoghq.com`        → `datadoghq.com`
+///   `api.datadoghq.com`        → `datadoghq.com`
+///   `app.us3.datadoghq.com`    → `us3.datadoghq.com`
+///   `us3.datadoghq.com`        → `us3.datadoghq.com`
+///   `custom.datadoghq.com`     → `custom.datadoghq.com`
+///   `datadoghq.com`            → `datadoghq.com`
 pub fn normalize_site(site: &str) -> String {
     if site.contains("oncall") {
         return site.to_string();
     }
+    const STRIP_PREFIXES: &[&str] = &["www", "api", "app"];
     let parts: Vec<&str> = site.split('.').collect();
-    let n = parts.len();
-    if n < 2 {
-        return site.to_string();
-    }
-    let keep_from = if n >= 3 && is_region_prefix(parts[n - 3]) {
-        n - 3
-    } else {
-        n - 2
-    };
-    parts[keep_from..].join(".")
-}
-
-/// Returns true when `site` contains a custom subdomain that will be stripped by
-/// `normalize_site`, and that subdomain is not a known harmless UI prefix (`app`, `www`)
-/// or a recognized regional prefix (`us3`, `ap1`, etc.).
-///
-/// This is used to warn users who may have set `DD_SITE` to a dedicated/custom Datadog
-/// instance URL — which requires the full host, not the stripped base domain.
-pub fn is_custom_subdomain(site: &str) -> bool {
-    if site.contains("oncall") {
-        return false; // oncall sites are passed through unchanged
-    }
-    let parts: Vec<&str> = site.split('.').collect();
-    let n = parts.len();
-    if n < 3 {
-        return false; // no subdomain prefix to strip
-    }
-    let keep_from = if n >= 3 && is_region_prefix(parts[n - 3]) {
-        n - 3
-    } else {
-        n - 2
-    };
-    if keep_from == 0 {
-        return false; // nothing would be stripped
-    }
-    // Any stripped label that isn't a known UI prefix is a custom subdomain
-    const SAFE_PREFIXES: &[&str] = &["api", "app", "www"];
-    parts[..keep_from]
+    let start = parts
         .iter()
-        .any(|p| !SAFE_PREFIXES.contains(p))
-}
-
-/// Returns true if `s` matches the pattern `[a-z]{2}[0-9]+` (e.g. "us3", "eu1", "ap1").
-fn is_region_prefix(s: &str) -> bool {
-    let b = s.as_bytes();
-    b.len() >= 3
-        && b[0].is_ascii_lowercase()
-        && b[1].is_ascii_lowercase()
-        && b[2..].iter().all(|c| c.is_ascii_digit())
+        .position(|p| !STRIP_PREFIXES.contains(p))
+        .unwrap_or(0);
+    parts[start..].join(".")
 }
 
 #[cfg(not(feature = "browser"))]
@@ -666,43 +615,27 @@ mod tests {
         );
     }
 
-    // --- is_custom_subdomain tests ---
+    // --- normalize_site custom subdomain passthrough tests ---
 
     #[test]
-    fn test_is_custom_subdomain_plain() {
-        assert!(!is_custom_subdomain("datadoghq.com"));
+    fn test_normalize_site_custom_subdomain_preserved() {
+        assert_eq!(
+            normalize_site("customname.datadoghq.com"),
+            "customname.datadoghq.com"
+        );
     }
 
     #[test]
-    fn test_is_custom_subdomain_app_prefix() {
-        assert!(!is_custom_subdomain("app.datadoghq.com"));
+    fn test_normalize_site_app_then_custom_subdomain() {
+        assert_eq!(
+            normalize_site("app.customname.datadoghq.com"),
+            "customname.datadoghq.com"
+        );
     }
 
     #[test]
-    fn test_is_custom_subdomain_region_prefix() {
-        assert!(!is_custom_subdomain("us3.datadoghq.com"));
-        assert!(!is_custom_subdomain("ap1.datadoghq.com"));
-        assert!(!is_custom_subdomain("eu1.datadoghq.com"));
-    }
-
-    #[test]
-    fn test_is_custom_subdomain_app_and_region_prefix() {
-        assert!(!is_custom_subdomain("app.us3.datadoghq.com"));
-    }
-
-    #[test]
-    fn test_is_custom_subdomain_oncall() {
-        assert!(!is_custom_subdomain("navy.oncall.datadoghq.com"));
-    }
-
-    #[test]
-    fn test_is_custom_subdomain_custom() {
-        assert!(is_custom_subdomain("customname.datadoghq.com"));
-    }
-
-    #[test]
-    fn test_is_custom_subdomain_app_then_custom() {
-        assert!(is_custom_subdomain("app.customname.datadoghq.com"));
+    fn test_normalize_site_www_prefix() {
+        assert_eq!(normalize_site("www.datadoghq.com"), "datadoghq.com");
     }
 
     // --- api_host tests (site already normalized at construction) ---


### PR DESCRIPTION
## Summary

- `normalize_site` now only strips known UI prefixes (`www`, `api`, `app`) — custom subdomains are left intact
- Removes `is_custom_subdomain`, `is_region_prefix`, and the warning added in #272 as a band-aid for this root cause

**Before:** `customname.datadoghq.com` → `datadoghq.com` (silently routes to US1)
**After:** `customname.datadoghq.com` → `customname.datadoghq.com` (preserved)

Region prefixes like `us3.datadoghq.com` continue to be preserved as before.

## Test plan

- [x] `cargo test config` — all 67 tests pass
- [x] New tests: `test_normalize_site_custom_subdomain_preserved`, `test_normalize_site_app_then_custom_subdomain`, `test_normalize_site_www_prefix`

Closes #264

👾 Generated with https://datadoghq.com