### PR TITLE
fix(ci): remove strip from Linux cross-compile job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,9 +111,6 @@ jobs:
           for target in x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu; do
             echo "${target}:"
             ls -lh "target/${target}/release/pup"
-            strip "target/${target}/release/pup"
-            echo "  stripped:"
-            ls -lh "target/${target}/release/pup"
           done
 
   cross-compile-macos:


### PR DESCRIPTION
## Summary
Remove the `strip` command from the Linux `cross-compile-linux` CI job's "Report sizes" step. The host `strip` on the x86_64 Ubuntu runner cannot process the cross-built `aarch64-unknown-linux-gnu` binary, causing the job to fail.

## Changes
- Removed `strip` calls from the Report sizes step in `.github/workflows/ci.yml:109-117`
- Kept `ls -lh` size reporting, matching the pattern used by the macOS and Windows jobs

## Testing
- Verified the diff only removes the `strip` lines and preserves the `ls -lh` reporting
- The macOS and Windows cross-compile jobs already use this simpler pattern without `strip`

Closes #297

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)