### PR TITLE
fix(ci): use standard runner for Linux release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
   # ---------------------------------------------------------------------------
   build-linux:
     name: Build Linux
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
## Summary

- The `build-linux` job in the release workflow was using `ubuntu-latest-16-cores`, a larger runner label not provisioned for this org, causing the job to hang indefinitely in queued state.
- Changed `runs-on` to `ubuntu-latest` to unblock release builds.

## Test plan

- [ ] Verify the release workflow runs successfully with the standard runner
- [ ] Confirm Linux build artifacts are produced correctly

🐾 Generated with [Bits CLI](https://datadoghq.com)