### PR TITLE
feat(rum): add rum aggregate command

### DIFF
--- a/src/commands/rum.rs
+++ b/src/commands/rum.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use datadog_api_client::datadogV2::api_rum::{ListRUMEventsOptionalParams, RUMAPI};
 use datadog_api_client::datadogV2::api_rum_metrics::RumMetricsAPI;
 use datadog_api_client::datadogV2::api_rum_replay_heatmaps::{
@@ -372,4 +372,152 @@ pub async fn heatmaps_query(cfg: &Config, view_name: &str) -> Result<()> {
         .await
         .map_err(|e| anyhow::anyhow!("failed to query RUM heatmaps: {e:?}"))?;
     formatter::output(cfg, &resp)
+}
+
+// ---- RUM Aggregate ----
+
+pub struct RumAggregateArgs {
+    pub query: String,
+    pub from: String,
+    pub to: String,
+    pub compute: Vec<String>,
+    pub group_by: Vec<String>,
+    pub limit: i32,
+}
+
+fn parse_rum_compute(input: &str) -> Result<(String, Option<String>)> {
+    let input = input.trim();
+    if input.is_empty() {
+        bail!("--compute is required");
+    }
+    if input == "count" {
+        return Ok(("count".into(), None));
+    }
+    if let Some(paren) = input.find('(') {
+        let func = &input[..paren];
+        let rest = input[paren + 1..].trim_end_matches(')').trim();
+        if func == "percentile" {
+            let parts: Vec<&str> = rest.splitn(2, ',').collect();
+            if parts.len() != 2 {
+                bail!("percentile requires field and value: percentile(@duration, 99)");
+            }
+            let metric = parts[0].trim().to_string();
+            let pct: u32 = parts[1]
+                .trim()
+                .parse()
+                .map_err(|_| anyhow::anyhow!("invalid percentile value: {}", parts[1].trim()))?;
+            let agg_name = match pct {
+                75 => "pc75",
+                90 => "pc90",
+                95 => "pc95",
+                98 => "pc98",
+                99 => "pc99",
+                _ => bail!("unsupported percentile: {pct} (supported: 75, 90, 95, 98, 99)"),
+            };
+            return Ok((agg_name.into(), Some(metric)));
+        }
+        let metric = rest.to_string();
+        let agg_name = match func {
+            "avg" | "sum" | "min" | "max" | "median" | "cardinality" => func.to_string(),
+            "count" => bail!("count does not accept a field argument; use just 'count'"),
+            _ => bail!("unknown aggregation function: {func}"),
+        };
+        return Ok((agg_name, Some(metric)));
+    }
+    bail!(
+        "invalid --compute format: {input:?}\n\
+         Expected: count, avg(@duration), sum(@duration), percentile(@duration, 99), etc."
+    )
+}
+
+pub async fn aggregate(cfg: &Config, args: RumAggregateArgs) -> Result<()> {
+    let RumAggregateArgs {
+        query,
+        from,
+        to,
+        mut compute,
+        group_by,
+        limit,
+    } = args;
+    if compute.is_empty() {
+        compute.push("count".into());
+    }
+    let from_ms = util::parse_time_to_unix_millis(&from)?;
+    let to_ms = util::parse_time_to_unix_millis(&to)?;
+
+    let compute_arr: Vec<serde_json::Value> = compute
+        .iter()
+        .map(|c| {
+            let (aggregation, metric) = parse_rum_compute(c)?;
+            let mut obj = serde_json::json!({ "type": "total", "aggregation": aggregation });
+            if let Some(m) = metric {
+                obj["metric"] = serde_json::Value::String(m);
+            }
+            Ok(obj)
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let filter = serde_json::json!({
+        "query": query,
+        "from": from_ms.to_string(),
+        "to": to_ms.to_string()
+    });
+
+    let mut body = serde_json::json!({
+        "filter": filter,
+        "compute": compute_arr
+    });
+
+    if !group_by.is_empty() {
+        let group_by_arr: Vec<serde_json::Value> = group_by
+            .iter()
+            .map(|facet| {
+                let mut obj = serde_json::json!({
+                    "facet": facet,
+                    "sort": { "type": "measure", "order": "desc", "metric": "c0" }
+                });
+                if limit > 0 {
+                    obj["limit"] = serde_json::json!(limit);
+                }
+                obj
+            })
+            .collect();
+        body["group_by"] = serde_json::json!(group_by_arr);
+    }
+
+    let data = client::raw_post(cfg, "/api/v2/rum/analytics/aggregate", body).await?;
+    formatter::output(cfg, &data)?;
+    Ok(())
+}
+
+/// Split a comma-separated compute string, respecting parentheses.
+pub fn split_rum_compute_args(input: &str) -> Vec<String> {
+    let mut result = Vec::new();
+    let mut current = String::new();
+    let mut depth = 0u32;
+    for ch in input.chars() {
+        match ch {
+            '(' => {
+                depth += 1;
+                current.push(ch);
+            }
+            ')' => {
+                depth = depth.saturating_sub(1);
+                current.push(ch);
+            }
+            ',' if depth == 0 => {
+                let trimmed = current.trim().to_string();
+                if !trimmed.is_empty() {
+                    result.push(trimmed);
+                }
+                current.clear();
+            }
+            _ => current.push(ch),
+        }
+    }
+    let trimmed = current.trim().to_string();
+    if !trimmed.is_empty() {
+        result.push(trimmed);
+    }
+    result
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4355,6 +4355,28 @@ enum RumActions {
         #[command(subcommand)]
         action: RumAppActions,
     },
+    /// Aggregate RUM events by facets
+    Aggregate {
+        #[arg(long, help = "RUM query filter (e.g. '@type:error @application.name:\"My App\"')")]
+        query: Option<String>,
+        #[arg(long, default_value = "1h", help = "Start time")]
+        from: String,
+        #[arg(long, default_value = "now", help = "End time")]
+        to: String,
+        #[arg(
+            long,
+            default_value = "count",
+            help = "Metrics to compute (comma-separated, e.g. count,avg(@duration))"
+        )]
+        compute: String,
+        #[arg(
+            long,
+            help = "Fields to group by (comma-separated, e.g. @application.version,@view.name)"
+        )]
+        group_by: Option<String>,
+        #[arg(long, default_value_t = 10, help = "Maximum groups per facet")]
+        limit: i32,
+    },
     /// List RUM events
     Events {
         #[arg(long, default_value = "1h")]
@@ -8585,6 +8607,34 @@ async fn main_inner() -> anyhow::Result<()> {
                         commands::rum::apps_delete(&cfg, &app_id).await?;
                     }
                 },
