### PR TITLE
feat(auth): make `pup auth token` available in release builds

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -20,7 +20,7 @@ pup <domain> <subgroup> <action> [options] # Nested commands
 | Domain | Subcommands | File | Status |
 |--------|-------------|------|--------|
 | acp | serve | src/commands/acp.rs | ✅ |
-| auth | login, logout, status, refresh | src/commands/auth.rs | ✅ |
+| auth | login, logout, status, token, refresh | src/commands/auth.rs | ✅ |
 | metrics | query, list, get, search | src/commands/metrics.rs | ✅ |
 | logs | search, list, aggregate | src/commands/logs.rs | ✅ |
 | traces | metrics (list, get, create, update, delete) | src/commands/traces.rs | ✅ |

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -226,7 +226,6 @@ pub fn status(cfg: &Config) -> Result<()> {
     })
 }
 
-#[cfg(debug_assertions)]
 pub fn token(cfg: &Config) -> Result<()> {
     if let Some(token) = &cfg.access_token {
         println!("{token}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -7816,8 +7816,7 @@ enum AuthActions {
         #[arg(long, value_name = "SITE")]
         site: Option<String>,
     },
-    /// Print access token (debug builds only)
-    #[cfg(debug_assertions)]
+    /// Print access token
     Token,
     /// Refresh access token
     Refresh,
@@ -11619,7 +11618,6 @@ async fn main_inner() -> anyhow::Result<()> {
                 }
                 commands::auth::status(&cfg)?
             }
-            #[cfg(debug_assertions)]
             AuthActions::Token => commands::auth::token(&cfg)?,
             AuthActions::Refresh => commands::auth::refresh(&cfg).await?,
             AuthActions::List => commands::auth::list(&cfg)?,


### PR DESCRIPTION
## Summary
- Remove `#[cfg(debug_assertions)]` gate from `pup auth token` so it works in release builds
- Add `token` to the auth subcommands listing in COMMANDS.md

## Changes
- `src/main.rs` — Remove `#[cfg(debug_assertions)]` from the `Token` enum variant and its match arm
- `src/commands/auth.rs` — Remove `#[cfg(debug_assertions)]` from the `token` function
- `docs/COMMANDS.md` — Add `token` to auth subcommands in the command index

## Testing
- `cargo build` — compiles successfully
- `cargo test` — 772 tests pass, 0 failures
- `cargo clippy -- -D warnings` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Human note: this is related to #339 . I see there's already a PR to add the `pup api` command. This seems like a super easy alternate way to open things up. Feel free to close if this isn't an acceptable solution ✌️ 