### PR TITLE
fix(auth): fix token storage on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1950,10 +1950,12 @@ version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
+ "byteorder",
  "linux-keyutils",
  "log",
  "security-framework 2.11.1",
  "security-framework 3.7.0",
+ "windows-sys 0.60.2",
  "zeroize",
 ]
 
@@ -4665,6 +4667,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4696,11 +4707,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4725,6 +4753,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4735,6 +4769,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4749,10 +4789,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4767,6 +4819,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4777,6 +4835,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4791,6 +4855,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4801,6 +4871,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ reqwest-middleware = "0.5"
 async-trait = "0.1"
 
 # OS keychain for token storage
-keyring = { version = "3", features = ["apple-native", "linux-native"], optional = true }
+keyring = { version = "3", features = ["apple-native", "linux-native", "windows-native"], optional = true }
 
 # XDG config directory resolution
 dirs = { version = "6", optional = true }

--- a/src/auth/storage.rs
+++ b/src/auth/storage.rs
@@ -338,8 +338,7 @@ impl KeychainStorage {
         // leaves no count entry (or the prior count), so load_state reads the old
         // data or returns default rather than assembling partial chunks.
         for (i, chunk) in chunks.iter().enumerate() {
-            keyring::Entry::new(SERVICE_NAME, &format!("{base}_{i}"))?
-                .set_password(chunk)?;
+            keyring::Entry::new(SERVICE_NAME, &format!("{base}_{i}"))?.set_password(chunk)?;
         }
         count_entry.set_password(&n.to_string())?;
         // Remove stale chunks left over from a prior write that had more entries.
@@ -1323,7 +1322,10 @@ mod tests {
         }));
         std::env::remove_var("DD_TOKEN_STORAGE");
         std::env::remove_var("PUP_CONFIG_DIR");
-        assert!(result.is_err(), "expected panic when DD_TOKEN_STORAGE=keychain but keychain unavailable");
+        assert!(
+            result.is_err(),
+            "expected panic when DD_TOKEN_STORAGE=keychain but keychain unavailable"
+        );
     }
 
     #[test]
