### PR TITLE
fix(security): wire --filter arg to rules list API query

### DIFF
--- a/src/commands/security.rs
+++ b/src/commands/security.rs
@@ -140,7 +140,7 @@ pub async fn findings_analyze(
     }
 }
 
-pub async fn rules_list(cfg: &Config, sort: Option<String>) -> Result<()> {
+pub async fn rules_list(cfg: &Config, filter: Option<String>, sort: Option<String>) -> Result<()> {
     let dd_cfg = client::make_dd_config(cfg);
     let api = match client::make_bearer_client(cfg) {
         Some(c) => SecurityMonitoringAPI::with_client_and_config(dd_cfg, c),
@@ -149,6 +149,9 @@ pub async fn rules_list(cfg: &Config, sort: Option<String>) -> Result<()> {
     let mut params = ListSecurityMonitoringRulesOptionalParams::default();
     if let Some(s) = sort {
         params = params.sort(parse_rule_sort(&s));
+    }
+    if let Some(f) = filter {
+        params = params.query(f);
     }
     let resp = api
         .list_security_monitoring_rules(params)

--- a/src/main.rs
+++ b/src/main.rs
@@ -9447,8 +9447,8 @@ async fn main_inner() -> anyhow::Result<()> {
             cfg.validate_auth()?;
             match action {
                 SecurityActions::Rules { action } => match action {
-                    SecurityRuleActions::List { sort, .. } => {
-                        commands::security::rules_list(&cfg, sort).await?
+                    SecurityRuleActions::List { filter, sort } => {
+                        commands::security::rules_list(&cfg, filter, sort).await?
                     }
                     SecurityRuleActions::Get { rule_id } => {
                         commands::security::rules_get(&cfg, &rule_id).await?;

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -1926,7 +1926,7 @@ async fn test_security_rules_list() {
     let mut s = mockito::Server::new_async().await;
     let cfg = test_config(&s.url());
     mock_all(&mut s, r#"{"data": []}"#).await;
-    let _ = crate::commands::security::rules_list(&cfg, None).await;
+    let _ = crate::commands::security::rules_list(&cfg, None, None).await;
     cleanup_env();
 }
 #[tokio::test]


### PR DESCRIPTION
## Summary
The `--filter` argument for `pup security rules list` was declared in the CLI but silently discarded, making it non-functional. This wires it through to the underlying API's `query` parameter.

## Changes
- Pass `filter` from `SecurityRuleActions::List` to `rules_list()` instead of discarding it with `..` (src/main.rs:9423)
- Add `filter` parameter to `rules_list()` and apply `params.query(f)` (src/commands/security.rs:31)

## Testing
- Built and verified with `cargo build`
- `cargo test`
- `cargo fmt --check` and `cargo clippy -- -D warnings` both pass
- Manual test: `./target/debug/pup security rules list --filter "type:log_detection"` returns filtered results

---
Generated with [Claude Code](https://claude.com/claude-code)