### PR TITLE
chore(deps): bump datadog-api-client-rust to 8fa08ce0 (2026-04-10)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -143,7 +143,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -543,7 +543,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -821,7 +821,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 [[package]]
 name = "datadog-api-client"
 version = "0.29.0"
-source = "git+https://github.com/DataDog/datadog-api-client-rust?rev=557230b8d7921a9288e8283f2c45770ec3789a05#557230b8d7921a9288e8283f2c45770ec3789a05"
+source = "git+https://github.com/DataDog/datadog-api-client-rust?rev=8fa08ce098d0218b50be712d064f0c52006d6c19#8fa08ce098d0218b50be712d064f0c52006d6c19"
 dependencies = [
  "async-stream",
  "chrono",
@@ -927,7 +927,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1093,7 +1093,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2807,7 +2807,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3279,7 +3279,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3336,7 +3336,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3751,7 +3751,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3915,7 +3915,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4526,7 +4526,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,9 +120,9 @@ ssh-key = { version = "0.6", features = ["p256", "std"], optional = true }
 futures = { version = "0.3", optional = true }
 tokio-util = { version = "0.7", features = ["compat", "io"], optional = true }
 
-# Datadog API client — latest master as of 2026-04-04 (557230b8)
+# Datadog API client — latest master as of 2026-04-10 (8fa08ce0)
 # Use default-features = false; feature sets are activated per-target via features above
-datadog-api-client = { git = "https://github.com/DataDog/datadog-api-client-rust", rev = "557230b8d7921a9288e8283f2c45770ec3789a05", optional = true, default-features = false }
+datadog-api-client = { git = "https://github.com/DataDog/datadog-api-client-rust", rev = "8fa08ce098d0218b50be712d064f0c52006d6c19", optional = true, default-features = false }
 
 # HTTP middleware (version-matched to DD client; compiles on all targets)
 reqwest-middleware = "0.5"

--- a/src/commands/scorecards.rs
+++ b/src/commands/scorecards.rs
@@ -122,7 +122,9 @@ pub async fn campaigns_update(cfg: &Config, campaign_id: &str, file: &str) -> Re
     let resp = api
         .update_scorecard_campaign(campaign_id.to_string(), body)
         .await
-        .map_err(|e| anyhow::anyhow!("failed to update scorecard campaign '{campaign_id}': {e:?}"))?;
+        .map_err(|e| {
+            anyhow::anyhow!("failed to update scorecard campaign '{campaign_id}': {e:?}")
+        })?;
     formatter::output(cfg, &resp)
 }
 
@@ -130,7 +132,9 @@ pub async fn campaigns_delete(cfg: &Config, campaign_id: &str) -> Result<()> {
     let api = make_api(cfg);
     api.delete_scorecard_campaign(campaign_id.to_string())
         .await
-        .map_err(|e| anyhow::anyhow!("failed to delete scorecard campaign '{campaign_id}': {e:?}"))?;
+        .map_err(|e| {
+            anyhow::anyhow!("failed to delete scorecard campaign '{campaign_id}': {e:?}")
+        })?;
     println!("Scorecard campaign '{campaign_id}' deleted successfully.");
     Ok(())
 }

--- a/src/commands/scorecards.rs
+++ b/src/commands/scorecards.rs
@@ -1,19 +1,26 @@
 use anyhow::Result;