@@ -1416,9 +1418,7 @@ mod tests {
         store.save_tokens(site, None, &big_token).unwrap();
 
         // Second write: tiny token → single chunk.
-        store
-            .save_tokens(site, None, &make_token("small"))
-            .unwrap();
+        store.save_tokens(site, None, &make_token("small")).unwrap();
         let loaded = store.load_tokens(site, None).unwrap().unwrap();
         assert_eq!(loaded.access_token, "small");
 

--- a/src/auth/storage.rs
+++ b/src/auth/storage.rs
@@ -228,11 +228,16 @@ struct SiteData {
     client: Option<ClientCredentials>,
 }
 
-// Maximum bytes per WinCred blob — well under CRED_MAX_CREDENTIAL_BLOB_SIZE (2560).
+// Maximum characters per WinCred blob entry.
+//
+// WinCred stores passwords as UTF-16LE, so each ASCII character occupies 2 bytes.
+// CRED_MAX_CREDENTIAL_BLOB_SIZE = 2560 bytes → 1280 ASCII characters maximum.
+// We use 1000 to stay well clear of that limit.
+//
 // SiteData (access token + refresh token + 79 scopes + client credentials) easily
-// exceeds 2560 bytes, so on Windows we split the JSON across numbered entries.
+// exceeds 1000 characters, so on Windows we split the JSON across numbered entries.
 #[cfg(all(not(target_arch = "wasm32"), target_os = "windows"))]
-const WIN_CHUNK_BYTES: usize = 2048;
+const WIN_CHUNK_BYTES: usize = 1000;
 
 #[cfg(not(target_arch = "wasm32"))]
 impl KeychainStorage {
@@ -1377,9 +1382,9 @@ mod tests {
         assert_eq!(backend.backend_type(), BackendType::Keychain);
     }
 
-    // Returns a token whose serialised SiteData exceeds WIN_CHUNK_BYTES (2048),
-    // guaranteeing that KeychainStorage will write at least two WinCred chunks.
-    // A 3000-char access token + JSON overhead ≈ 3200 bytes → 2 chunks minimum.
+    // Returns a token whose serialised SiteData exceeds WIN_CHUNK_BYTES (1000),
+    // guaranteeing that KeychainStorage will write at least four WinCred chunks.
+    // A 3000-char access token + JSON overhead ≈ 3200 bytes → 4 chunks minimum.
     #[cfg(target_os = "windows")]
     fn make_multi_chunk_token() -> TokenSet {
         make_token(&"a".repeat(3000))
@@ -1459,8 +1464,9 @@ mod tests {
             .save_tokens(site, None, &make_multi_chunk_token())
             .unwrap();
 
-        // Verify the payload produced exactly 2 chunks before we corrupt one,
-        // so this test stays correct if WIN_CHUNK_BYTES ever changes.
+        // Verify the payload produced at least 4 chunks before we corrupt one,
+        // so this test fails explicitly if WIN_CHUNK_BYTES ever grows large enough
+        // to collapse the payload back to a single chunk.
         let base = format!("state_{}", sanitize(site));
         let count: usize = keyring::Entry::new(SERVICE_NAME, &format!("{base}_c"))
             .unwrap()

--- a/src/auth/storage.rs
+++ b/src/auth/storage.rs
@@ -1377,25 +1377,37 @@ mod tests {
         assert_eq!(backend.backend_type(), BackendType::Keychain);
     }
 
-    // Verify that a large SiteData (well above WinCred's 2560-byte blob limit)
-    // round-trips correctly through the chunked storage scheme.
+    // Returns a token whose serialised SiteData exceeds WIN_CHUNK_BYTES (2048),
+    // guaranteeing that KeychainStorage will write at least two WinCred chunks.
+    // A 3000-char access token + JSON overhead ≈ 3200 bytes → 2 chunks minimum.
+    #[cfg(target_os = "windows")]
+    fn make_multi_chunk_token() -> TokenSet {
+        make_token(&"a".repeat(3000))
+    }
+
+    // Verify that a large SiteData (above WIN_CHUNK_BYTES) round-trips correctly
+    // through the chunked storage scheme.
     #[test]
     #[cfg(target_os = "windows")]
     fn test_keychain_storage_chunked_roundtrip() {
         let store = KeychainStorage;
         let site = "chunked_test.datadoghq.com";
 
-        let mut token = make_token("access_tok");
-        // Build a scope string long enough to push SiteData past 2560 bytes.
-        token.scope = (0..100)
-            .map(|i| format!("scope_{i:03}"))
-            .collect::<Vec<_>>()
-            .join(" ");
-
+        let token = make_multi_chunk_token();
         store.save_tokens(site, None, &token).unwrap();
+
+        // Verify that the multi-chunk path was actually exercised (chunk _1 exists).
+        let base = format!("state_{}", sanitize(site));
+        assert!(
+            keyring::Entry::new(SERVICE_NAME, &format!("{base}_1"))
+                .unwrap()
+                .get_password()
+                .is_ok(),
+            "chunk _1 must exist — payload must exceed WIN_CHUNK_BYTES"
+        );
+
         let loaded = store.load_tokens(site, None).unwrap().unwrap();
-        assert_eq!(loaded.access_token, "access_tok");
-        assert_eq!(loaded.scope, token.scope);
+        assert_eq!(loaded.access_token, token.access_token);
 
         store.delete_tokens(site, None).unwrap();
         assert!(store.load_tokens(site, None).unwrap().is_none());
@@ -1410,17 +1422,26 @@ mod tests {
         let site = "chunked_shrink.datadoghq.com";
 
         // First write: large token → multiple chunks.
-        let mut big_token = make_token("big");
-        big_token.scope = (0..100)
-            .map(|i| format!("scope_{i:03}"))
-            .collect::<Vec<_>>()
-            .join(" ");
-        store.save_tokens(site, None, &big_token).unwrap();
+        store
+            .save_tokens(site, None, &make_multi_chunk_token())
+            .unwrap();
 
         // Second write: tiny token → single chunk.
         store.save_tokens(site, None, &make_token("small")).unwrap();
         let loaded = store.load_tokens(site, None).unwrap().unwrap();
         assert_eq!(loaded.access_token, "small");
+
+        // Assert that the stale chunk _1 from the first write was deleted.
+        let base = format!("state_{}", sanitize(site));
+        assert!(
+            matches!(
+                keyring::Entry::new(SERVICE_NAME, &format!("{base}_1"))
+                    .unwrap()
+                    .get_password(),
+                Err(keyring::Error::NoEntry)
+            ),
+            "stale chunk _1 must be removed after shrinking to a single chunk"
+        );
 
         store.delete_tokens(site, None).unwrap();
     }
@@ -1433,16 +1454,24 @@ mod tests {
         let store = KeychainStorage;
         let site = "chunked_missing.datadoghq.com";
 
-        // Write a large multi-chunk token.
-        let mut token = make_token("tok");
-        token.scope = (0..100)
-            .map(|i| format!("scope_{i:03}"))
-            .collect::<Vec<_>>()
-            .join(" ");
-        store.save_tokens(site, None, &token).unwrap();
+        // Write a token large enough to produce at least 2 WinCred chunks.
+        store
+            .save_tokens(site, None, &make_multi_chunk_token())
+            .unwrap();
 
-        // Directly delete chunk _1 to simulate partial WinCred corruption.
+        // Verify the payload produced exactly 2 chunks before we corrupt one,
+        // so this test stays correct if WIN_CHUNK_BYTES ever changes.
         let base = format!("state_{}", sanitize(site));
+        let count: usize = keyring::Entry::new(SERVICE_NAME, &format!("{base}_c"))
+            .unwrap()
+            .get_password()
+            .unwrap()
+            .trim()
+            .parse()
+            .unwrap();
+        assert!(count >= 2, "expected at least 2 chunks, got {count}");
+
+        // Delete chunk _1 to simulate partial WinCred corruption.
         keyring::Entry::new(SERVICE_NAME, &format!("{base}_1"))
             .unwrap()
             .delete_credential()

--- a/src/auth/storage.rs
+++ b/src/auth/storage.rs
@@ -189,9 +189,27 @@ const SERVICE_NAME: &str = "pup";
 #[cfg(not(target_arch = "wasm32"))]
 impl KeychainStorage {
     pub fn new() -> Result<Self> {
-        // Verify the keyring crate can create entries without accessing the keychain.
-        // Actual availability is confirmed on first read/write to avoid spurious macOS
-        // authorization dialogs for a throwaway probe entry.
+        // On Windows, WinCred silently uses an in-memory mock unless windows-native
+        // is enabled, and even then has a 2560-byte blob limit that SiteData exceeds.
+        // Do a real write/read/delete cycle so an unusable backend fails fast here
+        // rather than silently losing tokens at runtime.
+        #[cfg(target_os = "windows")]
+        {
+            let entry = keyring::Entry::new(SERVICE_NAME, "__pup_probe__")
+                .map_err(|e| anyhow::anyhow!("keychain not available: {e}"))?;
+            entry
+                .set_password("probe")
+                .map_err(|e| anyhow::anyhow!("keychain write failed: {e}"))?;
+            entry
+                .get_password()
+                .map_err(|e| anyhow::anyhow!("keychain read failed: {e}"))?;
+            entry
+                .delete_credential()
+                .map_err(|e| anyhow::anyhow!("keychain probe cleanup failed: {e}"))?;
+        }
+        // On macOS and Linux, constructing an Entry is sufficient to confirm the
+        // backend is present; avoid a spurious macOS authorization dialog.
+        #[cfg(not(target_os = "windows"))]
         keyring::Entry::new(SERVICE_NAME, "__pup_probe__")
             .map_err(|e| anyhow::anyhow!("keychain not available: {e}"))?;
         Ok(Self)
@@ -210,12 +228,21 @@ struct SiteData {
     client: Option<ClientCredentials>,
 }
 
+// Maximum bytes per WinCred blob — well under CRED_MAX_CREDENTIAL_BLOB_SIZE (2560).
+// SiteData (access token + refresh token + 79 scopes + client credentials) easily
+// exceeds 2560 bytes, so on Windows we split the JSON across numbered entries.
+#[cfg(all(not(target_arch = "wasm32"), target_os = "windows"))]
+const WIN_CHUNK_BYTES: usize = 2048;
+
 #[cfg(not(target_arch = "wasm32"))]
 impl KeychainStorage {
     fn state_key(site: &str) -> String {
         format!("state_{}", sanitize(site))
     }
 
+    // --- non-Windows: single keychain entry per site ----------------------------
+
+    #[cfg(not(target_os = "windows"))]
     fn load_state(&self, site: &str) -> Result<SiteData> {
         let entry = keyring::Entry::new(SERVICE_NAME, &Self::state_key(site))?;
         match entry.get_password() {
@@ -225,18 +252,135 @@ impl KeychainStorage {
         }
     }
 
+    #[cfg(not(target_os = "windows"))]
     fn save_state(&self, site: &str, data: &SiteData) -> Result<()> {
         let entry = keyring::Entry::new(SERVICE_NAME, &Self::state_key(site))?;
         let json = serde_json::to_string(data)?;
         entry.set_password(&json).map_err(Into::into)
     }
 
+    #[cfg(not(target_os = "windows"))]
     fn delete_state(&self, site: &str) -> Result<()> {
         let entry = keyring::Entry::new(SERVICE_NAME, &Self::state_key(site))?;
         match entry.delete_credential() {
             Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
             Err(e) => Err(e.into()),
         }
+    }
+
+    // --- Windows: chunked entries to stay within WinCred's 2560-byte blob limit --
+    //
+    // Chunk count is stored under "<key>_c"; chunks under "<key>_0", "<key>_1", …
+    // On load the legacy single-entry format is tried as a fallback so that any
+    // data stored before this scheme was introduced is still readable.
+
+    #[cfg(target_os = "windows")]
+    fn load_state(&self, site: &str) -> Result<SiteData> {
+        let base = Self::state_key(site);
+        let count_entry = keyring::Entry::new(SERVICE_NAME, &format!("{base}_c"))?;
+        let n: usize = match count_entry.get_password() {
+            Ok(s) => s
+                .trim()
+                .parse()
+                .map_err(|_| anyhow::anyhow!("corrupt keychain chunk count"))?,
+            Err(keyring::Error::NoEntry) => {
+                // No chunk count — try the legacy single-entry format.
+                let entry = keyring::Entry::new(SERVICE_NAME, &base)?;
+                return match entry.get_password() {
+                    Ok(json) => Ok(serde_json::from_str(&json).unwrap_or_default()),
+                    Err(keyring::Error::NoEntry) => Ok(SiteData::default()),
+                    Err(e) => Err(e.into()),
+                };
+            }
+            Err(e) => return Err(e.into()),
+        };
+        if n == 0 {
+            return Ok(SiteData::default());
+        }
+        let mut json = String::new();
+        for i in 0..n {
+            let entry = keyring::Entry::new(SERVICE_NAME, &format!("{base}_{i}"))?;
+            match entry.get_password() {
+                Ok(chunk) => json.push_str(&chunk),
+                // A missing chunk means partial WinCred corruption (e.g. manual
+                // deletion). Return empty state so the caller sees "not logged in"
+                // rather than partial or garbled data.
+                Err(keyring::Error::NoEntry) => return Ok(SiteData::default()),
+                Err(e) => return Err(e.into()),
+            }
+        }
+        Ok(serde_json::from_str(&json).unwrap_or_default())
+    }
+
+    #[cfg(target_os = "windows")]
+    fn save_state(&self, site: &str, data: &SiteData) -> Result<()> {
+        let base = Self::state_key(site);
+        let json = serde_json::to_string(data)?;
+        // JSON only contains ASCII characters (base64url tokens, alphanumeric scope
+        // words, JSON punctuation), so byte-chunking never splits a multibyte sequence.
+        let chunks = json
+            .as_bytes()
+            .chunks(WIN_CHUNK_BYTES)
+            .map(|b| std::str::from_utf8(b).map_err(|e| anyhow::anyhow!("chunk encoding: {e}")))
+            .collect::<Result<Vec<_>>>()?;
+        let n = chunks.len();
+
+        // Read the old count so we can delete any stale extra entries after writing.
+        let count_entry = keyring::Entry::new(SERVICE_NAME, &format!("{base}_c"))?;
+        let old_n: usize = count_entry
+            .get_password()
+            .ok()
+            .and_then(|s| s.trim().parse().ok())
+            .unwrap_or(0);
+
+        count_entry.set_password(&n.to_string())?;
+        for (i, chunk) in chunks.iter().enumerate() {
+            keyring::Entry::new(SERVICE_NAME, &format!("{base}_{i}"))?
+                .set_password(chunk)?;
+        }
+        // Remove stale chunks left over from a prior write that had more entries.
+        for i in n..old_n {
+            // Best-effort: ignore errors on stale-chunk cleanup.
+            let _ = keyring::Entry::new(SERVICE_NAME, &format!("{base}_{i}"))
+                .and_then(|e| e.delete_credential());
+        }
+        Ok(())
+    }
+
+    #[cfg(target_os = "windows")]
+    fn delete_state(&self, site: &str) -> Result<()> {
+        let base = Self::state_key(site);
+        let count_entry = keyring::Entry::new(SERVICE_NAME, &format!("{base}_c"))?;
+        let n: usize = match count_entry.get_password() {
+            Ok(s) => {
+                let n = s
+                    .trim()
+                    .parse()
+                    .map_err(|_| anyhow::anyhow!("corrupt keychain chunk count"))?;
+                match count_entry.delete_credential() {
+                    Ok(()) | Err(keyring::Error::NoEntry) => {}
+                    Err(e) => return Err(e.into()),
+                }
+                n
+            }
+            Err(keyring::Error::NoEntry) => {
+                // Legacy single-entry format — delete and return.
+                let entry = keyring::Entry::new(SERVICE_NAME, &base)?;
+                match entry.delete_credential() {
+                    Ok(()) | Err(keyring::Error::NoEntry) => return Ok(()),
+                    Err(e) => return Err(e.into()),
+                }
+            }
+            Err(e) => return Err(e.into()),
+        };
+        for i in 0..n {
+            let entry = keyring::Entry::new(SERVICE_NAME, &format!("{base}_{i}"))?;
+            match entry.delete_credential() {
+                Ok(()) | Err(keyring::Error::NoEntry) => {}
+                Err(e) => return Err(e.into()),
+            }
+        }
+        Ok(())
     }
 }
 
@@ -596,7 +740,9 @@ use std::sync::Mutex;
 static STORAGE: Mutex<Option<Box<dyn Storage>>> = Mutex::new(None);
 
 pub fn get_storage() -> Result<&'static Mutex<Option<Box<dyn Storage>>>> {
-    let mut guard = STORAGE.lock().unwrap();
+    let mut guard = STORAGE
+        .lock()
+        .map_err(|_| anyhow::anyhow!("storage lock poisoned"))?;
     if guard.is_none() {
         let backend = detect_backend();
         *guard = Some(backend);
@@ -617,11 +763,19 @@ fn detect_backend() -> Box<dyn Storage> {
     }
 
     // On macOS, use Touch ID-capable storage by default.
-    // On other platforms, fall back to the keyring-based backend.
     #[cfg(target_os = "macos")]
     return Box::new(TouchIdStorage::new());
 
-    #[cfg(not(target_os = "macos"))]
+    // On Windows, WinCred has a hard blob-size limit (2560 bytes) that the
+    // serialised SiteData (access token + refresh token + 79 scopes + client
+    // credentials) easily exceeds.  Default to file storage so tokens always
+    // persist; users can opt into keychain via DD_TOKEN_STORAGE=keychain.
+    #[cfg(target_os = "windows")]
+    return Box::new(FileStorage::new().expect("failed to create file storage"));
+
+    // On other platforms (Linux, etc.), probe the keyring backend and fall
+    // back to file storage if the keychain daemon is not available.
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     match KeychainStorage::new() {
         Ok(ks) => Box::new(ks),
         Err(_) => {
@@ -1118,5 +1272,133 @@ mod tests {
         let result = remove_session("datadoghq.com", Some("nonexistent"));
         std::env::remove_var("PUP_CONFIG_DIR");
         assert!(result.is_ok());
+    }
+
+    // --- detect_backend ---------------------------------------------------------
+
+    #[test]
+    fn test_detect_backend_dd_token_storage_file() {
+        let _lock = crate::test_utils::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let tmp = TempDir::new("detect_file");
+        std::env::set_var("PUP_CONFIG_DIR", tmp.path());
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let backend = detect_backend();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+        std::env::remove_var("PUP_CONFIG_DIR");
+        assert_eq!(backend.backend_type(), BackendType::File);
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn test_detect_backend_windows_default_is_file() {
+        let _lock = crate::test_utils::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let tmp = TempDir::new("detect_win");
+        std::env::set_var("PUP_CONFIG_DIR", tmp.path());
+        std::env::remove_var("DD_TOKEN_STORAGE");
+        let backend = detect_backend();
+        std::env::remove_var("PUP_CONFIG_DIR");
+        assert_eq!(backend.backend_type(), BackendType::File);
+    }
+
+    // DD_TOKEN_STORAGE=keychain on Windows should return a Keychain backend
+    // (exercises the chunked WinCred scheme). Requires a functional WinCred — only
+    // compiled and run on Windows CI. A negative test (broken WinCred → Err) would
+    // need OS-level mocking that is not supported by this test framework.
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn test_detect_backend_dd_token_storage_keychain_windows() {
+        let _lock = crate::test_utils::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let tmp = TempDir::new("detect_kc_win");
+        std::env::set_var("PUP_CONFIG_DIR", tmp.path());
+        std::env::set_var("DD_TOKEN_STORAGE", "keychain");
+        let backend = detect_backend();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+        std::env::remove_var("PUP_CONFIG_DIR");
+        assert_eq!(backend.backend_type(), BackendType::Keychain);
+    }
+
+    // Verify that a large SiteData (well above WinCred's 2560-byte blob limit)
+    // round-trips correctly through the chunked storage scheme.
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn test_keychain_storage_chunked_roundtrip() {
+        let store = KeychainStorage;
+        let site = "chunked_test.datadoghq.com";
+
+        let mut token = make_token("access_tok");
+        // Build a scope string long enough to push SiteData past 2560 bytes.
+        token.scope = (0..100)
+            .map(|i| format!("scope_{i:03}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        store.save_tokens(site, None, &token).unwrap();
+        let loaded = store.load_tokens(site, None).unwrap().unwrap();
+        assert_eq!(loaded.access_token, "access_tok");
+        assert_eq!(loaded.scope, token.scope);
+
+        store.delete_tokens(site, None).unwrap();
+        assert!(store.load_tokens(site, None).unwrap().is_none());
+    }
+
+    // Confirm that shrinking a save (fewer chunks than the previous write) cleans
+    // up the stale extra entries rather than leaving orphaned WinCred blobs.
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn test_keychain_storage_chunked_shrink_cleans_stale_entries() {
+        let store = KeychainStorage;
+        let site = "chunked_shrink.datadoghq.com";
+
+        // First write: large token → multiple chunks.
+        let mut big_token = make_token("big");
+        big_token.scope = (0..100)
+            .map(|i| format!("scope_{i:03}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        store.save_tokens(site, None, &big_token).unwrap();
+
+        // Second write: tiny token → single chunk.
+        store
+            .save_tokens(site, None, &make_token("small"))
+            .unwrap();
+        let loaded = store.load_tokens(site, None).unwrap().unwrap();
+        assert_eq!(loaded.access_token, "small");
+
+        store.delete_tokens(site, None).unwrap();
+    }
+
+    // When a chunk entry is absent (e.g. manual WinCred deletion), load_state
+    // should return empty state rather than partial data.
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn test_keychain_storage_chunked_missing_chunk_returns_default() {
+        let store = KeychainStorage;
+        let site = "chunked_missing.datadoghq.com";
+
+        // Write a large multi-chunk token.
+        let mut token = make_token("tok");
+        token.scope = (0..100)
+            .map(|i| format!("scope_{i:03}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        store.save_tokens(site, None, &token).unwrap();
+
+        // Directly delete chunk _1 to simulate partial WinCred corruption.
+        let base = format!("state_{}", sanitize(site));
+        keyring::Entry::new(SERVICE_NAME, &format!("{base}_1"))
+            .unwrap()
+            .delete_credential()
+            .unwrap();
+
+        // Load should return None (empty state) not partial data.
+        assert!(store.load_tokens(site, None).unwrap().is_none());
+
+        let _ = store.delete_tokens(site, None);
     }
 }

--- a/src/auth/storage.rs
+++ b/src/auth/storage.rs
@@ -316,8 +316,9 @@ impl KeychainStorage {
     fn save_state(&self, site: &str, data: &SiteData) -> Result<()> {
         let base = Self::state_key(site);
         let json = serde_json::to_string(data)?;
-        // JSON only contains ASCII characters (base64url tokens, alphanumeric scope
-        // words, JSON punctuation), so byte-chunking never splits a multibyte sequence.
+        // Tokens, scope words, and JSON punctuation are all ASCII in practice.
+        // If a future field introduces non-ASCII UTF-8, from_utf8 below will
+        // return an error rather than silently producing garbled data.
         let chunks = json
             .as_bytes()
             .chunks(WIN_CHUNK_BYTES)
@@ -333,11 +334,14 @@ impl KeychainStorage {
             .and_then(|s| s.trim().parse().ok())
             .unwrap_or(0);
 
-        count_entry.set_password(&n.to_string())?;
+        // Write chunks before committing the count. A crash between chunk writes
+        // leaves no count entry (or the prior count), so load_state reads the old
+        // data or returns default rather than assembling partial chunks.
         for (i, chunk) in chunks.iter().enumerate() {
             keyring::Entry::new(SERVICE_NAME, &format!("{base}_{i}"))?
                 .set_password(chunk)?;
         }
+        count_entry.set_password(&n.to_string())?;
         // Remove stale chunks left over from a prior write that had more entries.
         for i in n..old_n {
             // Best-effort: ignore errors on stale-chunk cleanup.
@@ -428,7 +432,7 @@ impl Storage for KeychainStorage {
     fn delete_client_credentials(&self, site: &str) -> Result<()> {
         let mut data = self.load_state(site)?;
         data.client = None;
-        if data.tokens.is_empty() && data.client.is_none() {
+        if data.tokens.is_empty() {
             self.delete_state(site)
         } else {
             self.save_state(site, &data)
@@ -578,7 +582,7 @@ impl Storage for TouchIdStorage {
     fn delete_client_credentials(&self, site: &str) -> Result<()> {
         let mut data = self.load_state(site)?;
         data.client = None;
-        if data.tokens.is_empty() && data.client.is_none() {
+        if data.tokens.is_empty() {
             self.delete_state(site)
         } else {
             self.save_state(site, &data)
@@ -753,12 +757,23 @@ pub fn get_storage() -> Result<&'static Mutex<Option<Box<dyn Storage>>>> {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn detect_backend() -> Box<dyn Storage> {
+    detect_backend_with(KeychainStorage::new)
+}
+
+// Separated from detect_backend so tests can inject a failing keychain probe
+// and exercise all failure paths without OS-level credential-store mocking.
+#[cfg(not(target_arch = "wasm32"))]
+fn detect_backend_with(try_keychain: impl Fn() -> Result<KeychainStorage>) -> Box<dyn Storage> {
     // Check DD_TOKEN_STORAGE env var
     if let Ok(val) = std::env::var("DD_TOKEN_STORAGE") {
         match val.as_str() {
             "file" => return Box::new(FileStorage::new().expect("failed to create file storage")),
-            "keychain" => return Box::new(KeychainStorage::new().expect("keychain not available")),
-            _ => eprintln!("Warning: unknown DD_TOKEN_STORAGE={val:?}, auto-detecting"),
+            // Explicit opt-in: panic with a clear message if the backend is
+            // unavailable rather than silently falling back to a different store.
+            "keychain" => return Box::new(try_keychain().expect("keychain not available")),
+            _ => eprintln!(
+                "Warning: unknown DD_TOKEN_STORAGE={val:?} (valid: \"file\", \"keychain\"), auto-detecting"
+            ),
         }
     }
 
@@ -766,20 +781,17 @@ fn detect_backend() -> Box<dyn Storage> {
     #[cfg(target_os = "macos")]
     return Box::new(TouchIdStorage::new());
 
-    // On Windows, WinCred has a hard blob-size limit (2560 bytes) that the
-    // serialised SiteData (access token + refresh token + 79 scopes + client
-    // credentials) easily exceeds.  Default to file storage so tokens always
-    // persist; users can opt into keychain via DD_TOKEN_STORAGE=keychain.
-    #[cfg(target_os = "windows")]
-    return Box::new(FileStorage::new().expect("failed to create file storage"));
-
-    // On other platforms (Linux, etc.), probe the keyring backend and fall
-    // back to file storage if the keychain daemon is not available.
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    match KeychainStorage::new() {
+    // On other platforms (Windows, Linux, etc.), probe the keyring backend and
+    // fall back to file storage if the keychain daemon is not available.
+    // On Windows the chunked WinCred scheme keeps each blob under the 2560-byte
+    // platform limit, so keychain is safe to use as the default here too.
+    #[cfg(not(target_os = "macos"))]
+    match try_keychain() {
         Ok(ks) => Box::new(ks),
-        Err(_) => {
-            eprintln!("Warning: OS keychain not available, using file storage (~/.config/pup/)");
+        Err(e) => {
+            eprintln!(
+                "Warning: OS keychain not available ({e}), using file storage (~/.config/pup/)"
+            );
             Box::new(FileStorage::new().expect("failed to create file storage"))
         }
     }
@@ -1276,6 +1288,44 @@ mod tests {
 
     // --- detect_backend ---------------------------------------------------------
 
+    // Exercises the FileStorage fallback when the auto-detect keychain probe fails,
+    // without requiring OS-level credential-store mocking.
+    // Not compiled on macOS: detect_backend_with ignores the probe there (TouchId
+    // is always the macOS default), so injecting a failing probe would assert nothing.
+    #[test]
+    #[cfg(not(any(target_arch = "wasm32", target_os = "macos")))]
+    fn test_detect_backend_with_probe_failure_falls_back_to_file() {
+        let _lock = crate::test_utils::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let tmp = TempDir::new("detect_fallback");
+        std::env::set_var("PUP_CONFIG_DIR", tmp.path());
+        std::env::remove_var("DD_TOKEN_STORAGE");
+        let backend = detect_backend_with(|| Err(anyhow::anyhow!("probe failed")));
+        std::env::remove_var("PUP_CONFIG_DIR");
+        assert_eq!(backend.backend_type(), BackendType::File);
+    }
+
+    // When DD_TOKEN_STORAGE=keychain is explicitly set but the backend is
+    // unavailable, the process panics with a clear message rather than silently
+    // falling back (explicit opt-in should fail loudly).
+    #[test]
+    #[cfg(not(target_arch = "wasm32"))]
+    fn test_detect_backend_with_dd_keychain_panics_when_unavailable() {
+        let _lock = crate::test_utils::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let tmp = TempDir::new("detect_kc_panic");
+        std::env::set_var("PUP_CONFIG_DIR", tmp.path());
+        std::env::set_var("DD_TOKEN_STORAGE", "keychain");
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            detect_backend_with(|| Err(anyhow::anyhow!("probe failed")))
+        }));
+        std::env::remove_var("DD_TOKEN_STORAGE");
+        std::env::remove_var("PUP_CONFIG_DIR");
+        assert!(result.is_err(), "expected panic when DD_TOKEN_STORAGE=keychain but keychain unavailable");
+    }
+
     #[test]
     fn test_detect_backend_dd_token_storage_file() {
         let _lock = crate::test_utils::ENV_LOCK
@@ -1292,7 +1342,9 @@ mod tests {
 
     #[test]
     #[cfg(target_os = "windows")]
-    fn test_detect_backend_windows_default_is_file() {
+    fn test_detect_backend_windows_default_is_keychain() {
+        // Windows defaults to KeychainStorage (chunked WinCred) now that the
+        // chunked scheme keeps blobs within the 2560-byte platform limit.
         let _lock = crate::test_utils::ENV_LOCK
             .lock()
             .unwrap_or_else(|p| p.into_inner());
@@ -1301,7 +1353,7 @@ mod tests {
         std::env::remove_var("DD_TOKEN_STORAGE");
         let backend = detect_backend();
         std::env::remove_var("PUP_CONFIG_DIR");
-        assert_eq!(backend.backend_type(), BackendType::File);
+        assert_eq!(backend.backend_type(), BackendType::Keychain);
     }
 
     // DD_TOKEN_STORAGE=keychain on Windows should return a Keychain backend


### PR DESCRIPTION
## Summary

Fixes #352. On Windows, \`pup auth login\` appeared to succeed but tokens were never persisted — \`pup auth status\` immediately reported "not authenticated". Two root causes: (1) the \`windows-native\` keyring feature was missing so WinCred silently used an in-memory mock, and (2) WinCred stores credentials as UTF-16LE (2 bytes per ASCII char), so \`CRED_MAX_CREDENTIAL_BLOB_SIZE\` (2560 bytes) allows only 1280 ASCII characters — far less than the serialised \`SiteData\` (access + refresh token + 79 scopes + client credentials).

## Changes

- **\`windows-native\` keyring feature** (\`Cargo.toml\`) — enables actual WinCred instead of the in-memory mock
- **Chunked WinCred storage** (\`KeychainStorage\` on Windows) — JSON is split into ≤1000-character entries (\`<key>_c\` count + \`<key>_0\`, \`<key>_1\`, …) so each blob stays under 2000 bytes UTF-16LE (well within the 2560-byte limit); chunks are written before the count entry (crash-safe commit); legacy single-entry format still readable as fallback
- **Windows-only write/read/delete probe** in \`KeychainStorage::new()\` — unusable backend fails fast; all probe errors propagated
- **\`detect_backend_with(try_keychain)\`** — injectable function covering all platforms; enables unit testing of both the probe-failure fallback and the explicit \`DD_TOKEN_STORAGE=keychain\` panic without OS mocking
- **Fix dead tautology** — \`data.client.is_none()\` after \`data.client = None\` in \`delete_client_credentials\` for both \`KeychainStorage\` and \`TouchIdStorage\`
- **Improved warnings** — keychain unavailable warning now includes the error cause; unknown \`DD_TOKEN_STORAGE\` value lists valid options
- **Fix poisoned-mutex \`unwrap()\`** in \`get_storage()\` → propagated \`anyhow\` error

## Testing

- \`test_detect_backend_dd_token_storage_file\` — \`DD_TOKEN_STORAGE=file\` override (cross-platform)
- \`test_detect_backend_with_probe_failure_falls_back_to_file\` — auto-detect fallback when probe fails (Linux/Windows)
- \`test_detect_backend_with_dd_keychain_panics_when_unavailable\` — explicit opt-in panics when keychain unavailable
- \`test_detect_backend_windows_default_is_keychain\` — Windows default is \`KeychainStorage\` with chunked scheme
- \`test_detect_backend_dd_token_storage_keychain_windows\` — explicit keychain opt-in returns \`KeychainStorage\`
- \`test_keychain_storage_chunked_roundtrip\` — large \`SiteData\` (>1000 chars) survives save/load across multiple chunks
- \`test_keychain_storage_chunked_shrink_cleans_stale_entries\` — fewer chunks on re-save removes orphaned blobs
- \`test_keychain_storage_chunked_missing_chunk_returns_default\` — partial WinCred corruption returns empty state

Windows-specific tests are \`#[cfg(target_os = "windows")]\` and run only on Windows CI.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)