### PR TITLE
test(harness): add test-optimization flaky-tests search + fix missing request body

### DIFF
--- a/scripts/test_harness.py
+++ b/scripts/test_harness.py
@@ -1314,6 +1314,13 @@ READ_COMMANDS: list[dict] = [
         "category": "auth_required",
         "expect_json": True,
     },
+    # ── test-optimization ────────────────────────────────────────────────
+    {
+        "label": "test-optimization flaky-tests search",
+        "args": ["test-optimization", "flaky-tests", "search"],
+        "category": "auth_required",
+        "expect_json": True,
+    },
     # ── traces ────────────────────────────────────────────────────────────
     {
         "label": "traces search",

--- a/src/commands/test_optimization.rs
+++ b/src/commands/test_optimization.rs
@@ -63,11 +63,23 @@ pub async fn flaky_tests_search(cfg: &Config, file: Option<String>) -> Result<()
         Some(c) => TestOptimizationAPI::with_client_and_config(dd_cfg, c),
         None => TestOptimizationAPI::with_config(dd_cfg),
     };
-    let mut params = SearchFlakyTestsOptionalParams::default();
-    if let Some(f) = file {
+    let params = if let Some(f) = file {
         let body = crate::util::read_json_file(&f)?;
-        params = params.body(body);
-    }
+        SearchFlakyTestsOptionalParams::default().body(body)
+    } else {
+        use datadog_api_client::datadogV2::model::{
+            FlakyTestsSearchPageOptions, FlakyTestsSearchRequest,
+            FlakyTestsSearchRequestAttributes, FlakyTestsSearchRequestData,
+            FlakyTestsSearchRequestDataType,
+        };
+        let page_opts = FlakyTestsSearchPageOptions::new().limit(100);
+        let attrs = FlakyTestsSearchRequestAttributes::new().page(page_opts);
+        let data = FlakyTestsSearchRequestData::new()
+            .attributes(attrs)
+            .type_(FlakyTestsSearchRequestDataType::SEARCH_FLAKY_TESTS_REQUEST);
+        let body = FlakyTestsSearchRequest::new().data(data);
+        SearchFlakyTestsOptionalParams::default().body(body)
+    };
     let resp = api
         .search_flaky_tests(params)
         .await

--- a/tests/snapshots/test-optimization_flaky-tests_search__agent.json
+++ b/tests/snapshots/test-optimization_flaky-tests_search__agent.json
@@ -1,0 +1,13 @@
+{
+  "data": [
+    "<list>",
+    {
+      "attributes": {
+        "*": "<...>"
+      },
+      "id": "str",
+      "type": "str"
+    }
+  ],
+  "status": "str"
+}

--- a/tests/snapshots/test-optimization_flaky-tests_search__human.json
+++ b/tests/snapshots/test-optimization_flaky-tests_search__human.json
@@ -1,0 +1,17 @@
+{
+  "data": [
+    "<list>",
+    {
+      "attributes": {
+        "*": "<...>"
+      },
+      "id": "str",
+      "type": "str"
+    }
+  ],
+  "meta": {
+    "*": {
+      "next_page": "str"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `test-optimization flaky-tests search` to the test harness catalog, completing coverage for all 28 spec-paginated endpoints with pup commands
- Fixes a bug in `test_optimization.rs::flaky_tests_search` where no request body was sent when `--file` was omitted, causing a server-side 400 error (nil pointer dereference). Now constructs a default `FlakyTestsSearchRequest` with page options (limit 100), matching the `cicd.rs` pattern.

## Changes
- `scripts/test_harness.py` — new catalog entry for `test-optimization flaky-tests search`
- `src/commands/test_optimization.rs` — construct default request body when `--file` is omitted
- `tests/snapshots/test-optimization_flaky-tests_search__{agent,human}.json` — new snapshots

## Test plan
- [x] `cargo build --release` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test` — 635 tests pass
- [x] `pup test-optimization flaky-tests search` returns valid JSON
- [x] Harness produces snapshots for both agent and human modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)