-use datadog_api_client::datadogV2::api_service_scorecards::{
-    ListScorecardOutcomesOptionalParams, ListScorecardRulesOptionalParams, ServiceScorecardsAPI,
+use datadog_api_client::datadogV2::api_scorecards::{
+    GetScorecardCampaignOptionalParams, ListScorecardCampaignsOptionalParams,
+    ListScorecardOutcomesOptionalParams, ListScorecardRulesOptionalParams,
+    ListScorecardsOptionalParams, ScorecardsAPI,
 };
+use datadog_api_client::datadogV2::model::{CreateCampaignRequest, UpdateCampaignRequest};
 
 use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
-pub async fn rules_list(cfg: &Config) -> Result<()> {
+fn make_api(cfg: &Config) -> ScorecardsAPI {
     let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceScorecardsAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceScorecardsAPI::with_config(dd_cfg),
-    };
+    match client::make_bearer_client(cfg) {
+        Some(c) => ScorecardsAPI::with_client_and_config(dd_cfg, c),
+        None => ScorecardsAPI::with_config(dd_cfg),
+    }
+}
+
+pub async fn rules_list(cfg: &Config) -> Result<()> {
+    let api = make_api(cfg);
     let resp = api
         .list_scorecard_rules(ListScorecardRulesOptionalParams::default())
         .await
@@ -22,11 +29,7 @@ pub async fn rules_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn outcomes_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceScorecardsAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceScorecardsAPI::with_config(dd_cfg),
-    };
+    let api = make_api(cfg);
     let resp = api
         .list_scorecard_outcomes(ListScorecardOutcomesOptionalParams::default())
         .await
@@ -35,12 +38,8 @@ pub async fn outcomes_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn rules_create(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceScorecardsAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceScorecardsAPI::with_config(dd_cfg),
-    };
     let body = util::read_json_file(file)?;
+    let api = make_api(cfg);
     let resp = api
         .create_scorecard_rule(body)
         .await
@@ -49,12 +48,8 @@ pub async fn rules_create(cfg: &Config, file: &str) -> Result<()> {
 }
 
 pub async fn rules_update(cfg: &Config, rule_id: &str, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceScorecardsAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceScorecardsAPI::with_config(dd_cfg),
-    };
     let body = util::read_json_file(file)?;
+    let api = make_api(cfg);
     let resp = api
         .update_scorecard_rule(rule_id.to_string(), body)
         .await
@@ -63,11 +58,7 @@ pub async fn rules_update(cfg: &Config, rule_id: &str, file: &str) -> Result<()>
 }
 
 pub async fn rules_delete(cfg: &Config, rule_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceScorecardsAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceScorecardsAPI::with_config(dd_cfg),
-    };
+    let api = make_api(cfg);
     api.delete_scorecard_rule(rule_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete scorecard rule: {e:?}"))?;
@@ -76,15 +67,70 @@ pub async fn rules_delete(cfg: &Config, rule_id: &str) -> Result<()> {
 }
 
 pub async fn outcomes_batch_create(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceScorecardsAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceScorecardsAPI::with_config(dd_cfg),
-    };
     let body = util::read_json_file(file)?;
+    let api = make_api(cfg);
     let resp = api
         .create_scorecard_outcomes_batch(body)
         .await
         .map_err(|e| anyhow::anyhow!("failed to create scorecard outcomes batch: {e:?}"))?;
     formatter::output(cfg, &resp)
+}
+
+pub async fn list_scorecards(cfg: &Config) -> Result<()> {
+    let api = make_api(cfg);
+    let resp = api
+        .list_scorecards(ListScorecardsOptionalParams::default())
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to list scorecards: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn campaigns_list(cfg: &Config) -> Result<()> {
+    let api = make_api(cfg);
+    let resp = api
+        .list_scorecard_campaigns(ListScorecardCampaignsOptionalParams::default())
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to list scorecard campaigns: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn campaigns_get(cfg: &Config, campaign_id: &str) -> Result<()> {
+    let api = make_api(cfg);
+    let resp = api
+        .get_scorecard_campaign(
+            campaign_id.to_string(),
+            GetScorecardCampaignOptionalParams::default(),
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to get scorecard campaign '{campaign_id}': {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn campaigns_create(cfg: &Config, file: &str) -> Result<()> {
+    let body: CreateCampaignRequest = util::read_json_file(file)?;
+    let api = make_api(cfg);
+    let resp = api
+        .create_scorecard_campaign(body)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to create scorecard campaign: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn campaigns_update(cfg: &Config, campaign_id: &str, file: &str) -> Result<()> {
+    let body: UpdateCampaignRequest = util::read_json_file(file)?;
+    let api = make_api(cfg);
+    let resp = api
+        .update_scorecard_campaign(campaign_id.to_string(), body)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to update scorecard campaign '{campaign_id}': {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn campaigns_delete(cfg: &Config, campaign_id: &str) -> Result<()> {
+    let api = make_api(cfg);
+    api.delete_scorecard_campaign(campaign_id.to_string())
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to delete scorecard campaign '{campaign_id}': {e:?}"))?;
+    println!("Scorecard campaign '{campaign_id}' deleted successfully.");
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7369,6 +7369,8 @@ enum ReferenceTablesActions {
 // ---- Scorecards ----
 #[derive(Subcommand)]
 enum ScorecardsActions {
+    /// List all scorecards
+    List,
     /// Manage scorecard rules
     Rules {
         #[command(subcommand)]
@@ -7378,6 +7380,11 @@ enum ScorecardsActions {
     Outcomes {
         #[command(subcommand)]
         action: ScorecardsOutcomesActions,
+    },
+    /// Manage scorecard campaigns
+    Campaigns {
+        #[command(subcommand)]
+        action: ScorecardsCampaignsActions,
     },
 }
 
@@ -7413,6 +7420,34 @@ enum ScorecardsOutcomesActions {
     BatchCreate {
         #[arg(long, help = "Path to JSON file with outcomes batch")]
         file: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum ScorecardsCampaignsActions {
+    /// List all scorecard campaigns
+    List,
+    /// Get a scorecard campaign by ID
+    Get {
+        #[arg(help = "Campaign ID to retrieve")]
+        campaign_id: String,
+    },
+    /// Create a scorecard campaign from a JSON file
+    Create {
+        #[arg(long, help = "Path to JSON file with campaign definition")]
+        file: String,
+    },
+    /// Update a scorecard campaign from a JSON file
+    Update {
+        #[arg(help = "Campaign ID to update")]
+        campaign_id: String,
+        #[arg(long, help = "Path to JSON file with updated campaign definition")]
+        file: String,
+    },
+    /// Delete a scorecard campaign
+    Delete {
+        #[arg(help = "Campaign ID to delete")]
+        campaign_id: String,
     },
 }
 
@@ -11423,6 +11458,9 @@ async fn main_inner() -> anyhow::Result<()> {
         Commands::Scorecards { action } => {
             cfg.validate_auth()?;
             match action {
+                ScorecardsActions::List => {
+                    commands::scorecards::list_scorecards(&cfg).await?;
+                }
                 ScorecardsActions::Rules { action } => match action {
                     ScorecardsRulesActions::List => {
                         commands::scorecards::rules_list(&cfg).await?;
@@ -11443,6 +11481,23 @@ async fn main_inner() -> anyhow::Result<()> {
                     }
                     ScorecardsOutcomesActions::BatchCreate { file } => {
                         commands::scorecards::outcomes_batch_create(&cfg, &file).await?;
+                    }
+                },
+                ScorecardsActions::Campaigns { action } => match action {
+                    ScorecardsCampaignsActions::List => {
+                        commands::scorecards::campaigns_list(&cfg).await?;
+                    }
+                    ScorecardsCampaignsActions::Get { campaign_id } => {
+                        commands::scorecards::campaigns_get(&cfg, &campaign_id).await?;
+                    }
+                    ScorecardsCampaignsActions::Create { file } => {
+                        commands::scorecards::campaigns_create(&cfg, &file).await?;
+                    }
+                    ScorecardsCampaignsActions::Update { campaign_id, file } => {
+                        commands::scorecards::campaigns_update(&cfg, &campaign_id, &file).await?;
+                    }
+                    ScorecardsCampaignsActions::Delete { campaign_id } => {
+                        commands::scorecards::campaigns_delete(&cfg, &campaign_id).await?;
                     }
                 },
             }


### PR DESCRIPTION
## Summary

Pins the \`datadog-api-client-rust\` git dependency to commit \`8fa08ce0\` (2026-04-10), advancing from \`557230b8\` (2026-04-04). Also includes the scorecards API rename fix required to compile against the new SDK.

## Changes

- \`Cargo.toml\`: update \`rev\` and comment for \`datadog-api-client\`
- \`Cargo.lock\`: regenerated via \`cargo update -p datadog-api-client\`
- \`src/commands/scorecards.rs\`: migrate from deleted \`api_service_scorecards::ServiceScorecardsAPI\` → \`api_scorecards::ScorecardsAPI\`; extract \`make_api\` helper; add \`list_scorecards\` and campaigns CRUD
- \`src/main.rs\`: add \`ScorecardsActions::List\` variant and \`ScorecardsCampaignsActions\` enum + routing

## Upstream SDK changes (16 commits, 281 files)

| Area | What's new |
|---|---|
| **Bits AI** | New \`api_bits_ai\` — GetInvestigation, ListInvestigations, TriggerInvestigation |
| **Feature Flags** | Allocations API — create/update allocations, exposure schedules, rollout steps, guardrail metrics |
| **LLM Observability** | Annotation queues CRUD + annotated interactions retrieval |
| **Scorecards** | **Breaking rename**: \`api_service_scorecards\` → \`api_scorecards\`; new campaigns CRUD, ListScorecards |
| **Security Monitoring** | GetInvestigationLogQueriesMatchingSignal, GetSuggestedActionsMatchingSignal |
| **Test Optimization** | Flaky Tests Management Policies get/update |
| **Observability Pipelines** | S3 compression, Elasticsearch compression/metrics, Splunk HEC token strategy, enrichment table lookups |
| **v1 models** | Description fixes on product_analytics, sankey_rum_query, slo_count_definition |

## Follow-up PRs (all based on this branch)

- #358 — feat(llm-obs): annotation queue commands
- #359 — refactor(investigations): typed BitsAIAPI SDK client
- #360 — feat(test-optimization): flaky tests management policies
- #361 — feat(security): signal investigation + suggested actions
- #362 — feat(feature-flags): allocations + exposure schedules

## Testing

- \`cargo build\` passes
- \`cargo fmt --check\` passes
- \`cargo clippy -- -D warnings\` passes
- \`cargo test\` passes (776 tests)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)