### PR TITLE
feat(feature-flags): add allocations and exposure schedule commands

### DIFF
--- a/src/commands/feature_flags.rs
+++ b/src/commands/feature_flags.rs
@@ -231,3 +231,103 @@ pub async fn disable(
     eprintln!("Feature flag {feature_flag_id} disabled in environment {feature_flags_env_id}.");
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// Allocations
+// ---------------------------------------------------------------------------
+
+pub async fn allocations_create(
+    cfg: &Config,
+    feature_flag_id: &str,
+    environment_id: &str,
+    file: &str,
+) -> Result<()> {
+    let body: datadog_api_client::datadogV2::model::CreateAllocationsRequest =
+        util::read_json_file(file)?;
+    let api = make_api(cfg);
+    let flag_id = feature_flag_id
+        .parse::<uuid::Uuid>()
+        .map_err(|e| anyhow::anyhow!("invalid feature flag ID: {e:?}"))?;
+    let env_id = environment_id
+        .parse::<uuid::Uuid>()
+        .map_err(|e| anyhow::anyhow!("invalid environment ID: {e:?}"))?;
+    let resp = api
+        .create_allocations_for_feature_flag_in_environment(flag_id, env_id, body)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to create allocations: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn allocations_update(
+    cfg: &Config,
+    feature_flag_id: &str,
+    environment_id: &str,
+    file: &str,
+) -> Result<()> {
+    let body: datadog_api_client::datadogV2::model::OverwriteAllocationsRequest =
+        util::read_json_file(file)?;
+    let api = make_api(cfg);
+    let flag_id = feature_flag_id
+        .parse::<uuid::Uuid>()
+        .map_err(|e| anyhow::anyhow!("invalid feature flag ID: {e:?}"))?;
+    let env_id = environment_id
+        .parse::<uuid::Uuid>()
+        .map_err(|e| anyhow::anyhow!("invalid environment ID: {e:?}"))?;
+    let resp = api
+        .update_allocations_for_feature_flag_in_environment(flag_id, env_id, body)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to update allocations: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+// ---------------------------------------------------------------------------
+// Exposure schedules
+// ---------------------------------------------------------------------------
+
+pub async fn exposure_start(cfg: &Config, exposure_schedule_id: &str) -> Result<()> {
+    let api = make_api(cfg);
+    let id = exposure_schedule_id
+        .parse::<uuid::Uuid>()
+        .map_err(|e| anyhow::anyhow!("invalid exposure schedule ID: {e:?}"))?;
+    let resp = api
+        .start_exposure_schedule(id)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to start exposure schedule: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn exposure_stop(cfg: &Config, exposure_schedule_id: &str) -> Result<()> {
+    let api = make_api(cfg);
+    let id = exposure_schedule_id
+        .parse::<uuid::Uuid>()
+        .map_err(|e| anyhow::anyhow!("invalid exposure schedule ID: {e:?}"))?;
+    let resp = api
+        .stop_exposure_schedule(id)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to stop exposure schedule: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn exposure_pause(cfg: &Config, exposure_schedule_id: &str) -> Result<()> {
+    let api = make_api(cfg);
+    let id = exposure_schedule_id
+        .parse::<uuid::Uuid>()
+        .map_err(|e| anyhow::anyhow!("invalid exposure schedule ID: {e:?}"))?;
+    let resp = api
+        .pause_exposure_schedule(id)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to pause exposure schedule: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn exposure_resume(cfg: &Config, exposure_schedule_id: &str) -> Result<()> {
+    let api = make_api(cfg);
+    let id = exposure_schedule_id
+        .parse::<uuid::Uuid>()
+        .map_err(|e| anyhow::anyhow!("invalid exposure schedule ID: {e:?}"))?;
+    let resp = api
+        .resume_exposure_schedule(id)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to resume exposure schedule: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}

--- a/src/commands/scorecards.rs
+++ b/src/commands/scorecards.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
-use datadog_api_client::datadogV2::api_service_scorecards::{
-    ListScorecardOutcomesOptionalParams, ListScorecardRulesOptionalParams, ServiceScorecardsAPI,
+use datadog_api_client::datadogV2::api_scorecards::{
+    ListScorecardOutcomesOptionalParams, ListScorecardRulesOptionalParams, ScorecardsAPI,
 };
 
 use crate::client;
@@ -8,12 +8,16 @@ use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
-pub async fn rules_list(cfg: &Config) -> Result<()> {
+fn make_api(cfg: &Config) -> ScorecardsAPI {
     let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceScorecardsAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceScorecardsAPI::with_config(dd_cfg),
-    };
+    match client::make_bearer_client(cfg) {
+        Some(c) => ScorecardsAPI::with_client_and_config(dd_cfg, c),
+        None => ScorecardsAPI::with_config(dd_cfg),
+    }
+}
+
+pub async fn rules_list(cfg: &Config) -> Result<()> {
+    let api = make_api(cfg);
     let resp = api
         .list_scorecard_rules(ListScorecardRulesOptionalParams::default())
         .await
@@ -22,11 +26,7 @@ pub async fn rules_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn outcomes_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceScorecardsAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceScorecardsAPI::with_config(dd_cfg),
-    };
+    let api = make_api(cfg);
     let resp = api
         .list_scorecard_outcomes(ListScorecardOutcomesOptionalParams::default())
         .await
@@ -35,11 +35,7 @@ pub async fn outcomes_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn rules_create(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceScorecardsAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceScorecardsAPI::with_config(dd_cfg),
-    };
+    let api = make_api(cfg);
     let body = util::read_json_file(file)?;
     let resp = api
         .create_scorecard_rule(body)
@@ -49,11 +45,7 @@ pub async fn rules_create(cfg: &Config, file: &str) -> Result<()> {
 }
 
 pub async fn rules_update(cfg: &Config, rule_id: &str, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceScorecardsAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceScorecardsAPI::with_config(dd_cfg),
-    };
+    let api = make_api(cfg);
     let body = util::read_json_file(file)?;
     let resp = api
         .update_scorecard_rule(rule_id.to_string(), body)
@@ -63,11 +55,7 @@ pub async fn rules_update(cfg: &Config, rule_id: &str, file: &str) -> Result<()>
 }
 
 pub async fn rules_delete(cfg: &Config, rule_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceScorecardsAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceScorecardsAPI::with_config(dd_cfg),
-    };
+    let api = make_api(cfg);
     api.delete_scorecard_rule(rule_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete scorecard rule: {e:?}"))?;
@@ -76,11 +64,7 @@ pub async fn rules_delete(cfg: &Config, rule_id: &str) -> Result<()> {
 }
 
 pub async fn outcomes_batch_create(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceScorecardsAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceScorecardsAPI::with_config(dd_cfg),
-    };
+    let api = make_api(cfg);
     let body = util::read_json_file(file)?;
     let resp = api
         .create_scorecard_outcomes_batch(body)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1241,11 +1241,14 @@ enum Commands {
     ///
     /// Feature flags let you control the rollout of features to your users.
     /// This command group covers flag lifecycle management as well as
-    /// environment configuration and per-environment enable/disable controls.
+    /// environment configuration, per-environment enable/disable controls,
+    /// traffic allocations, and exposure schedule management.
     ///
     /// COMMAND GROUPS:
     ///   flags           Manage feature flag definitions (list, get, create, update, archive, unarchive)
     ///   environments    Manage feature flag environments (list, get, create, update, delete)
+    ///   allocations     Manage traffic allocations for a flag in an environment (create, update)
+    ///   exposure        Manage exposure schedules (start, stop, pause, resume)
     ///
     /// DIRECT COMMANDS:
     ///   enable          Enable a feature flag in an environment
@@ -1275,6 +1278,18 @@ enum Commands {
     ///
     ///   # Disable a flag in an environment
     ///   pup feature-flags disable <flag-id> <env-id>
+    ///
+    ///   # Create allocations for a flag in an environment
+    ///   pup feature-flags allocations create <flag-id> <env-id> --file=alloc.json
+    ///
+    ///   # Update (overwrite) allocations for a flag in an environment
+    ///   pup feature-flags allocations update <flag-id> <env-id> --file=alloc.json
+    ///
+    ///   # Start an exposure schedule
+    ///   pup feature-flags exposure start <schedule-id>
+    ///
+    ///   # Stop an exposure schedule
+    ///   pup feature-flags exposure stop <schedule-id>
     ///
     /// AUTHENTICATION:
     ///   Requires either OAuth2 authentication (pup auth login) or API keys
@@ -6232,6 +6247,16 @@ enum FeatureFlagActions {
         #[command(subcommand)]
         action: FeatureFlagEnvActions,
     },
+    /// Manage traffic allocations for a feature flag in an environment
+    Allocations {
+        #[command(subcommand)]
+        action: FeatureFlagAllocActions,
+    },
+    /// Manage exposure schedules for a feature flag
+    Exposure {
+        #[command(subcommand)]
+        action: FeatureFlagExposureActions,
+    },
     /// Enable a feature flag in an environment
     Enable {
         #[arg(help = "Feature flag ID (UUID)")]
@@ -6324,6 +6349,52 @@ enum FeatureFlagEnvActions {
     Delete {
         #[arg(help = "Environment ID (UUID)")]
         feature_flags_env_id: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum FeatureFlagAllocActions {
+    /// Create allocations for a feature flag in an environment
+    Create {
+        #[arg(help = "Feature flag ID (UUID)")]
+        feature_flag_id: String,
+        #[arg(help = "Environment ID (UUID)")]
+        environment_id: String,
+        #[arg(long, help = "JSON file with request body (required)")]
+        file: String,
+    },
+    /// Update (overwrite) allocations for a feature flag in an environment
+    Update {
+        #[arg(help = "Feature flag ID (UUID)")]
+        feature_flag_id: String,
+        #[arg(help = "Environment ID (UUID)")]
+        environment_id: String,
+        #[arg(long, help = "JSON file with request body (required)")]
+        file: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum FeatureFlagExposureActions {
+    /// Start an exposure schedule
+    Start {
+        #[arg(help = "Exposure schedule ID (UUID)")]
+        exposure_schedule_id: String,
+    },
+    /// Stop an exposure schedule
+    Stop {
+        #[arg(help = "Exposure schedule ID (UUID)")]
+        exposure_schedule_id: String,
+    },
+    /// Pause an exposure schedule
+    Pause {
+        #[arg(help = "Exposure schedule ID (UUID)")]
+        exposure_schedule_id: String,
+    },
+    /// Resume an exposure schedule
+    Resume {
+        #[arg(help = "Exposure schedule ID (UUID)")]
+        exposure_schedule_id: String,
     },
 }
 
@@ -10752,6 +10823,59 @@ async fn main_inner() -> anyhow::Result<()> {
                         feature_flags_env_id,
                     } => {
                         commands::feature_flags::envs_delete(&cfg, &feature_flags_env_id).await?;
+                    }
+                },
+                FeatureFlagActions::Allocations { action } => match action {
+                    FeatureFlagAllocActions::Create {
+                        feature_flag_id,
+                        environment_id,
+                        file,
+                    } => {
+                        commands::feature_flags::allocations_create(
+                            &cfg,
+                            &feature_flag_id,
+                            &environment_id,
+                            &file,
+                        )
+                        .await?;
+                    }
+                    FeatureFlagAllocActions::Update {
+                        feature_flag_id,
+                        environment_id,
+                        file,
+                    } => {
+                        commands::feature_flags::allocations_update(
+                            &cfg,
+                            &feature_flag_id,
+                            &environment_id,
+                            &file,
+                        )
+                        .await?;
+                    }
+                },
+                FeatureFlagActions::Exposure { action } => match action {
+                    FeatureFlagExposureActions::Start {
+                        exposure_schedule_id,
+                    } => {
+                        commands::feature_flags::exposure_start(&cfg, &exposure_schedule_id)
+                            .await?;
+                    }
+                    FeatureFlagExposureActions::Stop {
+                        exposure_schedule_id,
+                    } => {
+                        commands::feature_flags::exposure_stop(&cfg, &exposure_schedule_id).await?;
+                    }
+                    FeatureFlagExposureActions::Pause {
+                        exposure_schedule_id,
+                    } => {
+                        commands::feature_flags::exposure_pause(&cfg, &exposure_schedule_id)
+                            .await?;
+                    }
+                    FeatureFlagExposureActions::Resume {
+                        exposure_schedule_id,
+                    } => {
+                        commands::feature_flags::exposure_resume(&cfg, &exposure_schedule_id)
+                            .await?;
                     }
                 },
                 FeatureFlagActions::Enable {


### PR DESCRIPTION
## Summary

Extends `pup feature-flags` with allocations and exposure schedule management commands, and fixes a build-blocking API rename in the scorecards module introduced by the 2026-04-10 SDK bump.

## Changes

- `src/commands/feature_flags.rs` — adds six new async handler functions:
  - `allocations_create` / `allocations_update` (traffic allocation CRUD)
  - `exposure_start` / `exposure_stop` / `exposure_pause` / `exposure_resume`
- `src/main.rs` — wires up the new handlers via two new subcommand groups (`Allocations`, `Exposure`) added to `FeatureFlagActions`, with corresponding `FeatureFlagAllocActions` and `FeatureFlagExposureActions` enums; updates the `feature-flags` help doc
- `src/commands/scorecards.rs` — fixes broken import (`api_service_scorecards` → `api_scorecards`, `ServiceScorecardsAPI` → `ScorecardsAPI`) so the crate compiles against the bumped SDK; also refactors repeated `match client::make_bearer_client` blocks into a shared `make_api` helper

## Testing

- `cargo build` — clean
- `cargo fmt --check` — clean
- `cargo clippy -- -D warnings` — clean
- `cargo test` — 179/179 passed

## New commands

```
pup feature-flags allocations create <flag-id> <env-id> --file=alloc.json
pup feature-flags allocations update <flag-id> <env-id> --file=alloc.json
pup feature-flags exposure start  <schedule-id>
pup feature-flags exposure stop   <schedule-id>
pup feature-flags exposure pause  <schedule-id>
pup feature-flags exposure resume <schedule-id>
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)