### PR TITLE
feat(ddsql): add command tag to User-Agent and fix async polling

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -724,13 +724,25 @@ pub async fn raw_post(
     body: serde_json::Value,
 ) -> anyhow::Result<serde_json::Value> {
     let url = format!("{}{}", cfg.api_base_url(), path);
-    raw_post_with_url(cfg, &url, body).await
+    raw_post_impl(cfg, &url, body, useragent::get()).await
 }
 
-async fn raw_post_with_url(
+/// Like `raw_post`, but with a custom User-Agent string for audit log differentiation.
+pub async fn raw_post_with_ua(
+    cfg: &Config,
+    path: &str,
+    body: serde_json::Value,
+    ua: String,
+) -> anyhow::Result<serde_json::Value> {
+    let url = format!("{}{}", cfg.api_base_url(), path);
+    raw_post_impl(cfg, &url, body, ua).await
+}
+
+async fn raw_post_impl(
     cfg: &Config,
     url: &str,
     body: serde_json::Value,
+    ua: String,
 ) -> anyhow::Result<serde_json::Value> {
     let client = reqwest::Client::new();
     let mut req = client.post(url);
@@ -748,7 +760,7 @@ async fn raw_post_with_url(
     let resp = req
         .header("Content-Type", "application/json")
         .header("Accept", "application/json")
-        .header("User-Agent", useragent::get())
+        .header("User-Agent", ua)
         .json(&body)
         .send()
         .await?;

--- a/src/commands/ddsql.rs
+++ b/src/commands/ddsql.rs
@@ -96,19 +96,30 @@ fn extract_query_status(resp: &Value) -> Result<Option<String>> {
 /// Build a polling request for an in-progress async query.
 ///
 /// Endpoint: POST /api/unstable/advanced/query/tabular/fetch
-/// Same shape as the originating request, but with an additional `query_id` in attributes.
+/// Same shape as the originating request, but with `query_id` added and the type
+/// changed to `advanced_query_fetch_request` (the fetch endpoint rejects the
+/// original `analysis_workspace_query_request` type).
 fn build_fetch_request(base_body: &Value, query_id: &str) -> Value {
     let mut fetch_body = base_body.clone();
     fetch_body["data"]["attributes"]["query_id"] = json!(query_id);
+    fetch_body["data"]["type"] = json!("advanced_query_fetch_request");
     fetch_body
 }
 
 /// Submit an async query and poll until completion.
 ///
 /// Sends the initial request and, if the query is still running, polls the fetch
-/// endpoint until the query completes.
-async fn execute_async_query(cfg: &Config, body: Value) -> Result<Value> {
-    let resp = client::raw_post(cfg, "/api/unstable/advanced/query/tabular", body.clone()).await?;
+/// endpoint until the query completes. When `command` is provided, it is appended
+/// to the User-Agent header for audit log differentiation.
+async fn execute_async_query(cfg: &Config, body: Value, command: Option<&str>) -> Result<Value> {
+    let ua = useragent::get_with_command(command);
+    let resp = client::raw_post_with_ua(
+        cfg,
+        "/api/unstable/advanced/query/tabular",
+        body.clone(),
+        ua.clone(),
+    )
+    .await?;
 
     let mut query_id = match extract_query_status(&resp)? {
         None => return Ok(resp),
@@ -119,10 +130,11 @@ async fn execute_async_query(cfg: &Config, body: Value) -> Result<Value> {
         tokio::time::sleep(Duration::from_secs(1)).await;
 
         let fetch_body = build_fetch_request(&body, &query_id);
-        let poll_resp = client::raw_post(
+        let poll_resp = client::raw_post_with_ua(
             cfg,
             "/api/unstable/advanced/query/tabular/fetch",
             fetch_body,
+            ua.clone(),
         )
         .await?;
 
@@ -136,6 +148,7 @@ async fn execute_async_query(cfg: &Config, body: Value) -> Result<Value> {
 /// Execute a DDSQL query and return the result as a row-based JSON array.
 ///
 /// Shared function used by both `ddsql table` and `security findings-analyze`.
+/// Pass `command` to tag the User-Agent for audit log differentiation.
 pub async fn execute_ddsql_query(
     cfg: &Config,
     query: &str,
@@ -143,8 +156,20 @@ pub async fn execute_ddsql_query(
     to: &str,
     limit: Option<i32>,
 ) -> Result<Value> {
+    execute_ddsql_query_with_command(cfg, query, from, to, limit, None).await
+}
+
+/// Like `execute_ddsql_query`, but with a command identifier appended to the User-Agent.
+pub async fn execute_ddsql_query_with_command(
+    cfg: &Config,
+    query: &str,
+    from: &str,
+    to: &str,
+    limit: Option<i32>,
+    command: Option<&str>,
+) -> Result<Value> {
     let body = build_advanced_table_request(query, from, to, limit)?;
-    let data = execute_async_query(cfg, body).await?;
+    let data = execute_async_query(cfg, body, command).await?;
     columnar_to_rows(&data)
 }
 
@@ -170,7 +195,7 @@ pub async fn time_series(
     limit: i32,
 ) -> Result<()> {
     let body = build_advanced_table_request(query, from, to, Some(limit))?;
-    let data = execute_async_query(cfg, body).await?;
+    let data = execute_async_query(cfg, body, None).await?;
     let rows = columnar_to_rows(&data)?;
     formatter::output(cfg, &rows)
 }
@@ -388,6 +413,8 @@ mod tests {
         let base = build_advanced_table_request("SELECT 1", "1h", "now", None).unwrap();
         let fetch = build_fetch_request(&base, "qid-456");
         assert_eq!(fetch["data"]["attributes"]["query_id"], "qid-456");
+        // Type must change to advanced_query_fetch_request for the fetch endpoint.
+        assert_eq!(fetch["data"]["type"], "advanced_query_fetch_request");
         // Original fields are preserved.
         assert_eq!(
             fetch["data"]["attributes"]["datasets"][0]["query"]["sql_query"],

--- a/src/commands/security.rs
+++ b/src/commands/security.rs
@@ -129,7 +129,16 @@ pub async fn findings_analyze(
         eprintln!("Warning: query doesn't use dd.security_findings(). Did you mean to use `pup ddsql table`?");
     }
 
-    match ddsql::execute_ddsql_query(cfg, query, from, to, Some(limit as i32)).await {
+    match ddsql::execute_ddsql_query_with_command(
+        cfg,
+        query,
+        from,
+        to,
+        Some(limit as i32),
+        Some("security-findings-analyze"),
+    )
+    .await
+    {
         Ok(rows) => formatter::output(cfg, &rows),
         Err(e) => {
             let msg = e.to_string();

--- a/src/useragent.rs
+++ b/src/useragent.rs
@@ -93,6 +93,12 @@ pub fn is_agent_mode() -> bool {
 
 #[allow(dead_code)]
 pub fn get() -> String {
+    get_with_command(None)
+}
+
+/// Build the User-Agent string, optionally including a command identifier
+/// so that audit logs can differentiate which pup command made the request.
+pub fn get_with_command(command: Option<&str>) -> String {
     let agent = detect_agent_info();
     let base = format!(
         "pup/{} (rust; os {}; arch {}",
@@ -100,10 +106,15 @@ pub fn get() -> String {
         std::env::consts::OS,
         std::env::consts::ARCH,
     );
-    if agent.detected {
-        format!("{}; ai-agent {})", base, agent.name)
+    let with_agent = if agent.detected {
+        format!("{}; ai-agent {}", base, agent.name)
     } else {
-        format!("{})", base)
+        base
+    };
+    if let Some(cmd) = command {
+        format!("{}; cmd {})", with_agent, cmd)
+    } else {
+        format!("{})", with_agent)
     }
 }
 
@@ -138,6 +149,21 @@ mod tests {
         assert!(ua.contains("rust"));
         assert!(ua.contains("os "));
         assert!(ua.contains("arch "));
+        assert!(!ua.contains("cmd "));
+    }
+
+    #[test]
+    fn test_user_agent_with_command() {
+        let ua = get_with_command(Some("security-findings-analyze"));
+        assert!(ua.starts_with("pup/"));
+        assert!(ua.contains("; cmd security-findings-analyze)"));
+    }
+
+    #[test]
+    fn test_user_agent_with_no_command() {
+        let ua = get_with_command(None);
+        assert!(!ua.contains("cmd "));
+        assert_eq!(ua, get());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Adds per-command User-Agent tagging for audit log differentiation and fixes a bug where async DDSQL queries failed on the fetch/polling endpoint.

## Changes
- **User-Agent command tagging**: `findings analyze` now sends `; cmd security-findings-analyze` in the UA header, so dashboards can filter with `@http.useragent:*cmd security-findings-analyze*`
- **Fix async polling**: The fetch endpoint expects `"type": "advanced_query_fetch_request"` but we were sending `"analysis_workspace_query_request"`, causing 400 errors on queries that go async
- **New helpers**: `useragent::get_with_command()`, `client::raw_post_with_ua()`, `ddsql::execute_ddsql_query_with_command()` — all backwards-compatible, existing callers unchanged

## Test plan
- [x] `cargo test` — 746 pass (3 new tests)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Verified UA in audit logs contains `cmd security-findings-analyze`
- [x] Verified async DDSQL polling works end-to-end (was broken before this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)