+                RumActions::Aggregate {
+                    query,
+                    from,
+                    to,
+                    compute,
+                    group_by,
+                    limit,
+                } => {
+                    commands::rum::aggregate(
+                        &cfg,
+                        commands::rum::RumAggregateArgs {
+                            query: query.unwrap_or_default(),
+                            from,
+                            to,
+                            compute: commands::rum::split_rum_compute_args(&compute),
+                            group_by: group_by
+                                .map(|g| {
+                                    g.split(',')
+                                        .map(|s| s.trim().to_string())
+                                        .filter(|s| !s.is_empty())
+                                        .collect()
+                                })
+                                .unwrap_or_default(),
+                            limit,
+                        },
+                    )
+                    .await?;
+                }
                 RumActions::Events { from, to, limit } => {
                     commands::rum::events_list(&cfg, from, to, limit).await?;
                 }


### PR DESCRIPTION
## Summary
- Adds `pup rum aggregate` command for grouping and counting RUM events by facets
- Uses the RUM Analytics Aggregate API (`POST /api/v2/rum/analytics/aggregate`)
- Follows the exact same CLI pattern as `pup logs aggregate` (`--query`, `--compute`, `--group-by`, `--limit`, `--from`, `--to`)

## Usage

```bash
# Count errors by app version
pup rum aggregate \
  --query='@type:error @application.name:"My App" env:production' \
  --from=6h \
  --compute=count \
  --group-by=@application.version

# Count errors by version, view, and source in one call
pup rum aggregate \
  --query='@type:error @application.name:"My App"' \
  --compute=count \
  --group-by=@application.version,@view.name,@error.source \
  --limit=10

# Average page load time by view
pup rum aggregate \
  --query='@type:view' \
  --compute='avg(@view.loading_time)' \
  --group-by=@view.name
```

## Why

RUM aggregation is essential for:
- **Error pattern analysis**: Are errors concentrated on one app version or screen?
- **SLO breach investigation**: Correlating RUM errors with SLO degradation
- **Mobile triage**: Determining if a spike is a bad release, broken feature, or backend failure

`pup logs aggregate` already exists with this exact UX — this brings parity to RUM.

## Changes
- `src/commands/rum.rs`: Add `aggregate()`, `RumAggregateArgs`, `parse_rum_compute()`, `split_rum_compute_args()`
- `src/main.rs`: Add `Aggregate` variant to `RumActions` enum, wire handler

Closes #299

🐾 Generated with [Claude Code](https://claude.ai/claude-code)