### PR TITLE
feat(agent): add --no-agent flag to force-disable agent mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8520,9 +8520,13 @@ mod test_agent_schema {
     #[test]
     fn global_flags_include_no_agent() {
         let schema = get_schema();
-        let flags = schema["global_flags"].as_array().expect("global_flags missing");
+        let flags = schema["global_flags"]
+            .as_array()
+            .expect("global_flags missing");
         assert!(
-            flags.iter().any(|f| f["name"].as_str() == Some("--no-agent")),
+            flags
+                .iter()
+                .any(|f| f["name"].as_str() == Some("--no-agent")),
             "global_flags must include --no-agent"
         );
     }
@@ -8535,9 +8539,13 @@ mod test_agent_schema {
             .find(|s| s.get_name() == "monitors")
             .expect("monitors subcommand not found");
         let schema = build_agent_schema_scoped(&cmd, monitors_cmd, &["monitors"]);
-        let flags = schema["global_flags"].as_array().expect("global_flags missing");
+        let flags = schema["global_flags"]
+            .as_array()
+            .expect("global_flags missing");
         assert!(
-            flags.iter().any(|f| f["name"].as_str() == Some("--no-agent")),
+            flags
+                .iter()
+                .any(|f| f["name"].as_str() == Some("--no-agent")),
             "scoped schema global_flags must include --no-agent"
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,9 @@ pub(crate) struct Cli {
     /// Enable agent mode
     #[arg(long, global = true)]
     agent: bool,
+    /// Disable agent mode (overrides auto-detection and --agent)
+    #[arg(long, global = true)]
+    no_agent: bool,
     /// Block all write operations (create, update, delete)
     #[arg(long, global = true)]
     read_only: bool,
@@ -7877,6 +7880,12 @@ fn build_agent_schema_scoped(
                 "description": "Enable agent mode (auto-detected for AI coding assistants)"
             },
             {
+                "name": "--no-agent",
+                "type": "bool",
+                "default": "false",
+                "description": "Disable agent mode (overrides auto-detection and --agent)"
+            },
+            {
                 "name": "--org",
                 "type": "string",
                 "default": null,
@@ -7995,6 +8004,12 @@ fn build_agent_schema(cmd: &clap::Command) -> serde_json::Value {
                 "type": "bool",
                 "default": "false",
                 "description": "Enable agent mode (auto-detected for AI coding assistants)"
+            },
+            {
+                "name": "--no-agent",
+                "type": "bool",
+                "default": "false",
+                "description": "Disable agent mode (overrides auto-detection and --agent)"
             },
             {
                 "name": "--org",
@@ -8501,6 +8516,31 @@ mod test_agent_schema {
             "group command should have subcommands"
         );
     }
+
+    #[test]
+    fn global_flags_include_no_agent() {
+        let schema = get_schema();
+        let flags = schema["global_flags"].as_array().expect("global_flags missing");
+        assert!(
+            flags.iter().any(|f| f["name"].as_str() == Some("--no-agent")),
+            "global_flags must include --no-agent"
+        );
+    }
+
+    #[test]
+    fn no_agent_flag_in_scoped_schema() {
+        let cmd = Cli::command();
+        let monitors_cmd = cmd
+            .get_subcommands()
+            .find(|s| s.get_name() == "monitors")
+            .expect("monitors subcommand not found");
+        let schema = build_agent_schema_scoped(&cmd, monitors_cmd, &["monitors"]);
+        let flags = schema["global_flags"].as_array().expect("global_flags missing");
+        assert!(
+            flags.iter().any(|f| f["name"].as_str() == Some("--no-agent")),
+            "scoped schema global_flags must include --no-agent"
+        );
+    }
 }
 
 // ---- Main ----
@@ -8599,7 +8639,8 @@ async fn main_inner() -> anyhow::Result<()> {
     let args: Vec<String> = std::env::args().collect();
     let has_help = args.iter().any(|a| a == "--help" || a == "-h");
     let has_agent_flag = args.iter().any(|a| a == "--agent");
-    if has_help && (useragent::is_agent_mode() || has_agent_flag) {
+    let has_no_agent_flag = args.iter().any(|a| a == "--no-agent");
+    if has_help && !has_no_agent_flag && (useragent::is_agent_mode() || has_agent_flag) {
         let cmd = Cli::command();
         // Collect subcommand path from args (skip binary name, flags, and --help/-h)
         let sub_path: Vec<&str> = args
@@ -8679,7 +8720,7 @@ async fn main_inner() -> anyhow::Result<()> {
     if cli.yes {
         cfg.auto_approve = true;
     }
-    cfg.agent_mode = cli.agent || useragent::is_agent_mode();
+    cfg.agent_mode = !cli.no_agent && (cli.agent || useragent::is_agent_mode());
     if cfg.agent_mode {
         cfg.auto_approve = true;
     }


### PR DESCRIPTION
## Summary

Adds a `--no-agent` global flag so scripts that may run inside AI coding assistants can enforce consistent (non-agent) output format regardless of the environment. Resolves a gap where auto-detection could not be overridden.

## Changes

- `src/main.rs:44` — Add `no_agent: bool` field to `Cli` with `global = true`
- `src/main.rs:8604` — Check `--no-agent` in raw-args help interception to suppress JSON schema output
- `src/main.rs:8696` — `cfg.agent_mode = !cli.no_agent && (cli.agent || useragent::is_agent_mode())`
- Both `build_agent_schema_scoped` and `build_agent_schema` hardcoded `global_flags` updated with `--no-agent` entry
- 2 new tests: `global_flags_include_no_agent`, `no_agent_flag_in_scoped_schema`

## Testing

- `cargo test`: 774 passed
- `cargo clippy -- -D warnings`: clean

## Related Issues

Closes #337

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)