### PR TITLE
fix(deps): upgrade rustls-webpki to 0.103.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3345,9 +3345,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary

Bumps `rustls-webpki` from 0.103.10 to 0.103.12 in the lockfile, resolving two vulnerabilities flagged by `cargo audit`:

- **RUSTSEC-2026-0098** — name constraints for URI names were incorrectly accepted
- **RUSTSEC-2026-0099** — name constraints were accepted for certificates asserting a wildcard name

Lockfile-only change, no `Cargo.toml` modifications needed.

### Remaining advisories (blocked on upstream)

- **RUSTSEC-2023-0071** (`rsa` via `russh`/`ssh-key`) — Marvin Attack, no patched version exists
- **RUSTSEC-2026-0097** (`rand` 0.8/0.9/0.10) — unsound with custom logger, warning only

Partially addresses #304.

## Test plan

- [ ] `cargo check` compiles
- [ ] `cargo test` passes
- [ ] `cargo audit` no longer reports RUSTSEC-2026-0098 or RUSTSEC-2026-0099

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)