### PR TITLE
Improve symdb probe-locations reliability and output

### DIFF
--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -437,6 +437,13 @@ pup debugger probes create \
   --probe-location com.example.MyClass:myMethod \
   --capture "request.id" --capture "user.name"
 
+# Use a method signature from --view probe-locations output
+pup debugger probes create \
+  --service my-service \
+  --env staging \
+  --probe-location "com.example.MyClass:myMethod(String, int)" \
+  --capture "request.id"
+
 # Increase capture depth for nested objects (default: 1)
 pup debugger probes create \
   --service my-service \
@@ -507,6 +514,7 @@ pup debugger probes watch "probe-id" --wait 30
 ### Pipeline: Create and Watch
 ```bash
 # Search for a method, create a probe, and watch events
+# Note: --view probe-locations may output signatures like TYPE:METHOD(args)
 pup symdb search --service my-service --query MyController --view probe-locations \
   | head -1 \
   | xargs -I{} pup debugger probes create --service my-service --env staging --probe-location {} --capture --ttl 1h \
@@ -536,7 +544,7 @@ pup symdb search --service my-service --query MyController --view full
 # Scope names only
 pup symdb search --service my-service --query MyController --view names
 
-# Probe locations (type:method format)
+# Probe locations (type:method or type:method(args) format)
 pup symdb search --service my-service --query MyController --view probe-locations
 ```
 

--- a/skills/dd-debugger/SKILL.md
+++ b/skills/dd-debugger/SKILL.md
@@ -70,13 +70,13 @@ pup debugger probes delete <PROBE_ID>
 
 ## Service Context
 
-**Always run this before creating probes.** It returns JSON by default, showing environments with active instances, tracer versions, and supported probe features. If the service runs in multiple environments, ask the user which one to target — don't guess.
+**Always run this before creating probes.** It returns JSON by default (like all other commands) showing environments with active instances, tracer versions, and supported probe features. If the service runs in multiple environments, ask the user which one to target — don't guess.
 
 ```bash
-# Full JSON output (default, avoid)
+# Full JSON output (default)
 pup debugger context my-service
 
-# Compact: just the fields you need (preferably use this to avoid context bloat)
+# Compact: just the fields you need
 pup debugger context my-service --fields service,language,envs
 
 # Filter to a specific environment
@@ -117,13 +117,23 @@ pup debugger probes create \
   --capture "order.items[0].price"
 ```
 
+To disambiguate overloaded methods, pass a signature with argument types:
+
+```bash
+pup debugger probes create \
+  --service my-service \
+  --env staging \
+  --probe-location "com.example.MyClass:myMethod(int, java.lang.String)" \
+  --capture "user.name"
+```
+
 **Options:**
 
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--service` | Service name (required) | — |
 | `--env` | Environment (required) | — |
-| `--probe-location` | `TYPE:METHOD` (required) | — |
+| `--probe-location` | `TYPE:METHOD` or `TYPE:METHOD(args)` (required). The signature form disambiguates overloaded methods. | — |
 | `--language` | `java`, `python`, `dotnet`, `go` | Auto-detected from symdb |
 | `--capture EXPR` | Capture expression (repeatable). Use dot notation for fields, brackets for indexing. | None |
 | `--capture` | Without value: enable full snapshot (capture everything). | No snapshot |
@@ -300,7 +310,7 @@ pup debugger probes watch <ID> --limit 1 \
 | No events appearing | Check `--from` (default is `now`); probe may need time to instrument |
 | Instrumentation errors | Check stderr output from watch for status errors |
 | Auth error | Run `pup auth login` or set `DD_API_KEY` + `DD_APP_KEY` + `DD_SITE` |
-| Wrong method signature | Use the `dd-symdb` skill to find exact `TYPE:METHOD` values |
+| Wrong method signature | Use the `dd-symdb` skill to find exact `TYPE:METHOD` or `TYPE:METHOD(args)` values |
 
 ## References
 

--- a/skills/dd-pup/SKILL.md
+++ b/skills/dd-pup/SKILL.md
@@ -27,7 +27,7 @@ Pup CLI for Datadog API operations. Supports OAuth2 and API key auth.
 | Check SLOs | `pup slos list` |
 | On-call teams | `pup on-call teams list` |
 | Security signals | `pup security signals list --query "*" --from 24h` |
-| Inspect runtime values | `pup debugger probes create --service my-svc --env prod --probe-location com.example.MyClass:myMethod` |
+| Inspect runtime values | `pup debugger probes create --service my-svc --env prod --probe-location "com.example.MyClass:myMethod"` or `"com.example.MyClass:myMethod(String, int)"` |
 | Find probe-able methods | `pup symdb search --service my-svc --query MyController --view probe-locations` |
 | Check auth | `pup auth status` |
 | Refresh token | `pup auth refresh` |
@@ -192,10 +192,16 @@ pup debugger context my-svc --env prod
 pup symdb search --service my-svc --query MyController --view probe-locations
 
 # Place a log probe with capture expressions
+# --probe-location accepts TYPE:METHOD or TYPE:METHOD(arg1, arg2, ...) with optional signature
 pup debugger probes create --service my-svc --env prod \
   --probe-location "com.example.MyController:handleRequest" \
   --capture "request.id" --capture "request.headers" \
   --ttl 1h
+
+# With method signature (useful when the method is overloaded)
+pup debugger probes create --service my-svc --env prod \
+  --probe-location "com.example.MyController:handleRequest(String, HttpHeaders)" \
+  --capture "request.id" --ttl 1h
 
 # Watch probe events — compact output
 pup debugger probes watch <PROBE_ID> --fields "message,captures,timestamp" --timeout 60 --limit 10 --wait 5

--- a/skills/dd-symdb/SKILL.md
+++ b/skills/dd-symdb/SKILL.md
@@ -46,7 +46,7 @@ pup symdb search --service my-service --query "Controller" --view names
 
 ### Probe Locations View
 
-`TYPE:METHOD` pairs suitable for `--probe-location` in `pup debugger probes create`.
+`TYPE:METHOD(arg1, arg2, ...)` signatures suitable for `--probe-location` in `pup debugger probes create`. Falls back to `TYPE:METHOD` when no argument info is available.
 
 ```bash
 pup symdb search --service my-service --query "VetController" --view probe-locations
