### PR TITLE
feat(logs): add --sort option to logs aggregate

### DIFF
--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -20,6 +20,7 @@ pub struct AggregateArgs {
     pub group_by: Vec<String>,
     pub limit: i32,
     pub storage: Option<String>,
+    pub sort: String,
 }
 
 fn normalize_storage_tier(storage: Option<String>) -> Result<Option<String>> {
@@ -132,6 +133,36 @@ fn parse_compute_raw(input: &str) -> Result<(String, Option<String>)> {
     )
 }
 
+const VALID_SORT_AGGREGATIONS: &[&str] = &[
+    "count",
+    "cardinality",
+    "pc75",
+    "pc90",
+    "pc95",
+    "pc98",
+    "pc99",
+    "sum",
+    "min",
+    "max",
+];
+
+fn parse_aggregate_sort(sort: &str) -> Result<serde_json::Value> {
+    let sort = sort.trim().to_lowercase();
+    if !VALID_SORT_AGGREGATIONS.contains(&sort.as_str()) {
+        bail!(
+            "unknown sort aggregation {:?}; valid values are: {}",
+            sort,
+            VALID_SORT_AGGREGATIONS.join(", ")
+        );
+    }
+    Ok(serde_json::json!({
+        "type": "measure",
+        "order": "desc",
+        "aggregation": sort
+    }))
+}
+
+#[allow(clippy::too_many_arguments)]
 fn build_aggregate_body(
     query: String,
     from_ms: i64,
@@ -140,6 +171,7 @@ fn build_aggregate_body(
     group_bys: Vec<String>,
     limit: i32,
     storage: Option<String>,
+    sort: &str,
 ) -> Result<serde_json::Value> {
     let storage_tier = normalize_storage_tier(storage)?;
 
@@ -170,10 +202,11 @@ fn build_aggregate_body(
     });
 
     if !group_bys.is_empty() {
+        let sort_obj = parse_aggregate_sort(sort)?;
         let group_by_arr: Vec<serde_json::Value> = group_bys
             .iter()
             .map(|facet| {
-                let mut obj = serde_json::json!({ "facet": facet });
+                let mut obj = serde_json::json!({ "facet": facet, "sort": sort_obj });
                 if limit > 0 {
                     obj["limit"] = serde_json::json!(limit);
                 }
@@ -291,13 +324,16 @@ pub async fn aggregate(cfg: &Config, args: AggregateArgs) -> Result<()> {
         group_by,
         limit,
         storage,
+        sort,
     } = args;
     if compute.is_empty() {
         compute.push("count".into());
     }
     let from_ms = util::parse_time_to_unix_millis(&from)?;
     let to_ms = util::parse_time_to_unix_millis(&to)?;
-    let body = build_aggregate_body(query, from_ms, to_ms, compute, group_by, limit, storage)?;
+    let body = build_aggregate_body(
+        query, from_ms, to_ms, compute, group_by, limit, storage, &sort,
+    )?;
     let data = client::raw_post(cfg, "/api/v2/logs/analytics/aggregate", body).await?;
     formatter::output(cfg, &data)?;
     Ok(())
@@ -565,6 +601,7 @@ mod tests {
             vec!["service".into()],
             3,
             Some("flex".into()),
+            "count",
         )
         .unwrap();
 
@@ -583,7 +620,12 @@ mod tests {
                 }],
                 "group_by": [{
                     "facet": "service",
-                    "limit": 3
+                    "limit": 3,
+                    "sort": {
+                        "type": "measure",
+                        "order": "desc",
+                        "aggregation": "count"
+                    }
                 }]
             })
         );
@@ -591,8 +633,17 @@ mod tests {
 
     #[test]
     fn test_build_aggregate_body_omits_group_by_for_plain_count() {
-        let body =
-            build_aggregate_body("*".into(), 1, 2, vec!["count".into()], vec![], 10, None).unwrap();
+        let body = build_aggregate_body(
+            "*".into(),
+            1,
+            2,
+            vec!["count".into()],
+            vec![],
+            10,
+            None,
+            "count",
+        )
+        .unwrap();
 
         assert_eq!(
             body,
@@ -623,6 +674,7 @@ mod tests {
             vec![],
             10,
             None,
+            "count",
         )
         .unwrap();
 
@@ -653,6 +705,7 @@ mod tests {
             vec!["service".into(), "status".into()],
             5,
             None,
+            "count",
         )
         .unwrap();
 
@@ -666,11 +719,80 @@ mod tests {
                 },
                 "compute": [{ "aggregation": "count" }],
                 "group_by": [
-                    { "facet": "service", "limit": 5 },
-                    { "facet": "status", "limit": 5 }
+                    { "facet": "service", "limit": 5, "sort": { "type": "measure", "order": "desc", "aggregation": "count" } },
+                    { "facet": "status", "limit": 5, "sort": { "type": "measure", "order": "desc", "aggregation": "count" } }
                 ]
             })
         );
