### PR TITLE
Support OAuth auth for cost and cloud cost management commands

### DIFF
--- a/src/auth/types.rs
+++ b/src/auth/types.rs
@@ -55,6 +55,7 @@ pub fn read_only_scopes() -> Vec<&'static str> {
         "bits_investigations_read",
         "cases_read",
         "ci_visibility_read",
+        "cloud_cost_management_read",
         "code_coverage_read",
         "test_optimization_read",
         "dashboards_read",
@@ -114,6 +115,9 @@ pub fn default_scopes() -> Vec<&'static str> {
         // CI Visibility
         "ci_visibility_read",
         "code_coverage_read",
+        // Cloud Cost Management
+        "cloud_cost_management_read",
+        "cloud_cost_management_write",
         "dora_metrics_write",
         "test_optimization_read",
         "test_optimization_write",
@@ -254,7 +258,7 @@ mod tests {
     #[test]
     fn test_default_scopes() {
         let scopes = default_scopes();
-        assert_eq!(scopes.len(), 77);
+        assert_eq!(scopes.len(), 79);
         assert!(scopes.contains(&"dashboards_read"));
         assert!(scopes.contains(&"monitors_read"));
         assert!(scopes.contains(&"logs_read_data"));

--- a/src/commands/cost.rs
+++ b/src/commands/cost.rs
@@ -11,8 +11,11 @@ use crate::formatter;
 use crate::util;
 
 fn make_usage_api(cfg: &Config) -> UsageMeteringV2API {
-    // Cost/billing endpoints require API key auth — no OAuth support.
-    UsageMeteringV2API::with_config(client::make_dd_config(cfg))
+    let dd_cfg = client::make_dd_config(cfg);
+    match client::make_bearer_client(cfg) {
+        Some(c) => UsageMeteringV2API::with_client_and_config(dd_cfg, c),
+        None => UsageMeteringV2API::with_config(dd_cfg),
+    }
 }
 
 pub async fn projected(cfg: &Config) -> Result<()> {
@@ -64,8 +67,11 @@ pub async fn attribution(cfg: &Config, start: String, fields: Option<String>) ->
 // ---- Cloud Cost Management — AWS CUR Config ----
 
 fn make_ccm_api(cfg: &Config) -> CloudCostManagementAPI {
-    // CCM endpoints require API key auth — no OAuth support.
-    CloudCostManagementAPI::with_config(client::make_dd_config(cfg))
+    let dd_cfg = client::make_dd_config(cfg);
+    match client::make_bearer_client(cfg) {
+        Some(c) => CloudCostManagementAPI::with_client_and_config(dd_cfg, c),
+        None => CloudCostManagementAPI::with_config(dd_cfg),
+    }
 }
 
 pub async fn aws_config_list(cfg: &Config) -> Result<()> {


### PR DESCRIPTION
## Summary

- Updates cost commands (`projected`, `by-org`, `attribution`) and cloud cost management commands (AWS/Azure/GCP config CRUD) to use OAuth bearer tokens when available, falling back to API key auth. This matches the pattern already used by `usage.rs` and most other command modules.
- Adds `cloud_cost_management_read` and `cloud_cost_management_write` to the known and default OAuth scope lists, required by the cloud cost management API endpoints.
- Updated the server-side OAuth client scopes in staging, prod, and gov.

Fixes #334

## Test plan

- [x] `cargo check` passes
- [x] `cargo test auth::types` passes (scope count updated 77 -> 79)
- [x] `pup auth login` with OAuth, then `pup cost aws-config list`, `cost azure-config list`, `cost gcp-config list` all succeed with OAuth tokens on both prod and staging
- [x] Confirmed via server-side logs that OAuth authentication succeeds for all cost/usage endpoints (`projected`, `by-org`, `attribution`)
- [x] `cost projected`, `by-org`, and `attribution` pass API-layer auth but return application-level permission errors unrelated to OAuth (org-level billing entitlement required -- not a regression from this change)
