### PR TITLE
feat(auth): add --subdomain flag for SAML/SSO login

### DIFF
--- a/src/auth/dcr.rs
+++ b/src/auth/dcr.rs
@@ -194,6 +194,7 @@ impl DcrClient {
         state: &str,
         challenge: &super::pkce::PkceChallenge,
         scopes: &[&str],
+        subdomain: Option<&str>,
     ) -> String {
         let scope = scopes.join(" ");
         let params = url::form_urlencoded::Serializer::new(String::new())
@@ -205,6 +206,12 @@ impl DcrClient {
             .append_pair("code_challenge", &challenge.challenge)
             .append_pair("code_challenge_method", &challenge.method)
             .finish();
-        format!("https://app.{}/oauth2/v1/authorize?{params}", self.site)
+
+        // Use custom subdomain for SAML/SSO auth, otherwise use standard app.{site}
+        let auth_host = match subdomain {
+            Some(sub) => format!("{sub}.datadoghq.com"),
+            None => format!("app.{}", self.site),
+        };
+        format!("https://{auth_host}/oauth2/v1/authorize?{params}")
     }
 }

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -15,7 +15,7 @@ where
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub async fn login(cfg: &Config, scopes: Vec<String>) -> Result<()> {
+pub async fn login(cfg: &Config, scopes: Vec<String>, subdomain: Option<&str>) -> Result<()> {
     use crate::auth::{dcr, pkce};
 
     let site = &cfg.site;
@@ -26,6 +26,9 @@ pub async fn login(cfg: &Config, scopes: Vec<String>) -> Result<()> {
     let redirect_uri = server.redirect_uri();
     let org_label = org.map(|o| format!(" (org: {o})")).unwrap_or_default();
     eprintln!("\n🔐 Starting OAuth2 login for site: {site}{org_label}\n");
+    if let Some(sub) = subdomain {
+        eprintln!("🏢 Using SAML/SSO subdomain: {sub}.datadoghq.com");
+    }
     eprintln!("📡 Callback server started on: {redirect_uri}");
 
     let scope_strs: Vec<&str> = scopes.iter().map(String::as_str).collect();
@@ -73,6 +76,7 @@ pub async fn login(cfg: &Config, scopes: Vec<String>) -> Result<()> {
         &state,
         &challenge,
         &scope_strs,
+        subdomain,
     );
 
     // 5. Open browser
@@ -121,7 +125,7 @@ pub async fn login(cfg: &Config, scopes: Vec<String>) -> Result<()> {
 }
 
 #[cfg(target_arch = "wasm32")]
-pub async fn login(_cfg: &Config, _scopes: Vec<String>) -> Result<()> {
+pub async fn login(_cfg: &Config, _scopes: Vec<String>, _subdomain: Option<&str>) -> Result<()> {
     bail!(
         "OAuth login is not available in WASM builds.\n\
          Use DD_ACCESS_TOKEN env var for bearer token auth,\n\

--- a/src/main.rs
+++ b/src/main.rs
@@ -6260,6 +6260,9 @@ enum AuthActions {
         /// Overrides DD_SITE env var and config file. Defaults to datadoghq.com.
         #[arg(long, value_name = "SITE")]
         site: Option<String>,
+        /// Organization subdomain for SAML/SSO login (e.g. mycompany for mycompany.datadoghq.com).
+        #[arg(long, value_name = "SUBDOMAIN")]
+        subdomain: Option<String>,
     },
     /// Logout and clear tokens
     Logout,
@@ -9365,6 +9368,7 @@ async fn main_inner() -> anyhow::Result<()> {
                 scopes,
                 read_only,
                 site,
+                subdomain,
             } => {
                 if let Some(s) = site {
                     cfg.site = s;
@@ -9372,7 +9376,7 @@ async fn main_inner() -> anyhow::Result<()> {
                 let is_read_only = read_only || cfg.read_only;
                 let resolved =
                     resolve_login_scopes(scopes.as_deref(), cfg.org.as_deref(), is_read_only);
-                commands::auth::login(&cfg, resolved).await?
+                commands::auth::login(&cfg, resolved, subdomain.as_deref()).await?
             }
             AuthActions::Logout => commands::auth::logout(&cfg).await?,
             AuthActions::Status { site } => {


### PR DESCRIPTION
## Summary
Adds support for SAML/SSO authentication with custom organization subdomains.

## Problem
Organizations using federated authentication (SAML/SSO) with custom subdomains 
(e.g., mycompany.datadoghq.com) cannot use `pup auth login` because the OAuth2 
authorization URL always uses `app.{site}`, which doesn't show the SAML login option.

## Solution
Add a `--subdomain` flag that allows specifying the organization's subdomain 
for the authorization URL.

## Usage
```bash
pup auth login --site=us3.datadoghq.com --subdomain=mycompany
# Opens: https://mycompany.datadoghq.com/oauth2/v1/authorize?...
```

## Changes
- `src/main.rs`: Add `--subdomain` flag to `auth login` command
- `src/commands/auth.rs`: Pass subdomain to authorization URL builder
- `src/auth/dcr.rs`: Use custom subdomain in authorization URL when provided

## Testing
- `cargo build` compiles successfully
- `cargo test` passes
- `cargo clippy` passes with no warnings
- CLI help shows new `--subdomain` flag

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)