### PR TITLE
fix(scorecards): migrate to api_scorecards + add campaigns and list endpoints

### DIFF
--- a/src/commands/scorecards.rs
+++ b/src/commands/scorecards.rs
@@ -1,19 +1,26 @@
 use anyhow::Result;
-use datadog_api_client::datadogV2::api_service_scorecards::{
-    ListScorecardOutcomesOptionalParams, ListScorecardRulesOptionalParams, ServiceScorecardsAPI,
+use datadog_api_client::datadogV2::api_scorecards::{
+    GetScorecardCampaignOptionalParams, ListScorecardCampaignsOptionalParams,
+    ListScorecardOutcomesOptionalParams, ListScorecardRulesOptionalParams,
+    ListScorecardsOptionalParams, ScorecardsAPI,
 };
+use datadog_api_client::datadogV2::model::{CreateCampaignRequest, UpdateCampaignRequest};
 
 use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
-pub async fn rules_list(cfg: &Config) -> Result<()> {
+fn make_api(cfg: &Config) -> ScorecardsAPI {
     let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceScorecardsAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceScorecardsAPI::with_config(dd_cfg),
-    };
+    match client::make_bearer_client(cfg) {
+        Some(c) => ScorecardsAPI::with_client_and_config(dd_cfg, c),
+        None => ScorecardsAPI::with_config(dd_cfg),
+    }
+}
+
+pub async fn rules_list(cfg: &Config) -> Result<()> {
+    let api = make_api(cfg);
     let resp = api
         .list_scorecard_rules(ListScorecardRulesOptionalParams::default())
         .await
@@ -22,11 +29,7 @@ pub async fn rules_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn outcomes_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceScorecardsAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceScorecardsAPI::with_config(dd_cfg),
-    };
+    let api = make_api(cfg);
     let resp = api
         .list_scorecard_outcomes(ListScorecardOutcomesOptionalParams::default())
         .await
@@ -35,12 +38,8 @@ pub async fn outcomes_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn rules_create(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceScorecardsAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceScorecardsAPI::with_config(dd_cfg),
-    };
     let body = util::read_json_file(file)?;
+    let api = make_api(cfg);
     let resp = api
         .create_scorecard_rule(body)
         .await
@@ -49,12 +48,8 @@ pub async fn rules_create(cfg: &Config, file: &str) -> Result<()> {
 }
 
 pub async fn rules_update(cfg: &Config, rule_id: &str, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceScorecardsAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceScorecardsAPI::with_config(dd_cfg),
-    };
     let body = util::read_json_file(file)?;
+    let api = make_api(cfg);
     let resp = api
         .update_scorecard_rule(rule_id.to_string(), body)
         .await
@@ -63,11 +58,7 @@ pub async fn rules_update(cfg: &Config, rule_id: &str, file: &str) -> Result<()>
 }
 
 pub async fn rules_delete(cfg: &Config, rule_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceScorecardsAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceScorecardsAPI::with_config(dd_cfg),
-    };
+    let api = make_api(cfg);
     api.delete_scorecard_rule(rule_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete scorecard rule: {e:?}"))?;
@@ -76,15 +67,70 @@ pub async fn rules_delete(cfg: &Config, rule_id: &str) -> Result<()> {
 }
 
 pub async fn outcomes_batch_create(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceScorecardsAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceScorecardsAPI::with_config(dd_cfg),
-    };
     let body = util::read_json_file(file)?;
+    let api = make_api(cfg);
     let resp = api
         .create_scorecard_outcomes_batch(body)
         .await
         .map_err(|e| anyhow::anyhow!("failed to create scorecard outcomes batch: {e:?}"))?;
     formatter::output(cfg, &resp)
+}
+
+pub async fn list_scorecards(cfg: &Config) -> Result<()> {
+    let api = make_api(cfg);
+    let resp = api
+        .list_scorecards(ListScorecardsOptionalParams::default())
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to list scorecards: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn campaigns_list(cfg: &Config) -> Result<()> {
+    let api = make_api(cfg);
+    let resp = api
+        .list_scorecard_campaigns(ListScorecardCampaignsOptionalParams::default())
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to list scorecard campaigns: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn campaigns_get(cfg: &Config, campaign_id: &str) -> Result<()> {
+    let api = make_api(cfg);
+    let resp = api
+        .get_scorecard_campaign(
+            campaign_id.to_string(),
+            GetScorecardCampaignOptionalParams::default(),
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to get scorecard campaign '{campaign_id}': {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn campaigns_create(cfg: &Config, file: &str) -> Result<()> {
+    let body: CreateCampaignRequest = util::read_json_file(file)?;
+    let api = make_api(cfg);
+    let resp = api
+        .create_scorecard_campaign(body)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to create scorecard campaign: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn campaigns_update(cfg: &Config, campaign_id: &str, file: &str) -> Result<()> {
+    let body: UpdateCampaignRequest = util::read_json_file(file)?;
+    let api = make_api(cfg);
+    let resp = api
+        .update_scorecard_campaign(campaign_id.to_string(), body)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to update scorecard campaign '{campaign_id}': {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn campaigns_delete(cfg: &Config, campaign_id: &str) -> Result<()> {
+    let api = make_api(cfg);
+    api.delete_scorecard_campaign(campaign_id.to_string())
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to delete scorecard campaign '{campaign_id}': {e:?}"))?;
+    println!("Scorecard campaign '{campaign_id}' deleted successfully.");
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7369,6 +7369,8 @@ enum ReferenceTablesActions {
 // ---- Scorecards ----
 #[derive(Subcommand)]
 enum ScorecardsActions {
+    /// List all scorecards
+    List,
     /// Manage scorecard rules
     Rules {
         #[command(subcommand)]
@@ -7378,6 +7380,11 @@ enum ScorecardsActions {
     Outcomes {
         #[command(subcommand)]
         action: ScorecardsOutcomesActions,
+    },
+    /// Manage scorecard campaigns
+    Campaigns {
+        #[command(subcommand)]
+        action: ScorecardsCampaignsActions,
     },
 }
 
@@ -7413,6 +7420,34 @@ enum ScorecardsOutcomesActions {
     BatchCreate {
         #[arg(long, help = "Path to JSON file with outcomes batch")]
         file: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum ScorecardsCampaignsActions {
+    /// List all scorecard campaigns
+    List,
+    /// Get a scorecard campaign by ID
+    Get {
+        #[arg(help = "Campaign ID to retrieve")]
+        campaign_id: String,
+    },
+    /// Create a scorecard campaign from a JSON file
+    Create {
+        #[arg(long, help = "Path to JSON file with campaign definition")]
+        file: String,
+    },
+    /// Update a scorecard campaign from a JSON file
+    Update {
+        #[arg(help = "Campaign ID to update")]
+        campaign_id: String,
+        #[arg(long, help = "Path to JSON file with updated campaign definition")]
+        file: String,
+    },
+    /// Delete a scorecard campaign
+    Delete {
+        #[arg(help = "Campaign ID to delete")]
+        campaign_id: String,
     },
 }
 
@@ -11423,6 +11458,9 @@ async fn main_inner() -> anyhow::Result<()> {
         Commands::Scorecards { action } => {
             cfg.validate_auth()?;
             match action {
+                ScorecardsActions::List => {
+                    commands::scorecards::list_scorecards(&cfg).await?;
+                }
                 ScorecardsActions::Rules { action } => match action {
                     ScorecardsRulesActions::List => {
                         commands::scorecards::rules_list(&cfg).await?;
@@ -11443,6 +11481,23 @@ async fn main_inner() -> anyhow::Result<()> {
                     }
                     ScorecardsOutcomesActions::BatchCreate { file } => {
                         commands::scorecards::outcomes_batch_create(&cfg, &file).await?;
+                    }
+                },
+                ScorecardsActions::Campaigns { action } => match action {
+                    ScorecardsCampaignsActions::List => {
+                        commands::scorecards::campaigns_list(&cfg).await?;
+                    }
+                    ScorecardsCampaignsActions::Get { campaign_id } => {
+                        commands::scorecards::campaigns_get(&cfg, &campaign_id).await?;
+                    }
+                    ScorecardsCampaignsActions::Create { file } => {
+                        commands::scorecards::campaigns_create(&cfg, &file).await?;
+                    }
+                    ScorecardsCampaignsActions::Update { campaign_id, file } => {
+                        commands::scorecards::campaigns_update(&cfg, &campaign_id, &file).await?;
+                    }
+                    ScorecardsCampaignsActions::Delete { campaign_id } => {
+                        commands::scorecards::campaigns_delete(&cfg, &campaign_id).await?;
                     }
                 },
             }


### PR DESCRIPTION
## Summary

Fixes compile error from SDK bump: `api_service_scorecards::ServiceScorecardsAPI` was renamed to `api_scorecards::ScorecardsAPI` in the upstream SDK. Also adds campaign management and `list scorecards` endpoints now available in the renamed API.

## Changes

- `src/commands/scorecards.rs`: update import from `api_service_scorecards` → `api_scorecards`, extract `make_api` helper, add `list_scorecards`, `campaigns_list/get/create/update/delete` (src/commands/scorecards.rs)
- `src/main.rs`: add `List` variant to `ScorecardsActions`, add `ScorecardsCampaignsActions` enum, add routing arms (src/main.rs)

## New commands

- `pup scorecards list`
- `pup scorecards campaigns list`
- `pup scorecards campaigns get <campaign_id>`
- `pup scorecards campaigns create --file <file>`
- `pup scorecards campaigns update <campaign_id> --file <file>`
- `pup scorecards campaigns delete <campaign_id>`

## Testing

- `cargo build` passes
- `cargo test` passes (776 tests, 0 failures)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)