### PR TITLE
feat(rum): add --query flag to rum events

### DIFF
--- a/src/commands/rum.rs
+++ b/src/commands/rum.rs
@@ -78,7 +78,13 @@ pub async fn apps_delete(cfg: &Config, app_id: &str) -> Result<()> {
     Ok(())
 }
 
-pub async fn events_list(cfg: &Config, from: String, to: String, limit: i32) -> Result<()> {
+pub async fn events_list(
+    cfg: &Config,
+    query: Option<String>,
+    from: String,
+    to: String,
+    limit: i32,
+) -> Result<()> {
     let dd_cfg = client::make_dd_config(cfg);
     let api = match client::make_bearer_client(cfg) {
         Some(c) => RUMAPI::with_client_and_config(dd_cfg, c),
@@ -90,10 +96,13 @@ pub async fn events_list(cfg: &Config, from: String, to: String, limit: i32) -> 
     let to_dt =
         chrono::DateTime::from_timestamp_millis(util::parse_time_to_unix_millis(&to)?).unwrap();
 
-    let params = ListRUMEventsOptionalParams::default()
+    let mut params = ListRUMEventsOptionalParams::default()
         .filter_from(from_dt)
         .filter_to(to_dt)
         .page_limit(limit);
+    if let Some(q) = query {
+        params = params.filter_query(q);
+    }
 
     let resp = api
         .list_rum_events(params)

--- a/src/main.rs
+++ b/src/main.rs
@@ -4357,6 +4357,8 @@ enum RumActions {
     },
     /// List RUM events
     Events {
+        #[arg(long, help = "RUM query filter (e.g. '@type:error @application.name:\"My App\"')")]
+        query: Option<String>,
         #[arg(long, default_value = "1h")]
         from: String,
         #[arg(long, default_value = "now")]
@@ -8585,8 +8587,8 @@ async fn main_inner() -> anyhow::Result<()> {
                         commands::rum::apps_delete(&cfg, &app_id).await?;
                     }
                 },
-                RumActions::Events { from, to, limit } => {
-                    commands::rum::events_list(&cfg, from, to, limit).await?;
+                RumActions::Events { query, from, to, limit } => {
+                    commands::rum::events_list(&cfg, query, from, to, limit).await?;
                 }
                 RumActions::Sessions { action } => match action {
                     RumSessionActions::Search {


### PR DESCRIPTION
## Summary
- Adds `--query` flag to `pup rum events` for filtering RUM events by Datadog query syntax
- `ListRUMEventsOptionalParams` already supports `filter_query` — this just wires it to the CLI
- Follows the same pattern as `rum sessions search --query` and `cicd tests --query`

## Usage

```bash
pup rum events --query='@type:error @application.name:"My App"' --from=1h --limit=100
pup rum events --query='@type:view @view.name:/checkout' --from=24h
```

## Changes
- `src/commands/rum.rs`: Add `query: Option<String>` parameter to `events_list()`, wire to `params.filter_query()`
- `src/main.rs`: Add `--query` arg to `Events` variant, pass through in handler

Closes #300

🐾 Generated with [Claude Code](https://claude.ai/claude-code)