### PR TITLE
fix(llm-obs): correct datasets list endpoint path

### DIFF
--- a/src/commands/llm_obs.rs
+++ b/src/commands/llm_obs.rs
@@ -101,7 +101,7 @@ pub async fn datasets_create(cfg: &Config, project_id: &str, file: &str) -> Resu
 }
 
 pub async fn datasets_list(cfg: &Config, project_id: &str) -> Result<()> {
-    let path = format!("/api/v2/llm-obs/v1/projects/{project_id}/datasets");
+    let path = format!("/api/v2/llm-obs/v1/{project_id}/datasets");
     let resp = client::raw_get(cfg, &path, &[])
         .await
         .map_err(|e| anyhow::anyhow!("failed to list LLM obs datasets: {e:?}"))?;

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -3229,7 +3229,7 @@ async fn test_llm_obs_datasets_list() {
     // Raw HTTP path: verify the correct project-scoped path is called.
     let body = r#"{"data":[{"id":"ds-1","type":"datasets","attributes":{"name":"my-dataset","description":null,"metadata":null,"created_at":"2024-01-01T00:00:00Z","updated_at":"2024-01-01T00:00:00Z","current_version":1}}]}"#;
     let _mock = server
-        .mock("GET", "/api/v2/llm-obs/v1/projects/proj-1/datasets")
+        .mock("GET", "/api/v2/llm-obs/v1/proj-1/datasets")
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(body)


### PR DESCRIPTION
## Summary
The `pup llm-obs datasets list` command was hitting `/api/v2/llm-obs/v1/projects/{project_id}/datasets` instead of the correct `/api/v2/llm-obs/v1/{project_id}/datasets`, resulting in a HTTP 404 for every call.

## Changes
- `src/commands/llm_obs.rs:104` — remove spurious `projects/` segment from the datasets list path
- `src/test_commands.rs:3232` — update mock path in the happy-path test to match the corrected endpoint

## Testing
- `cargo test test_llm_obs_datasets_list` — both the 200 and 403 cases pass
- `cargo clippy` / `cargo fmt --check` clean

## Related Issues
Closes #349

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)