### PR TITLE
refactor(investigations): migrate to typed BitsAIAPI SDK client

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -302,6 +302,10 @@ static UNSTABLE_OPS: &[&str] = &[
     "v2.list_custom_rule_revisions",
     "v2.revert_custom_rule_revision",
     "v2.update_custom_ruleset",
+    // Bits AI Investigations (3)
+    "v2.get_investigation",
+    "v2.list_investigations",
+    "v2.trigger_investigation",
 ];
 
 // ---------------------------------------------------------------------------
@@ -950,7 +954,7 @@ mod tests {
 
     #[test]
     fn test_unstable_ops_count() {
-        assert_eq!(UNSTABLE_OPS.len(), 140);
+        assert_eq!(UNSTABLE_OPS.len(), 143);
     }
 
     #[test]

--- a/src/commands/investigations.rs
+++ b/src/commands/investigations.rs
@@ -1,25 +1,47 @@
 use anyhow::Result;
+use datadog_api_client::datadogV2::api_bits_ai::{BitsAIAPI, ListInvestigationsOptionalParams};
 
 use crate::client;
 use crate::config::Config;
 use crate::formatter;
+use crate::util;
+
+fn make_api(cfg: &Config) -> BitsAIAPI {
+    let dd_cfg = client::make_dd_config(cfg);
+    match client::make_bearer_client(cfg) {
+        Some(c) => BitsAIAPI::with_client_and_config(dd_cfg, c),
+        None => BitsAIAPI::with_config(dd_cfg),
+    }
+}
 
 pub async fn list(cfg: &Config, page_limit: i64, page_offset: i64) -> Result<()> {
-    let path = format!(
-        "/api/v2/bits-ai/investigations?page[limit]={page_limit}&page[offset]={page_offset}"
-    );
-    let data = client::raw_get(cfg, &path, &[]).await?;
-    formatter::output(cfg, &data)
+    let api = make_api(cfg);
+    let params = ListInvestigationsOptionalParams::default()
+        .page_limit(page_limit)
+        .page_offset(page_offset);
+    let resp = api
+        .list_investigations(params)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to list investigations: {e:?}"))?;
+    formatter::output(cfg, &resp)
 }
 
 pub async fn get(cfg: &Config, investigation_id: &str) -> Result<()> {
-    let path = format!("/api/unstable/bits-ai/investigation/{investigation_id}");
-    let data = client::raw_get(cfg, &path, &[]).await?;
-    formatter::output(cfg, &data)
+    let api = make_api(cfg);
+    let resp = api
+        .get_investigation(investigation_id.to_string())
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to get investigation: {e:?}"))?;
+    formatter::output(cfg, &resp)
 }
 
 pub async fn trigger(cfg: &Config, file: &str) -> Result<()> {
-    let body: serde_json::Value = crate::util::read_json_file(file)?;
-    let data = client::raw_post(cfg, "/api/v2/bits-ai/investigations", body).await?;
-    formatter::output(cfg, &data)
+    let body: datadog_api_client::datadogV2::model::TriggerInvestigationRequest =
+        util::read_json_file(file)?;
+    let api = make_api(cfg);
+    let resp = api
+        .trigger_investigation(body)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to trigger investigation: {e:?}"))?;
+    formatter::output(cfg, &resp)
 }


### PR DESCRIPTION
## Summary

Migrates `investigations.rs` from raw HTTP calls to the typed `BitsAIAPI` SDK client, consistent with how other commands use the SDK (e.g., `feature_flags.rs`). No CLI surface changes.

## Changes

- `src/commands/investigations.rs`: replace `client::raw_get/raw_post` with `BitsAIAPI` typed calls; add `make_api` helper
- `src/client.rs`: register three unstable operation IDs (`v2.get_investigation`, `v2.list_investigations`, `v2.trigger_investigation`); update count to 143

## Notes

- `get` URL path changes from `/api/unstable/bits-ai/investigation/{id}` → `/api/v2/bits-ai/investigations/{id}` (promoted to v2 in the SDK)
- `trigger` body now deserializes into typed `TriggerInvestigationRequest` instead of raw `serde_json::Value`

## Testing

- `cargo build` passes
- `cargo fmt --check` passes
- `cargo clippy -- -D warnings` passes
- `cargo test` passes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)