@@ -79,6 +79,13 @@ pup debugger probes create \
   --service my-service \
   --env production \
   --probe-location "com.example.MyController:handleRequest" \
+  --template "handleRequest called with id={id}"
+
+# Or use the full signature when multiple overloads exist
+pup debugger probes create \
+  --service my-service \
+  --env production \
+  --probe-location "com.example.MyController:handleRequest(int, java.lang.String)" \
   --template "handleRequest called with id={id}"
 
 # 3. Stream events

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,6 +9,26 @@ use reqwest_middleware::{Middleware, Next};
 
 use crate::config::Config;
 
+/// HTTP error with the status code preserved for programmatic matching.
+#[derive(Debug)]
+pub struct HttpError {
+    pub status: u16,
+    pub method: String,
+    pub url: String,
+    pub body: String,
+}
+
+impl std::fmt::Display for HttpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} {} failed (HTTP {}): {}",
+            self.method, self.url, self.status, self.body
+        )
+    }
+}
+
+impl std::error::Error for HttpError {}
 #[cfg(not(target_arch = "wasm32"))]
 struct BearerAuthMiddleware {
     token: String,
@@ -727,7 +747,7 @@ pub async fn raw_request(
     let client = reqwest::Client::new();
     let method_name = method.to_uppercase();
     let method = reqwest::Method::from_bytes(method_name.as_bytes())
-        .map_err(|_| anyhow::anyhow!("unsupported HTTP method: {method}"))?;
+        .map_err(|_| anyhow::anyhow!("unsupported HTTP method: {method_name}"))?;
     let mut req = client.request(method, &url);
     if !query.is_empty() {
         req = req.query(query);
@@ -754,7 +774,13 @@ pub async fn raw_request(
     if !resp.status().is_success() {
         let status = resp.status();
         let text = resp.text().await.unwrap_or_default();
-        anyhow::bail!("API error (HTTP {status}): {text}");
+        return Err(HttpError {
+            status: status.as_u16(),
+            method: method_name,
+            url,
+            body: text,
+        }
+        .into());
     }
 
     let resp_ct = resp
@@ -804,7 +830,13 @@ pub async fn raw_get(
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
-        anyhow::bail!("GET {url} failed (HTTP {status}): {body}");
+        return Err(HttpError {
+            status: status.as_u16(),
+            method: "GET".into(),
+            url,
+            body,
+        }
+        .into());
     }
     Ok(resp.json().await?)
 }
@@ -833,7 +865,13 @@ pub async fn raw_patch(
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
-        anyhow::bail!("PATCH {url} failed (HTTP {status}): {body}");
+        return Err(HttpError {
+            status: status.as_u16(),
+            method: "PATCH".into(),
+            url,
+            body,
+        }
+        .into());
     }
     Ok(resp.json().await?)
 }
@@ -882,7 +920,13 @@ async fn raw_post_impl(
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
-        anyhow::bail!("POST {url} failed (HTTP {status}): {body}");
+        return Err(HttpError {
+            status: status.as_u16(),
+            method: "POST".into(),
+            url: url.to_string(),
+            body,
+        }
+        .into());
     }
     Ok(resp.json().await?)
 }
@@ -1008,7 +1052,13 @@ pub async fn raw_delete(cfg: &Config, path: &str) -> anyhow::Result<()> {
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
-        anyhow::bail!("DELETE {url} failed (HTTP {status}): {body}");
+        return Err(HttpError {
+            status: status.as_u16(),
+            method: "DELETE".into(),
+            url,
+            body,
+        }
+        .into());
     }
     Ok(())
 }

