### PR TITLE
feat(llm-obs): add annotation queue commands

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -243,7 +243,7 @@ static UNSTABLE_OPS: &[&str] = &[
     "v2.delete_aws_cloud_auth_persona_mapping",
     "v2.get_aws_cloud_auth_persona_mapping",
     "v2.list_aws_cloud_auth_persona_mappings",
-    // LLM Observability (8)
+    // LLM Observability (15)
     "v2.create_llm_obs_project",
     "v2.list_llm_obs_projects",
     "v2.create_llm_obs_experiment",
@@ -252,6 +252,13 @@ static UNSTABLE_OPS: &[&str] = &[
     "v2.delete_llm_obs_experiments",
     "v2.create_llm_obs_dataset",
     "v2.list_llm_obs_datasets",
+    "v2.create_llm_obs_annotation_queue",
+    "v2.list_llm_obs_annotation_queues",
+    "v2.update_llm_obs_annotation_queue",
+    "v2.delete_llm_obs_annotation_queue",
+    "v2.create_llm_obs_annotation_queue_interactions",
+    "v2.delete_llm_obs_annotation_queue_interactions",
+    "v2.get_llm_obs_annotated_interactions",
     // Logs Restriction Queries (9)
     "v2.list_restriction_queries",
     "v2.get_restriction_query",
@@ -941,7 +948,7 @@ mod tests {
 
     #[test]
     fn test_unstable_ops_count() {
-        assert_eq!(UNSTABLE_OPS.len(), 131);
+        assert_eq!(UNSTABLE_OPS.len(), 138);
     }
 
     #[test]

--- a/src/commands/llm_obs.rs
+++ b/src/commands/llm_obs.rs
@@ -214,7 +214,6 @@ pub async fn experiments_dimension_values(
 
 // ---- Spans (no typed equivalent — unstable MCP endpoint) ----
 
-#[allow(clippy::too_many_arguments)]
 // ---- Annotation Queues ----
 
 pub async fn annotation_queues_create(cfg: &Config, file: &str) -> Result<()> {

--- a/src/commands/llm_obs.rs
+++ b/src/commands/llm_obs.rs
@@ -1,8 +1,12 @@
 use anyhow::Result;
-use datadog_api_client::datadogV2::api_llm_observability::LLMObservabilityAPI;
+use datadog_api_client::datadogV2::api_llm_observability::{
+    LLMObservabilityAPI, ListLLMObsAnnotationQueuesOptionalParams,
+};
 use datadog_api_client::datadogV2::model::{
-    LLMObsDatasetRequest, LLMObsDeleteExperimentsRequest, LLMObsExperimentRequest,
-    LLMObsExperimentUpdateRequest, LLMObsProjectRequest,
+    LLMObsAnnotationQueueInteractionsRequest, LLMObsAnnotationQueueRequest,
+    LLMObsAnnotationQueueUpdateRequest, LLMObsDatasetRequest,
+    LLMObsDeleteAnnotationQueueInteractionsRequest, LLMObsDeleteExperimentsRequest,
+    LLMObsExperimentRequest, LLMObsExperimentUpdateRequest, LLMObsProjectRequest,
 };
 
 use crate::client;
@@ -205,6 +209,97 @@ pub async fn experiments_dimension_values(
     )
     .await
     .map_err(|e| anyhow::anyhow!("failed to get experiment dimension values: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+// ---- Spans (no typed equivalent — unstable MCP endpoint) ----
+
+#[allow(clippy::too_many_arguments)]
+// ---- Annotation Queues ----
+
+pub async fn annotation_queues_create(cfg: &Config, file: &str) -> Result<()> {
+    let body: LLMObsAnnotationQueueRequest = util::read_json_file(file)?;
+    let api = make_api(cfg);
+    let resp = api
+        .create_llm_obs_annotation_queue(body)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to create annotation queue: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn annotation_queues_list(
+    cfg: &Config,
+    project_id: Option<String>,
+    queue_ids: Option<Vec<String>>,
+) -> Result<()> {
+    let api = make_api(cfg);
+    let mut params = ListLLMObsAnnotationQueuesOptionalParams::default();
+    if let Some(pid) = project_id {
+        params = params.project_id(pid);
+    }
+    if let Some(ids) = queue_ids {
+        params = params.queue_ids(ids);
+    }
+    let resp = api
+        .list_llm_obs_annotation_queues(params)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to list annotation queues: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn annotation_queues_update(cfg: &Config, queue_id: &str, file: &str) -> Result<()> {
+    let body: LLMObsAnnotationQueueUpdateRequest = util::read_json_file(file)?;
+    let api = make_api(cfg);
+    let resp = api
+        .update_llm_obs_annotation_queue(queue_id.to_string(), body)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to update annotation queue: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn annotation_queues_delete(cfg: &Config, queue_id: &str) -> Result<()> {
+    let api = make_api(cfg);
+    api.delete_llm_obs_annotation_queue(queue_id.to_string())
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to delete annotation queue: {e:?}"))?;
+    eprintln!("Annotation queue deleted.");
+    Ok(())
+}
+
+pub async fn annotation_queue_interactions_add(
+    cfg: &Config,
+    queue_id: &str,
+    file: &str,
+) -> Result<()> {
+    let body: LLMObsAnnotationQueueInteractionsRequest = util::read_json_file(file)?;
+    let api = make_api(cfg);
+    let resp = api
+        .create_llm_obs_annotation_queue_interactions(queue_id.to_string(), body)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to add interactions: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn annotation_queue_interactions_delete(
+    cfg: &Config,
+    queue_id: &str,
+    file: &str,
+) -> Result<()> {
+    let body: LLMObsDeleteAnnotationQueueInteractionsRequest = util::read_json_file(file)?;
+    let api = make_api(cfg);
+    api.delete_llm_obs_annotation_queue_interactions(queue_id.to_string(), body)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to delete interactions: {e:?}"))?;
+    eprintln!("Annotation queue interactions deleted.");
+    Ok(())
+}
+
+pub async fn annotation_queue_interactions_list(cfg: &Config, queue_id: &str) -> Result<()> {
+    let api = make_api(cfg);
+    let resp = api
+        .get_llm_obs_annotated_interactions(queue_id.to_string())
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to list annotated interactions: {e:?}"))?;
     formatter::output(cfg, &resp)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7185,6 +7185,12 @@ enum LlmObsActions {
         #[command(subcommand)]
         action: LlmObsSpansActions,
     },
+    /// Manage LLM Observability annotation queues
+    #[command(name = "annotation-queues")]
+    AnnotationQueues {
+        #[command(subcommand)]
+        action: LlmObsAnnotationQueuesActions,
+    },
 }
 
 #[derive(Subcommand)]
@@ -7333,6 +7339,66 @@ enum LlmObsDatasetsActions {
     List {
         #[arg(long, help = "Project ID (required)")]
         project_id: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum LlmObsAnnotationQueuesActions {
+    /// Create an annotation queue
+    Create {
+        #[arg(long, help = "JSON file with annotation queue body (required)")]
+        file: String,
+    },
+    /// List annotation queues
+    List {
+        #[arg(long, help = "Filter by project ID")]
+        project_id: Option<String>,
+        #[arg(
+            long,
+            value_delimiter = ',',
+            help = "Filter by queue IDs (comma-separated)"
+        )]
+        queue_ids: Option<Vec<String>>,
+    },
+    /// Update an annotation queue
+    Update {
+        #[arg(help = "Annotation queue ID")]
+        queue_id: String,
+        #[arg(long, help = "JSON file with annotation queue update body (required)")]
+        file: String,
+    },
+    /// Delete an annotation queue
+    Delete {
+        #[arg(help = "Annotation queue ID")]
+        queue_id: String,
+    },
+    /// Manage interactions within an annotation queue
+    Interactions {
+        #[command(subcommand)]
+        action: LlmObsAnnotationQueueInteractionsActions,
+    },
+}
+
+#[derive(Subcommand)]
+enum LlmObsAnnotationQueueInteractionsActions {
+    /// Add interactions to an annotation queue
+    Add {
+        #[arg(help = "Annotation queue ID")]
+        queue_id: String,
+        #[arg(long, help = "JSON file with interactions body (required)")]
+        file: String,
+    },
+    /// Remove interactions from an annotation queue
+    Delete {
+        #[arg(help = "Annotation queue ID")]
+        queue_id: String,
+        #[arg(long, help = "JSON file with interactions to delete (required)")]
+        file: String,
+    },
+    /// List annotated interactions for an annotation queue
+    List {
+        #[arg(help = "Annotation queue ID")]
+        queue_id: String,
     },
 }
 
@@ -11950,6 +12016,42 @@ async fn main_inner() -> anyhow::Result<()> {
                         )
                         .await?;
                     }
+                },
+                LlmObsActions::AnnotationQueues { action } => match action {
+                    LlmObsAnnotationQueuesActions::Create { file } => {
+                        commands::llm_obs::annotation_queues_create(&cfg, &file).await?;
+                    }
+                    LlmObsAnnotationQueuesActions::List {
+                        project_id,
+                        queue_ids,
+                    } => {
+                        commands::llm_obs::annotation_queues_list(&cfg, project_id, queue_ids)
+                            .await?;
+                    }
+                    LlmObsAnnotationQueuesActions::Update { queue_id, file } => {
+                        commands::llm_obs::annotation_queues_update(&cfg, &queue_id, &file).await?;
+                    }
+                    LlmObsAnnotationQueuesActions::Delete { queue_id } => {
+                        commands::llm_obs::annotation_queues_delete(&cfg, &queue_id).await?;
+                    }
+                    LlmObsAnnotationQueuesActions::Interactions { action } => match action {
+                        LlmObsAnnotationQueueInteractionsActions::Add { queue_id, file } => {
+                            commands::llm_obs::annotation_queue_interactions_add(
+                                &cfg, &queue_id, &file,
+                            )
+                            .await?;
+                        }
+                        LlmObsAnnotationQueueInteractionsActions::Delete { queue_id, file } => {
+                            commands::llm_obs::annotation_queue_interactions_delete(
+                                &cfg, &queue_id, &file,
+                            )
+                            .await?;
+                        }
+                        LlmObsAnnotationQueueInteractionsActions::List { queue_id } => {
+                            commands::llm_obs::annotation_queue_interactions_list(&cfg, &queue_id)
+                                .await?;
+                        }
+                    },
                 },
             }
         }


### PR DESCRIPTION
## Summary

Adds annotation queue management to `pup llm-obs`, surfacing the new annotation queue API from the SDK bump (8fa08ce0, 2026-04-10).

## New commands

- `pup llm-obs annotation-queues create --file <json>`
- `pup llm-obs annotation-queues list [--project-id <id>] [--queue-ids <ids>]`
- `pup llm-obs annotation-queues update <queue-id> --file <json>`
- `pup llm-obs annotation-queues delete <queue-id>`
- `pup llm-obs annotation-queues interactions add <queue-id> --file <json>`
- `pup llm-obs annotation-queues interactions delete <queue-id> --file <json>`
- `pup llm-obs annotation-queues interactions list <queue-id>`

## Changes

- `src/commands/llm_obs.rs`: 7 new async functions + updated imports (`ListLLMObsAnnotationQueuesOptionalParams`, `LLMObsAnnotationQueueRequest`, `LLMObsAnnotationQueueUpdateRequest`, `LLMObsAnnotationQueueInteractionsRequest`, `LLMObsDeleteAnnotationQueueInteractionsRequest`)
- `src/main.rs`: `LlmObsAnnotationQueuesActions` + `LlmObsAnnotationQueueInteractionsActions` enums + routing arm in `Commands::LlmObs` match block
- `src/client.rs`: 7 new unstable op IDs added to `UNSTABLE_OPS` (count updated 131 → 138)

## Testing

- `cargo build` introduces no new errors (7 pre-existing errors in `src/commands/scorecards.rs` from the base branch SDK bump are unrelated)
- `cargo fmt --check` passes
- All annotation queue methods confirmed unstable in SDK (`is_unstable_operation_enabled` gate) and registered accordingly

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)