### PR TITLE
ci-fix: Check, Test & Coverage (PR #369)

### DIFF
--- a/src/commands/software_catalog.rs
+++ b/src/commands/software_catalog.rs
@@ -10,14 +10,29 @@ use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
-pub async fn entities_list(cfg: &Config) -> Result<()> {
+pub async fn entities_list(
+    cfg: &Config,
+    filter_kind: Option<String>,
+    filter_owner: Option<String>,
+    filter_ref: Option<String>,
+) -> Result<()> {
     let dd_cfg = client::make_dd_config(cfg);
     let api = match client::make_bearer_client(cfg) {
         Some(c) => SoftwareCatalogAPI::with_client_and_config(dd_cfg, c),
         None => SoftwareCatalogAPI::with_config(dd_cfg),
     };
+    let mut params = ListCatalogEntityOptionalParams::default();
+    if let Some(v) = &filter_kind {
+        params = params.filter_kind(v.clone());
+    }
+    if let Some(v) = &filter_owner {
+        params = params.filter_owner(v.clone());
+    }
+    if let Some(v) = &filter_ref {
+        params = params.filter_ref(v.clone());
+    }
     let resp = api
-        .list_catalog_entity(ListCatalogEntityOptionalParams::default())
+        .list_catalog_entity(params)
         .await
         .map_err(|e| anyhow::anyhow!("failed to list catalog entities: {e:?}"))?;
     formatter::output(cfg, &resp)

--- a/src/main.rs
+++ b/src/main.rs
@@ -4904,7 +4904,10 @@ enum SoftwareCatalogEntityActions {
         filter_kind: Option<String>,
         #[arg(long, help = "Filter entities by owner")]
         filter_owner: Option<String>,
-        #[arg(long, help = "Filter entities by reference, e.g. service:shop-frontend")]
+        #[arg(
+            long,
+            help = "Filter entities by reference, e.g. service:shop-frontend"
+        )]
         filter_ref: Option<String>,
     },
     /// Create or update entities from a JSON file

--- a/src/main.rs
+++ b/src/main.rs
@@ -4893,7 +4893,20 @@ enum SoftwareCatalogActions {
 #[derive(Subcommand)]
 enum SoftwareCatalogEntityActions {
     /// List catalog entities
-    List,
+    ///
+    /// EXAMPLES:
+    ///   pup software-catalog entities list --filter-kind service
+    ///   pup software-catalog entities list --filter-owner team-claude
+    ///   pup software-catalog entities list --filter-ref service:shop-frontend
+    #[command(verbatim_doc_comment)]
+    List {
+        #[arg(long, help = "Filter entities by kind (e.g. service, datastore)")]
+        filter_kind: Option<String>,
+        #[arg(long, help = "Filter entities by owner")]
+        filter_owner: Option<String>,
+        #[arg(long, help = "Filter entities by reference, e.g. service:shop-frontend")]
+        filter_ref: Option<String>,
+    },
     /// Create or update entities from a JSON file
     Upsert {
         #[arg(long, help = "JSON file with entity definition (required)")]
@@ -9982,8 +9995,18 @@ async fn main_inner() -> anyhow::Result<()> {
             cfg.validate_auth()?;
             match action {
                 SoftwareCatalogActions::Entities { action } => match action {
-                    SoftwareCatalogEntityActions::List => {
-                        commands::software_catalog::entities_list(&cfg).await?;
+                    SoftwareCatalogEntityActions::List {
+                        filter_kind,
+                        filter_owner,
+                        filter_ref,
+                    } => {
+                        commands::software_catalog::entities_list(
+                            &cfg,
+                            filter_kind,
+                            filter_owner,
+                            filter_ref,
+                        )
+                        .await?;
                     }
                     SoftwareCatalogEntityActions::Upsert { file } => {
                         commands::software_catalog::entities_upsert(&cfg, &file).await?;

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -4154,10 +4154,34 @@ async fn test_software_catalog_entities_list() {
     let mut server = mockito::Server::new_async().await;
     let cfg = test_config(&server.url());
     let _mock = mock_any(&mut server, "GET", r#"{"data":[]}"#).await;
-    let result = crate::commands::software_catalog::entities_list(&cfg).await;
+    let result =
+        crate::commands::software_catalog::entities_list(&cfg, None, None, None).await;
     assert!(
         result.is_ok(),
         "software catalog entities list failed: {:?}",
+        result.err()
+    );
+    cleanup_env();
+    std::env::remove_var("DD_TOKEN_STORAGE");
+}
+
+#[tokio::test]
+async fn test_software_catalog_entities_list_with_filters() {
+    let _lock = lock_env();
+    std::env::set_var("DD_TOKEN_STORAGE", "file");
+    let mut server = mockito::Server::new_async().await;
+    let cfg = test_config(&server.url());
+    let _mock = mock_any(&mut server, "GET", r#"{"data":[]}"#).await;
+    let result = crate::commands::software_catalog::entities_list(
+        &cfg,
+        Some("service".to_string()),
+        None,
+        None,
+    )
+    .await;
+    assert!(
+        result.is_ok(),
+        "software catalog entities list with kind filter failed: {:?}",
         result.err()
     );
     cleanup_env();
@@ -4212,7 +4236,8 @@ async fn test_software_catalog_entities_list_error() {
         .with_body(r#"{"errors":["Internal Server Error"]}"#)
         .create_async()
         .await;
-    let result = crate::commands::software_catalog::entities_list(&cfg).await;
+    let result =
+        crate::commands::software_catalog::entities_list(&cfg, None, None, None).await;
     assert!(
         result.is_err(),
         "expected software catalog entities list to fail on 500"

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -4154,8 +4154,7 @@ async fn test_software_catalog_entities_list() {
     let mut server = mockito::Server::new_async().await;
     let cfg = test_config(&server.url());
     let _mock = mock_any(&mut server, "GET", r#"{"data":[]}"#).await;
-    let result =
-        crate::commands::software_catalog::entities_list(&cfg, None, None, None).await;
+    let result = crate::commands::software_catalog::entities_list(&cfg, None, None, None).await;
     assert!(
         result.is_ok(),
         "software catalog entities list failed: {:?}",
@@ -4236,8 +4235,7 @@ async fn test_software_catalog_entities_list_error() {
         .with_body(r#"{"errors":["Internal Server Error"]}"#)
         .create_async()
         .await;
-    let result =
-        crate::commands::software_catalog::entities_list(&cfg, None, None, None).await;
+    let result = crate::commands::software_catalog::entities_list(&cfg, None, None, None).await;
     assert!(
         result.is_err(),
         "expected software catalog entities list to fail on 500"


### PR DESCRIPTION
Fixes CI job failure: **Check, Test & Coverage** on PR #369 (fork PR — cannot push directly).

**Original PR**: #369 — feat(software-catalog): expose entity list filter flags
**Based on**: commit `49f0040`

---
*Generated by [signal-keeper](https://github.com/platinummonkey/signal-keeper) CI fix*