+    }
+
+    #[test]
+    fn test_parse_aggregate_sort_valid_values() {
+        for agg in VALID_SORT_AGGREGATIONS {
+            let sort = parse_aggregate_sort(agg).unwrap();
+            assert_eq!(sort["aggregation"], *agg);
+            assert_eq!(sort["order"], "desc");
+            assert_eq!(sort["type"], "measure");
+        }
+    }
+
+    #[test]
+    fn test_parse_aggregate_sort_case_insensitive() {
+        let sort = parse_aggregate_sort("PC95").unwrap();
+        assert_eq!(sort["aggregation"], "pc95");
+    }
+
+    #[test]
+    fn test_parse_aggregate_sort_trims_whitespace() {
+        let sort = parse_aggregate_sort("  sum  ").unwrap();
+        assert_eq!(sort["aggregation"], "sum");
+    }
+
+    #[test]
+    fn test_parse_aggregate_sort_invalid() {
+        let err = parse_aggregate_sort("invalid").unwrap_err();
+        assert!(err.to_string().contains("unknown sort aggregation"));
+    }
+
+    #[test]
+    fn test_build_aggregate_body_sort_pc95() {
+        let body = build_aggregate_body(
+            "*".into(),
+            1,
+            2,
+            vec!["count".into()],
+            vec!["host".into()],
+            10,
+            None,
+            "pc95",
+        )
+        .unwrap();
+
+        assert_eq!(
+            body["group_by"][0]["sort"],
+            serde_json::json!({
+                "type": "measure",
+                "order": "desc",
+                "aggregation": "pc95"
+            })
+        );
+    }
+
+    #[test]
+    fn test_build_aggregate_body_sort_not_included_without_group_by() {
+        let body = build_aggregate_body(
+            "*".into(),
+            1,
+            2,
+            vec!["count".into()],
+            vec![],
+            10,
+            None,
+            "pc95",
+        )
+        .unwrap();
+
+        assert!(body.get("group_by").is_none());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2889,6 +2889,12 @@ enum LogActions {
         limit: i32,
         #[arg(long, help = "Storage tier: indexes, online-archives, or flex")]
         storage: Option<String>,
+        #[arg(
+            long,
+            default_value = "count",
+            help = "Sort groups by aggregation (count,cardinality,pc75,pc90,pc95,pc98,pc99,sum,min,max)"
+        )]
+        sort: String,
     },
     /// Manage log archives
     Archives {
@@ -9045,6 +9051,7 @@ async fn main_inner() -> anyhow::Result<()> {
                     group_by,
                     limit,
                     storage,
+                    sort,
                 } => {
                     commands::logs::aggregate(
                         &cfg,
@@ -9063,6 +9070,7 @@ async fn main_inner() -> anyhow::Result<()> {
                                 .unwrap_or_default(),
                             limit,
                             storage,
+                            sort,
                         },
                     )
                     .await?;

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -594,6 +594,7 @@ async fn test_logs_aggregate() {
             group_by: vec![],
             limit: 10,
             storage: None,
+            sort: "count".into(),
         },
     )
     .await;
@@ -620,6 +621,7 @@ async fn test_logs_aggregate_multiple_computes() {
             group_by: vec!["service".into(), "status".into()],
             limit: 10,
             storage: None,
+            sort: "count".into(),
         },
     )
     .await;
@@ -728,6 +730,7 @@ async fn test_logs_aggregate_with_flex_storage() {
             group_by: vec![],
             limit: 10,
             storage: Some("flex".into()),
+            sort: "count".into(),
         },
     )
     .await;


### PR DESCRIPTION
Currently, aggregating logs will only sort alphabetically. This makes it hard to use effectively, for example finding the most common application errors. This PR adds support for the sort option that [already exists](https://docs.datadoghq.com/api/latest/logs/#aggregate-events) in the Datadog API
## Summary
- Add `--sort` option to `pup logs aggregate` command to control how grouped results are sorted
- Supports aggregation functions: `count`, `cardinality`, `pc75`, `pc90`, `pc95`, `pc98`, `pc99`, `sum`, `min`, `max`
- Defaults to sorting by `count` (descending), changing the previous behavior which relied on the API default (alphabetical)

## Changes
- `src/main.rs`: Add `--sort` CLI argument to `Aggregate` variant with default value `"count"` and pass through to handler
- `src/commands/logs.rs`: Add `sort` field to `AggregateArgs`, add `parse_aggregate_sort()` validation function, inject sort object into each `group_by` entry in the API request body per the [Logs Aggregate API spec](https://docs.datadoghq.com/api/latest/logs/#aggregate-events)
- `src/test_commands.rs`: Update existing integration tests for new field

## Testing
- 6 new unit tests for sort parsing (valid values, case insensitivity, whitespace trimming, invalid input rejection) and body generation (sort in group_by, sort omitted without group_by)
- 4 existing tests updated for new function signature
- All 32 logs tests pass, clippy clean, fmt clean

## Usage
```bash
# Sort by count (default)
pup logs aggregate --query="*" --group-by=service

# Sort by p95 latency
pup logs aggregate --query="*" --compute="percentile(@duration, 95)" --group-by=service --sort=pc95

# Sort by max duration
pup logs aggregate --query="*" --compute="max(@duration)" --group-by=host --sort=max
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code), edited by humans