### PR TITLE
[NOT READY] Add OAuth support to remaining 6 commands

### DIFF
--- a/src/commands/authn_mappings.rs
+++ b/src/commands/authn_mappings.rs
@@ -11,7 +11,10 @@ use crate::util;
 
 pub async fn list(cfg: &Config) -> Result<()> {
     let dd_cfg = client::make_dd_config(cfg);
-    let api = AuthNMappingsAPI::with_config(dd_cfg);
+    let api = match client::make_bearer_client(cfg) {
+        Some(c) => AuthNMappingsAPI::with_client_and_config(dd_cfg, c),
+        None => AuthNMappingsAPI::with_config(dd_cfg),
+    };
     let resp = api
         .list_authn_mappings(ListAuthNMappingsOptionalParams::default())
         .await
@@ -21,7 +24,10 @@ pub async fn list(cfg: &Config) -> Result<()> {
 
 pub async fn get(cfg: &Config, mapping_id: &str) -> Result<()> {
     let dd_cfg = client::make_dd_config(cfg);
-    let api = AuthNMappingsAPI::with_config(dd_cfg);
+    let api = match client::make_bearer_client(cfg) {
+        Some(c) => AuthNMappingsAPI::with_client_and_config(dd_cfg, c),
+        None => AuthNMappingsAPI::with_config(dd_cfg),
+    };
     let resp = api
         .get_authn_mapping(mapping_id.to_string())
         .await
@@ -32,7 +38,10 @@ pub async fn get(cfg: &Config, mapping_id: &str) -> Result<()> {
 pub async fn create(cfg: &Config, file: &str) -> Result<()> {
     let body: AuthNMappingCreateRequest = util::read_json_file(file)?;
     let dd_cfg = client::make_dd_config(cfg);
-    let api = AuthNMappingsAPI::with_config(dd_cfg);
+    let api = match client::make_bearer_client(cfg) {
+        Some(c) => AuthNMappingsAPI::with_client_and_config(dd_cfg, c),
+        None => AuthNMappingsAPI::with_config(dd_cfg),
+    };
     let resp = api
         .create_authn_mapping(body)
         .await
@@ -43,7 +52,10 @@ pub async fn create(cfg: &Config, file: &str) -> Result<()> {
 pub async fn update(cfg: &Config, mapping_id: &str, file: &str) -> Result<()> {
     let body: AuthNMappingUpdateRequest = util::read_json_file(file)?;
     let dd_cfg = client::make_dd_config(cfg);
-    let api = AuthNMappingsAPI::with_config(dd_cfg);
+    let api = match client::make_bearer_client(cfg) {
+        Some(c) => AuthNMappingsAPI::with_client_and_config(dd_cfg, c),
+        None => AuthNMappingsAPI::with_config(dd_cfg),
+    };
     let resp = api
         .update_authn_mapping(mapping_id.to_string(), body)
         .await
@@ -53,7 +65,10 @@ pub async fn update(cfg: &Config, mapping_id: &str, file: &str) -> Result<()> {
 
 pub async fn delete(cfg: &Config, mapping_id: &str) -> Result<()> {
     let dd_cfg = client::make_dd_config(cfg);
-    let api = AuthNMappingsAPI::with_config(dd_cfg);
+    let api = match client::make_bearer_client(cfg) {
+        Some(c) => AuthNMappingsAPI::with_client_and_config(dd_cfg, c),
+        None => AuthNMappingsAPI::with_config(dd_cfg),
+    };
     api.delete_authn_mapping(mapping_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete AuthN mapping: {e:?}"))?;

--- a/src/commands/data_deletion.rs
+++ b/src/commands/data_deletion.rs
@@ -10,7 +10,10 @@ use crate::util;
 
 fn make_api(cfg: &Config) -> DataDeletionAPI {
     let dd_cfg = client::make_dd_config(cfg);
-    DataDeletionAPI::with_config(dd_cfg)
+    match client::make_bearer_client(cfg) {
+        Some(c) => DataDeletionAPI::with_client_and_config(dd_cfg, c),
+        None => DataDeletionAPI::with_config(dd_cfg),
+    }
 }
 
 pub async fn requests_list(

--- a/src/commands/datasets.rs
+++ b/src/commands/datasets.rs
@@ -8,7 +8,10 @@ use crate::util;
 
 fn make_api(cfg: &Config) -> DatasetsAPI {
     let dd_cfg = client::make_dd_config(cfg);
-    DatasetsAPI::with_config(dd_cfg)
+    match client::make_bearer_client(cfg) {
+        Some(c) => DatasetsAPI::with_client_and_config(dd_cfg, c),
+        None => DatasetsAPI::with_config(dd_cfg),
+    }
 }
 
 pub async fn list(cfg: &Config) -> Result<()> {

--- a/src/commands/logs_restriction.rs
+++ b/src/commands/logs_restriction.rs
@@ -11,7 +11,10 @@ use crate::util;
 
 pub async fn list(cfg: &Config) -> Result<()> {
     let dd_cfg = client::make_dd_config(cfg);
-    let api = LogsRestrictionQueriesAPI::with_config(dd_cfg);
+    let api = match client::make_bearer_client(cfg) {
+        Some(c) => LogsRestrictionQueriesAPI::with_client_and_config(dd_cfg, c),
+        None => LogsRestrictionQueriesAPI::with_config(dd_cfg),
+    };
     let resp = api
         .list_restriction_queries(ListRestrictionQueriesOptionalParams::default())
         .await
@@ -21,7 +24,10 @@ pub async fn list(cfg: &Config) -> Result<()> {
 
 pub async fn get(cfg: &Config, query_id: &str) -> Result<()> {
     let dd_cfg = client::make_dd_config(cfg);
-    let api = LogsRestrictionQueriesAPI::with_config(dd_cfg);
+    let api = match client::make_bearer_client(cfg) {
+        Some(c) => LogsRestrictionQueriesAPI::with_client_and_config(dd_cfg, c),
+        None => LogsRestrictionQueriesAPI::with_config(dd_cfg),
+    };
     let resp = api
         .get_restriction_query(query_id.to_string())
         .await
@@ -31,7 +37,10 @@ pub async fn get(cfg: &Config, query_id: &str) -> Result<()> {
 
 pub async fn create(cfg: &Config, file: &str) -> Result<()> {
     let dd_cfg = client::make_dd_config(cfg);
-    let api = LogsRestrictionQueriesAPI::with_config(dd_cfg);
+    let api = match client::make_bearer_client(cfg) {
+        Some(c) => LogsRestrictionQueriesAPI::with_client_and_config(dd_cfg, c),
+        None => LogsRestrictionQueriesAPI::with_config(dd_cfg),
+    };
     let body = util::read_json_file(file)?;
     let resp = api
         .create_restriction_query(body)
@@ -42,7 +51,10 @@ pub async fn create(cfg: &Config, file: &str) -> Result<()> {
 
 pub async fn update(cfg: &Config, query_id: &str, file: &str) -> Result<()> {
     let dd_cfg = client::make_dd_config(cfg);
-    let api = LogsRestrictionQueriesAPI::with_config(dd_cfg);
+    let api = match client::make_bearer_client(cfg) {
+        Some(c) => LogsRestrictionQueriesAPI::with_client_and_config(dd_cfg, c),
+        None => LogsRestrictionQueriesAPI::with_config(dd_cfg),
+    };
     let body = util::read_json_file(file)?;
     let resp = api
         .update_restriction_query(query_id.to_string(), body)
@@ -53,7 +65,10 @@ pub async fn update(cfg: &Config, query_id: &str, file: &str) -> Result<()> {
 
 pub async fn delete(cfg: &Config, query_id: &str) -> Result<()> {
     let dd_cfg = client::make_dd_config(cfg);
-    let api = LogsRestrictionQueriesAPI::with_config(dd_cfg);
+    let api = match client::make_bearer_client(cfg) {
+        Some(c) => LogsRestrictionQueriesAPI::with_client_and_config(dd_cfg, c),
+        None => LogsRestrictionQueriesAPI::with_config(dd_cfg),
+    };
     api.delete_restriction_query(query_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete restriction query: {e:?}"))?;
@@ -63,7 +78,10 @@ pub async fn delete(cfg: &Config, query_id: &str) -> Result<()> {
 
 pub async fn roles_list(cfg: &Config, query_id: &str) -> Result<()> {
     let dd_cfg = client::make_dd_config(cfg);
-    let api = LogsRestrictionQueriesAPI::with_config(dd_cfg);
+    let api = match client::make_bearer_client(cfg) {
+        Some(c) => LogsRestrictionQueriesAPI::with_client_and_config(dd_cfg, c),
+        None => LogsRestrictionQueriesAPI::with_config(dd_cfg),
+    };
     let resp = api
         .list_restriction_query_roles(
             query_id.to_string(),
@@ -76,7 +94,10 @@ pub async fn roles_list(cfg: &Config, query_id: &str) -> Result<()> {
 
 pub async fn roles_add(cfg: &Config, query_id: &str, file: &str) -> Result<()> {
     let dd_cfg = client::make_dd_config(cfg);
-    let api = LogsRestrictionQueriesAPI::with_config(dd_cfg);
+    let api = match client::make_bearer_client(cfg) {
+        Some(c) => LogsRestrictionQueriesAPI::with_client_and_config(dd_cfg, c),
+        None => LogsRestrictionQueriesAPI::with_config(dd_cfg),
+    };
     let body = util::read_json_file(file)?;
     api.add_role_to_restriction_query(query_id.to_string(), body)
         .await

--- a/src/commands/obs_pipelines.rs
+++ b/src/commands/obs_pipelines.rs
@@ -10,8 +10,11 @@ use crate::formatter;
 use crate::util;
 
 fn make_api(cfg: &Config) -> ObservabilityPipelinesAPI {
-    // Observability Pipelines does not support OAuth — API key auth only.
-    ObservabilityPipelinesAPI::with_config(client::make_dd_config(cfg))
+    let dd_cfg = client::make_dd_config(cfg);
+    match client::make_bearer_client(cfg) {
+        Some(c) => ObservabilityPipelinesAPI::with_client_and_config(dd_cfg, c),
+        None => ObservabilityPipelinesAPI::with_config(dd_cfg),
+    }
 }
 
 pub async fn list(cfg: &Config, limit: i64) -> Result<()> {

--- a/src/commands/workflows.rs
+++ b/src/commands/workflows.rs
@@ -12,12 +12,15 @@ use crate::formatter::{self, Metadata};
 use crate::util;
 
 // ---------------------------------------------------------------------------
-// Helper: build a WorkflowAutomationAPI (API key auth only)
+// Helper: build a WorkflowAutomationAPI
 // ---------------------------------------------------------------------------
 
 fn make_api(cfg: &Config) -> WorkflowAutomationAPI {
     let dd_cfg = client::make_dd_config(cfg);
-    WorkflowAutomationAPI::with_config(dd_cfg)
+    match client::make_bearer_client(cfg) {
+        Some(c) => WorkflowAutomationAPI::with_client_and_config(dd_cfg, c),
+        None => WorkflowAutomationAPI::with_config(dd_cfg),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -65,7 +68,7 @@ pub async fn delete(cfg: &Config, workflow_id: &str) -> Result<()> {
 }
 
 // ---------------------------------------------------------------------------
-// Workflow execution (API trigger only — requires DD_API_KEY + DD_APP_KEY)
+// Workflow execution
 // ---------------------------------------------------------------------------
 
 pub async fn run(
@@ -77,7 +80,10 @@ pub async fn run(
     timeout: &str,
 ) -> Result<()> {
     let dd_cfg = client::make_dd_config(cfg);
-    let api = WorkflowAutomationAPI::with_config(dd_cfg);
+    let api = match client::make_bearer_client(cfg) {
+        Some(c) => WorkflowAutomationAPI::with_client_and_config(dd_cfg, c),
+        None => WorkflowAutomationAPI::with_config(dd_cfg),
+    };
 
     let input_payload: Option<BTreeMap<String, serde_json::Value>> = match (&payload, &payload_file)
     {
@@ -136,7 +142,10 @@ pub async fn run(
         tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
         let dd_cfg = client::make_dd_config(cfg);
-        let api = WorkflowAutomationAPI::with_config(dd_cfg);
+        let api = match client::make_bearer_client(cfg) {
+            Some(c) => WorkflowAutomationAPI::with_client_and_config(dd_cfg, c),
+            None => WorkflowAutomationAPI::with_config(dd_cfg),
+        };
         let status = api
             .get_workflow_instance(workflow_id.to_string(), instance_id.clone())
             .await
@@ -217,7 +226,10 @@ pub async fn instance_cancel(cfg: &Config, workflow_id: &str, instance_id: &str)
 
 fn make_connection_api(cfg: &Config) -> ActionConnectionAPI {
     let dd_cfg = client::make_dd_config(cfg);
-    ActionConnectionAPI::with_config(dd_cfg)
+    match client::make_bearer_client(cfg) {
+        Some(c) => ActionConnectionAPI::with_client_and_config(dd_cfg, c),
+        None => ActionConnectionAPI::with_config(dd_cfg),
+    }
 }
 
 pub async fn connections_get(cfg: &Config, connection_id: &str) -> Result<()> {


### PR DESCRIPTION
## Summary

- Add OAuth bearer token support to the 6 remaining command files that only supported API+App key auth: `authn_mappings`, `data_deletion`, `datasets`, `logs_restriction`, `obs_pipelines`, and `workflows`
- Apply the same `make_bearer_client` pattern used everywhere else in the codebase, so these commands use OAuth when the user authenticates via `pup auth login`
- Remove stale comments about "API key auth only" / "no OAuth support"
- Follows up on PR #341 which fixed this for `cost.rs`

Note: some of these API endpoints do not yet support `ValidOAuthAccessToken` on the server side. The client-side change is still correct -- pup should always prefer OAuth and fall back to API key auth. As the server-side routes are updated to accept OAuth, these commands will automatically work without further client changes.

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` passes (744 tests)
- [x] `cargo fmt` produces no changes
- [x] `datasets`: OAuth token sent and accepted by server (auth succeeded), confirming the client-side plumbing works end-to-end
- [x] `authn_mappings`, `data_deletion`, `logs_restriction`, `obs_pipelines`: OAuth token sent correctly (confirmed via server logs), but these routes don't yet accept `ValidOAuthAccessToken` server-side -- will need server-side route updates
- [x] `workflows`: has a client-side check that blocks OAuth -- will need a separate change to remove that restriction
- [x] Fallback path: all commands continue to work with API key auth when no OAuth token is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)