### PR TITLE
ci: merge check/test/coverage, cache tools, share cache keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  check:
-    name: Check & Lint
+  check-test-coverage:
+    name: Check, Test & Coverage
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -28,67 +28,26 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: cargo-check-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-check-
+          key: cargo-ubuntu-check-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: cargo-ubuntu-
+      - name: Cache cargo-llvm-cov
+        id: cache-llvm-cov
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ~/.cargo/bin/cargo-llvm-cov
+          key: cargo-llvm-cov-${{ runner.os }}
       - name: Install Rust
         run: |
-          rustup toolchain install stable --profile minimal --component clippy,rustfmt
+          rustup toolchain install stable --profile minimal --component clippy,rustfmt,llvm-tools-preview
           rustup default stable
       - name: Format check
         run: cargo fmt --check
       - name: Clippy
         run: cargo clippy -- -D warnings
-      - name: Build
-        run: cargo build --release
-      - name: Report binary size
-        run: |
-          ls -lh target/release/pup
-          strip target/release/pup
-          echo "Stripped:"
-          ls -lh target/release/pup
-
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: cargo-test-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-test-
-      - name: Install Rust
-        run: |
-          rustup toolchain install stable --profile minimal
-          rustup default stable
-      - name: Run tests
-        run: cargo test --verbose -- --test-threads=1
-
-  coverage:
-    name: Code Coverage
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: cargo-cov-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-cov-
-      - name: Install Rust
-        run: |
-          rustup toolchain install stable --profile minimal --component llvm-tools-preview
-          rustup default stable
       - name: Install cargo-llvm-cov
+        if: steps.cache-llvm-cov.outputs.cache-hit != 'true'
         run: cargo install cargo-llvm-cov
-      - name: Generate coverage
+      - name: Test with coverage
         run: cargo llvm-cov --lcov --output-path lcov.info --ignore-filename-regex 'main\.rs|auth/' -- --test-threads=1
       - name: Coverage summary
         run: cargo llvm-cov report --ignore-filename-regex 'main\.rs|auth/'
@@ -110,8 +69,8 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: cargo-cross-linux-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-cross-linux-
+          key: cargo-ubuntu-cross-linux-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: cargo-ubuntu-
       - name: Install Rust
         run: |
           rustup toolchain install stable --profile minimal
@@ -122,7 +81,14 @@ jobs:
           ZIG_VERSION="0.13.0"
           curl -sL "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-x86_64-${ZIG_VERSION}.tar.xz" | tar xJ
           echo "$PWD/zig-linux-x86_64-${ZIG_VERSION}" >> "$GITHUB_PATH"
+      - name: Cache cargo-zigbuild
+        id: cache-zigbuild
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ~/.cargo/bin/cargo-zigbuild
+          key: cargo-zigbuild-${{ runner.os }}
       - name: Install cargo-zigbuild
+        if: steps.cache-zigbuild.outputs.cache-hit != 'true'
         run: cargo install --locked cargo-zigbuild
       - name: Build all targets
         run: |
@@ -144,6 +110,9 @@ jobs:
         run: |
           for target in x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu; do
             echo "${target}:"
+            ls -lh "target/${target}/release/pup"
+            strip "target/${target}/release/pup"
+            echo "  stripped:"
             ls -lh "target/${target}/release/pup"
           done
 
@@ -189,8 +158,8 @@ jobs:
             ls -lh "target/${target}/release/pup"
           done
 
-  windows:
-    name: Windows Build & Test
+  cross-compile-windows:
+    name: Cross Compile (Windows)
     runs-on: windows-latest
     defaults:
       run:
@@ -235,16 +204,23 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: cargo-wasm-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-wasm-
+          key: cargo-ubuntu-wasm-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: cargo-ubuntu-
       - name: Install Rust
         run: |
           rustup toolchain install stable --profile minimal
           rustup default stable
           rustup target add wasm32-wasip2 wasm32-unknown-unknown
+      - name: Cache wasm-pack
+        id: cache-wasm-pack
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ~/.cargo/bin/wasm-pack
+          key: wasm-pack-${{ runner.os }}
       - name: Build WASI
         run: cargo build --target wasm32-wasip2 --no-default-features --features wasi --release
       - name: Install wasm-pack
+        if: steps.cache-wasm-pack.outputs.cache-hit != 'true'
         run: cargo install wasm-pack
       - name: Build browser WASM
         run: wasm-pack build --target web --no-default-features --features browser


### PR DESCRIPTION
## Summary

- **Merge 3 jobs → 1**: Consolidate `check`, `test`, and `coverage` into a single `check-test-coverage` job (fmt → clippy → `cargo llvm-cov`), eliminating two redundant compilation passes on ubuntu
- **Cache tool binaries**: `cargo-llvm-cov`, `cargo-zigbuild`, and `wasm-pack` are cached via `actions/cache` so `cargo install` is skipped on cache hit (~3-8 min saved)
- **Share cache prefix**: All ubuntu jobs use `cargo-ubuntu-*` keys with a shared restore prefix so registry downloads seed each other
- **Move size report**: Binary size reporting (with `strip`) moved from the old `check` job to `cross-compile-linux` where release builds already happen
- **Rename Windows job**: `Windows Build & Test` → `Cross Compile (Windows)` to match Linux/macOS naming

Net result: 7 jobs → 5 jobs, -60/+36 lines.

## Test plan

- [x] CI passes on this PR (the workflow is testing itself)
- [x] Verify cache hits show on second run (check `Post Cache` steps in Actions logs)
- [x] Confirm coverage artifact is still uploaded

🐾 Generated with [Bits CLI](https://datadoghq.com)