--- a/src/commands/debugger.rs
+++ b/src/commands/debugger.rs
@@ -91,6 +91,7 @@ struct ResolvedProbe<'a> {
     env: &'a str,
     type_name: &'a str,
     method_name: &'a str,
+    signature: Option<&'a str>,
     language: &'a str,
     template_str: String,
     segments: serde_json::Value,
@@ -207,12 +208,16 @@ fn build_probe_payload(p: &ResolvedProbe<'_>) -> serde_json::Value {
         "language": p.language,
         "where": {
             "type_name": p.type_name,
-            "method_name": p.method_name
+            "method_name": p.method_name,
         },
         "evaluate_at": "EXIT",
         "tags": [],
         "version": 0
     });
+
+    if let Some(sig) = p.signature {
+        probe["where"]["signature"] = serde_json::json!(sig);
+    }
 
     if let Some(w) = &p.when {
         probe["when"] = w.clone();
@@ -286,9 +291,15 @@ pub async fn probes_create(cfg: &Config, params: ProbeCreateParams<'_>) -> Resul
         None
     };
 
-    let (type_name, method_name) = probe_location
+    let (type_name, method_part) = probe_location
         .rsplit_once(':')
         .ok_or_else(|| anyhow::anyhow!("probe_location must be in format TYPE:METHOD"))?;
+
+    // Split optional signature: "myMethod(int,int)" → method="myMethod", sig="(int,int)"
+    let (method_name, signature) = match method_part.find('(') {
+        Some(i) => (&method_part[..i], Some(&method_part[i..])),
+        None => (method_part, None),
+    };
 
     // Parse condition if provided
     let when = if let Some(cond) = condition {
@@ -340,6 +351,7 @@ pub async fn probes_create(cfg: &Config, params: ProbeCreateParams<'_>) -> Resul
         env,
         type_name,
         method_name,
+        signature,
         language,
         template_str,
         segments,
@@ -730,6 +742,7 @@ mod tests {
             env: "staging",
             type_name: "com.example.MyClass",
             method_name: "myMethod",
+            signature: None,
             language: "java",
             template_str,
             segments,
@@ -994,6 +1007,61 @@ mod tests {
         let out = extract_create_fields(&resp, "id,bogus");
         assert_eq!(out["id"], "082b17fd-c75c-4ab0-8426-3456b98d7600");
         assert!(out.get("bogus").is_none());
+    }
+
+    #[test]
+    fn test_probe_location_parsing_plain() {
+        let loc = "com.example.MyClass:myMethod";
+        let (_, method_part) = loc.rsplit_once(':').unwrap();
+        let (method_name, signature) = match method_part.find('(') {
+            Some(i) => (&method_part[..i], Some(&method_part[i..])),
+            None => (method_part, None),
+        };
+        assert_eq!(method_name, "myMethod");
+        assert_eq!(signature, None);
+    }
+
+    #[test]
+    fn test_probe_location_parsing_with_signature() {
+        let loc = "com.example.MyClass:myMethod(int,java.lang.String)";
+        let (type_name, method_part) = loc.rsplit_once(':').unwrap();
+        let (method_name, signature) = match method_part.find('(') {
+            Some(i) => (&method_part[..i], Some(&method_part[i..])),
+            None => (method_part, None),
+        };
+        assert_eq!(type_name, "com.example.MyClass");
+        assert_eq!(method_name, "myMethod");
+        assert_eq!(signature, Some("(int,java.lang.String)"));
+    }
+
+    #[test]
+    fn test_probe_location_parsing_empty_args() {
+        let loc = "com.example.MyClass:myMethod()";
+        let (_, method_part) = loc.rsplit_once(':').unwrap();
+        let (method_name, signature) = match method_part.find('(') {
+            Some(i) => (&method_part[..i], Some(&method_part[i..])),
+            None => (method_part, None),
+        };
+        assert_eq!(method_name, "myMethod");
+        assert_eq!(signature, Some("()"));
+    }
+
+    #[test]
+    fn test_build_probe_payload_no_signature() {
+        let payload = test_resolved_probe(|_| {});
+        let where_block = &payload["data"]["attributes"]["probe"]["where"];
+        assert!(where_block.get("signature").is_none());
+    }
+
+    #[test]
+    fn test_build_probe_payload_with_signature() {
+        let payload = test_resolved_probe(|rp| {
+            rp.signature = Some("(int,java.lang.String)");
+        });
+        let where_block = &payload["data"]["attributes"]["probe"]["where"];
+        assert_eq!(where_block["type_name"], "com.example.MyClass");
+        assert_eq!(where_block["method_name"], "myMethod");
+        assert_eq!(where_block["signature"], "(int,java.lang.String)");
     }
 
     fn sample_context_response() -> serde_json::Value {

--- a/src/commands/symdb.rs
+++ b/src/commands/symdb.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use anyhow::Result;
 
 use crate::client;
@@ -22,9 +24,32 @@ impl std::fmt::Display for SymdbView {
     }
 }
 
+const MAX_RETRIES: u32 = 3;
+const RETRY_BASE_MS: u64 = 1000;
+
+/// Fetch with retries for transient server errors (502, 503, 504).
 async fn fetch(cfg: &Config, path: &str, query: &[(&str, &str)]) -> Result<serde_json::Value> {
-    client::raw_get(cfg, path, query).await
+    for attempt in 0..=MAX_RETRIES {
+        match client::raw_get(cfg, path, query).await {
+            Ok(v) => return Ok(v),
+            Err(e) => {
+                let retryable = e
+                    .downcast_ref::<client::HttpError>()
+                    .is_some_and(|h| matches!(h.status, 502..=504));
+                if !retryable || attempt == MAX_RETRIES {
+                    return Err(e);
+                }
+                let delay = RETRY_BASE_MS * 2u64.pow(attempt);
+                eprintln!("retrying in {delay}ms ({e:#})…");
+                tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+            }
+        }
+    }
+    unreachable!()
 }
+
+const POLL_INTERVAL_MS: u64 = 1000;
+const MAX_POLL_SECS: u64 = 60;
 
 pub async fn search(
     cfg: &Config,
@@ -32,8 +57,12 @@ pub async fn search(
     query: &str,
     version: Option<&str>,
     view: &SymdbView,
+    allow_partial: bool,
 ) -> Result<()> {
     let mut params: Vec<(&str, &str)> = vec![("service", service), ("query", query)];
+    if allow_partial {
+        params.push(("allow_partial", "true"));
+    }
     if let Some(v) = version {
         params.push(("version", v));
     }
@@ -46,21 +75,68 @@ pub async fn search(
             output_lines(cfg, &names)
         }
         SymdbView::ProbeLocations => {
-            let locations = collect_probe_locations(cfg, service, &data).await?;
-            output_lines(cfg, &locations)
+            let mut collector = ProbeCollector::new();
+            let mut all = collector.collect(cfg, &data).await?;
+
+            if !cfg.agent_mode {
+                print_lines(&all);
+            }
+
+            // Re-poll while any service-version is still indexing.
+            if !all_indexing_complete(&data) {
+                let deadline =
+                    std::time::Instant::now() + std::time::Duration::from_secs(MAX_POLL_SECS);
+                loop {
+                    tokio::time::sleep(std::time::Duration::from_millis(POLL_INTERVAL_MS)).await;
+                    let data =
+                        fetch(cfg, "/api/unstable/symdb-api/v2/scopes/search", &params).await?;
+                    let new = collector.collect(cfg, &data).await?;
+                    if !new.is_empty() {
+                        if !cfg.agent_mode {
+                            print_lines(&new);
+                        }
+                        all.extend(new);
+                    }
+                    if all_indexing_complete(&data) || std::time::Instant::now() >= deadline {
+                        break;
+                    }
+                }
+            }
+
+            if cfg.agent_mode {
+                output_lines(cfg, &all)
+            } else {
+                Ok(())
+            }
         }
     }
+}
+
+fn print_lines(lines: &[String]) {
+    for line in lines {
+        println!("{line}");
+    }
+}
+
+/// Returns true when every service-version in the response has finished indexing.
+fn all_indexing_complete(data: &serde_json::Value) -> bool {
+    let Some(items) = data["data"].as_array() else {
+        return true;
+    };
+    items.iter().all(|item| {
+        matches!(
+            item["attributes"]["indexing_status"].as_str(),
+            Some("COMPLETED" | "SOME_FAILED" | "ALL_FAILED" | "NO_ATTACHMENTS") | None
+        )
+    })
 }
 
 /// In agent mode, emit a structured envelope; otherwise print one line per item.
 fn output_lines(cfg: &Config, lines: &[String]) -> Result<()> {
     if cfg.agent_mode {
-        let v = lines.to_vec();
-        return formatter::output(cfg, &v);
+        return formatter::output(cfg, &lines.to_vec());
     }
-    for line in lines {
-        println!("{line}");
-    }
+    print_lines(lines);
     Ok(())
 }
 
@@ -84,22 +160,21 @@ fn collect_names(data: &serde_json::Value) -> Vec<String> {
 }
 
 #[cfg(feature = "native")]
-async fn fetch_children_bulk(
-    cfg: &Config,
-    service: &str,
-    class_names: &[&str],
-) -> Vec<Result<serde_json::Value>> {
+async fn fetch_children_bulk(cfg: &Config, scope_ids: &[&str]) -> Vec<Result<serde_json::Value>> {
     let sem = std::sync::Arc::new(tokio::sync::Semaphore::new(20));
-    let futs: Vec<_> = class_names
+    let futs: Vec<_> = scope_ids
         .iter()
-        .map(|name| {
-            let service = service.to_string();
-            let name = name.to_string();
+        .map(|id| {
+            let id = id.to_string();
             let sem = sem.clone();
             async move {
                 let _permit = sem.acquire().await;
-                let query = [("service", service.as_str()), ("scope_name", name.as_str())];
-                fetch(cfg, "/api/unstable/symdb-api/v2/scopes/children", &query).await
+                fetch(
+                    cfg,
+                    &format!("/api/unstable/symdb-api/v2/scopes/{id}/children"),
+                    &[],
+                )
+                .await
             }
         })
         .collect();
@@ -107,86 +182,121 @@ async fn fetch_children_bulk(
 }
 
 #[cfg(not(feature = "native"))]
-async fn fetch_children_bulk(
-    cfg: &Config,
-    service: &str,
-    class_names: &[&str],
-) -> Vec<Result<serde_json::Value>> {
-    let mut results = Vec::with_capacity(class_names.len());
-    for name in class_names {
-        let query = [("service", service), ("scope_name", name)];
-        results.push(fetch(cfg, "/api/unstable/symdb-api/v2/scopes/children", &query).await);
+async fn fetch_children_bulk(cfg: &Config, scope_ids: &[&str]) -> Vec<Result<serde_json::Value>> {
+    let mut results = Vec::with_capacity(scope_ids.len());
+    for id in scope_ids {
+        results.push(
+            fetch(
+                cfg,
+                &format!("/api/unstable/symdb-api/v2/scopes/{id}/children"),
+                &[],
+            )
+            .await,
+        );
     }
     results
 }
 
-async fn collect_probe_locations(
-    cfg: &Config,
-    service: &str,
-    data: &serde_json::Value,
-) -> Result<Vec<String>> {
-    let Some(items) = data["data"].as_array() else {
-        return Ok(Vec::new());
-    };
+/// Build a probe location string from a scope entry's probe_location and symbols.
+/// Extracts ARG-type symbols to produce `type:method(argType1,argType2,...)`.
+/// Falls back to `type:method` when no ARG symbols are present.
+fn format_probe_location(scope: &serde_json::Value, type_name: &str, method_name: &str) -> String {
+    if let Some(symbols) = scope["scope"]["symbols"].as_array() {
+        let arg_types: Vec<&str> = symbols
+            .iter()
+            .filter(|s| s["symbol_type"].as_str() == Some("ARG"))
+            .filter_map(|s| s["type"].as_str())
+            .collect();
+        if !arg_types.is_empty() {
+            return format!("{type_name}:{method_name}({})", arg_types.join(", "));
+        }
+    }
+    format!("{type_name}:{method_name}")
+}
 
-    // First pass: collect direct probe locations and class names that need
-    // a children lookup.
-    let mut seen = std::collections::HashSet::new();
-    let mut lines: Vec<String> = Vec::new();
-    let mut class_names: Vec<&str> = Vec::new();
+/// Tracks state across polls so we don't re-fetch children for classes we've already expanded.
+struct ProbeCollector {
+    seen_locations: HashSet<String>,
+    seen_class_ids: HashSet<String>,
+}
 
-    for item in items {
-        let Some(scopes) = item["attributes"]["scopes"].as_array() else {
-            continue;
-        };
-        for s in scopes {
-            let scope_type = s["scope"]["scope_type"].as_str().unwrap_or("");
-            let pl = &s["probe_location"];
-
-            if !pl.is_null() {
-                if let (Some(t), Some(m)) = (pl["type_name"].as_str(), pl["method_name"].as_str()) {
-                    let loc = format!("{t}:{m}");
-                    if seen.insert(loc.clone()) {
-                        lines.push(loc);
-                    }
-                }
-            } else if scope_type == "CLASS" {
-                if let Some(name) = s["scope"]["name"].as_str() {
-                    class_names.push(name);
-                }
-            }
+impl ProbeCollector {
+    fn new() -> Self {
+        Self {
+            seen_locations: HashSet::new(),
+            seen_class_ids: HashSet::new(),
         }
     }
 
-    // Fetch children for all classes.
-    let results = fetch_children_bulk(cfg, service, &class_names).await;
-
-    for result in results {
-        let Ok(children) = result else { continue };
-        let Some(child_items) = children["data"].as_array() else {
-            continue;
+    /// Extract probe locations from a search response. Returns only new locations.
+    async fn collect(&mut self, cfg: &Config, data: &serde_json::Value) -> Result<Vec<String>> {
+        let Some(items) = data["data"].as_array() else {
+            return Ok(Vec::new());
         };
-        for child_item in child_items {
-            let Some(child_scopes) = child_item["attributes"]["scopes"].as_array() else {
+
+        let mut lines: Vec<String> = Vec::new();
+        let mut new_class_ids: Vec<&str> = Vec::new();
+
+        for item in items {
+            let Some(scopes) = item["attributes"]["scopes"].as_array() else {
                 continue;
             };
-            for cs in child_scopes {
-                let cpl = &cs["probe_location"];
-                if cpl.is_null() {
-                    continue;
-                }
-                if let (Some(t), Some(m)) = (cpl["type_name"].as_str(), cpl["method_name"].as_str())
-                {
-                    let loc = format!("{t}:{m}");
-                    if seen.insert(loc.clone()) {
-                        lines.push(loc);
+            for s in scopes {
+                let scope_type = s["scope"]["scope_type"].as_str().unwrap_or("");
+                let pl = &s["probe_location"];
+
+                if !pl.is_null() {
+                    if let (Some(t), Some(m)) =
+                        (pl["type_name"].as_str(), pl["method_name"].as_str())
+                    {
+                        let loc = format_probe_location(s, t, m);
+                        if self.seen_locations.insert(loc.clone()) {
+                            lines.push(loc);
+                        }
+                    }
+                } else if scope_type == "CLASS" {
+                    if let Some(id) = s["scope"]["id"].as_str() {
+                        if self.seen_class_ids.insert(id.to_string()) {
+                            new_class_ids.push(id);
+                        }
                     }
                 }
             }
         }
-    }
 
-    Ok(lines)
+        // Fetch children only for newly discovered classes.
+        if !new_class_ids.is_empty() {
+            let results = fetch_children_bulk(cfg, &new_class_ids).await;
+
+            for result in results {
+                let Ok(children) = result else { continue };
+                let Some(child_items) = children["data"].as_array() else {
+                    continue;
+                };
+                for child_item in child_items {
+                    let Some(child_scopes) = child_item["attributes"]["scopes"].as_array() else {
+                        continue;
+                    };
+                    for cs in child_scopes {
+                        let cpl = &cs["probe_location"];
+                        if cpl.is_null() {
+                            continue;
+                        }
+                        if let (Some(t), Some(m)) =
+                            (cpl["type_name"].as_str(), cpl["method_name"].as_str())
+                        {
+                            let loc = format_probe_location(cs, t, m);
+                            if self.seen_locations.insert(loc.clone()) {
+                                lines.push(loc);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(lines)
+    }
 }
 
 /// Fetch the language for a service from symdb metadata.
@@ -266,6 +376,103 @@ mod tests {
     }
 
     #[test]
+    fn test_format_probe_location_with_args() {
+        let scope = serde_json::json!({
+            "scope": {
+                "symbols": [
+                    { "symbol_type": "ARG", "name": "a", "type": "int" },
+                    { "symbol_type": "ARG", "name": "b", "type": "java.lang.String" },
+                    { "symbol_type": "LOCAL", "name": "tmp", "type": "int" }
+                ]
+            }
+        });
+        assert_eq!(
+            format_probe_location(&scope, "com.example.Foo", "bar"),
+            "com.example.Foo:bar(int, java.lang.String)"
+        );
+    }
+
+    #[test]
+    fn test_format_probe_location_no_args() {
+        let scope = serde_json::json!({
+            "scope": {
+                "symbols": [
+                    { "symbol_type": "LOCAL", "name": "tmp", "type": "int" }
+                ]
+            }
+        });
+        assert_eq!(
+            format_probe_location(&scope, "com.example.Foo", "bar"),
+            "com.example.Foo:bar"
+        );
+    }
+
+    #[test]
+    fn test_format_probe_location_no_symbols() {
+        let scope = serde_json::json!({});
+        assert_eq!(
+            format_probe_location(&scope, "com.example.Foo", "bar"),
+            "com.example.Foo:bar"
+        );
+    }
+
+    #[test]
+    fn test_format_probe_location_empty_symbols() {
+        let scope = serde_json::json!({ "scope": { "symbols": [] } });
+        assert_eq!(
+            format_probe_location(&scope, "com.example.Foo", "bar"),
+            "com.example.Foo:bar"
+        );
+    }
+
+    #[test]
+    fn test_all_indexing_complete() {
+        let completed =
+            serde_json::json!({"data": [{"attributes": {"indexing_status": "COMPLETED"}}]});
+        assert!(all_indexing_complete(&completed));
+
+        let some_failed =
+            serde_json::json!({"data": [{"attributes": {"indexing_status": "SOME_FAILED"}}]});
+        assert!(all_indexing_complete(&some_failed));
+
+        let all_failed =
+            serde_json::json!({"data": [{"attributes": {"indexing_status": "ALL_FAILED"}}]});
+        assert!(all_indexing_complete(&all_failed));
+
+        let no_attach =
+            serde_json::json!({"data": [{"attributes": {"indexing_status": "NO_ATTACHMENTS"}}]});
+        assert!(all_indexing_complete(&no_attach));
+
+        let processing =
+            serde_json::json!({"data": [{"attributes": {"indexing_status": "PROCESSING"}}]});
+        assert!(!all_indexing_complete(&processing));
+
+        let requested =
+            serde_json::json!({"data": [{"attributes": {"indexing_status": "REQUESTED"}}]});
+        assert!(!all_indexing_complete(&requested));
+
+        let pending = serde_json::json!({"data": [{"attributes": {"indexing_status": "PENDING"}}]});
+        assert!(!all_indexing_complete(&pending));
+
+        // Mixed: one completed + one processing → not complete.
+        let mixed = serde_json::json!({"data": [
+            {"attributes": {"indexing_status": "COMPLETED"}},
+            {"attributes": {"indexing_status": "PROCESSING"}}
+        ]});
+        assert!(!all_indexing_complete(&mixed));
+
+        // Empty data array → complete (nothing to wait for).
+        assert!(all_indexing_complete(&serde_json::json!({"data": []})));
+
+        // Missing data key → complete.
+        assert!(all_indexing_complete(&serde_json::json!({})));
+
+        // Missing indexing_status field → complete (backward compat).
+        let no_field = serde_json::json!({"data": [{"attributes": {}}]});
+        assert!(all_indexing_complete(&no_field));
+    }
+
+    #[test]
     fn test_symdb_view_display() {
         assert_eq!(SymdbView::Full.to_string(), "full");
         assert_eq!(SymdbView::Names.to_string(), "names");
@@ -282,7 +489,15 @@ mod tests {
             r#"{"data": [{"attributes": {"scopes": [{"scope": {"name": "MyClass"}}]}}]}"#,
         )
         .await;
-        let _ = super::search(&cfg, "my-service", "MyClass", None, &super::SymdbView::Full).await;
+        let _ = super::search(
+            &cfg,
+            "my-service",
+            "MyClass",
+            None,
+            &super::SymdbView::Full,
+            true,
+        )
+        .await;
         cleanup_env();
     }
 
@@ -302,6 +517,7 @@ mod tests {
             "MyClass",
             None,
             &super::SymdbView::Names,
+            true,
         )
         .await;
         cleanup_env();
@@ -319,6 +535,7 @@ mod tests {
             "MyClass",
             None,
             &super::SymdbView::ProbeLocations,
+            true,
         )
         .await;
         cleanup_env();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1100,6 +1100,7 @@ enum Commands {
     ///
     ///   # Create a log probe
     ///   pup debugger probes create --service my-svc --env staging --probe-location com.example.MyClass:myMethod
+    ///   pup debugger probes create --service my-svc --env staging --probe-location "com.example.MyClass:myMethod(int,String)"
     ///
     ///   # Create a log probe with custom budget and TTL
     ///   pup debugger probes create --service my-svc --env staging --probe-location com.example.MyClass:myMethod --budget 500 --ttl 2h
@@ -3268,7 +3269,7 @@ enum DebuggerProbeActions {
         service: String,
         #[arg(long, help = "Environment")]
         env: String,
-        #[arg(long, help = "Probe location as type_name:method_name")]
+        #[arg(long, help = "Probe location as TYPE:METHOD or TYPE:METHOD(arg_types)")]
         probe_location: String,
         #[arg(long, help = "Tracer language (auto-detected from symdb if omitted)")]
         language: Option<String>,
@@ -3518,6 +3519,12 @@ enum SymdbActions {
         version: Option<String>,
         #[arg(long, default_value_t = commands::symdb::SymdbView::Full, help = "Output view")]
         view: commands::symdb::SymdbView,
+        #[arg(
+            long,
+            default_value_t = false,
+            help = "Disable partial results (wait for full indexing before returning)"
+        )]
+        no_allow_partial: bool,
     },
 }
 
@@ -10638,6 +10645,7 @@ async fn main_inner() -> anyhow::Result<()> {
                     query,
                     version,
                     view,
+                    no_allow_partial,
                 } => {
                     commands::symdb::search(
                         &cfg,
@@ -10645,6 +10653,7 @@ async fn main_inner() -> anyhow::Result<()> {
                         query.as_deref().unwrap_or(""),
                         version.as_deref(),
                         &view,
+                        !no_allow_partial,
                     )
                     .await?;
                 }


### PR DESCRIPTION
## Summary
Improve symdb search reliability for large services by adding retry logic, partial-result polling driven by `indexing_status`, and richer probe-location output with method signatures.

## Changes
- Add retry logic with exponential backoff for transient 502/503/504 errors (`src/client.rs`, `src/commands/symdb.rs`)
- Add `HttpError` struct preserving status codes for programmatic retry decisions (`src/client.rs`)
- Request partial results (`allow_partial=true`) and poll until every service-version reports a terminal `indexing_status` (`COMPLETED`, `SOME_FAILED`, `ALL_FAILED`, `NO_ATTACHMENTS`) with a 60s deadline (`src/commands/symdb.rs`)
- Add `--no-allow-partial` flag to disable partial results when callers prefer waiting for full indexing (`src/main.rs`, `src/commands/symdb.rs`)
- Switch `fetch_children_bulk` from `/scopes/children?scope_name=...` to `/scopes/{id}/children` (`src/commands/symdb.rs`)
- Add `format_probe_location` helper that extracts ARG-type symbols into `type:method(arg1, arg2, ...)` matching the API's `where.signature` format (`src/commands/symdb.rs`)
- Track seen locations and class IDs across polls via `ProbeCollector` to avoid duplicate children fetches (`src/commands/symdb.rs`)
- Add `signature` field to `ResolvedProbe` and pass it through to `where.signature` in probe creation payload (`src/commands/debugger.rs`)
- Both `TYPE:METHOD` and `TYPE:METHOD(args)` accepted as `--probe-location` values (`src/commands/debugger.rs`)
- Update skill docs and `docs/EXAMPLES.md` to document the new signature format

## Testing
Tested against large Java services (500–2600 probe locations). All complete within the 60s deadline, typically 12–29s depending on service size and indexing state.
