### PR TITLE
feat(fleet): add tracers, clusters, and instrumented-pods commands via typed SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1809,7 +1809,7 @@ checksum = "ae8e22120c32fb4d19ec55fba35015f57095cd95a2e3b732e44457f5915b2ee8"
 dependencies = [
  "num-integer",
  "num-traits",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_core 0.10.0",
 ]
 
@@ -2730,7 +2730,7 @@ dependencies = [
  "mockito",
  "open",
  "openssl",
- "rand 0.10.0",
+ "rand 0.10.1",
  "regex",
  "reqwest",
  "reqwest-middleware",
@@ -2807,7 +2807,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2854,9 +2854,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
@@ -3190,7 +3190,7 @@ dependencies = [
  "pkcs5",
  "pkcs8 0.11.0-rc.11",
  "polyval 0.7.1",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_core 0.10.0",
  "rsa 0.10.0-rc.17",
  "russh-cryptovec",
@@ -3347,9 +3347,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4295,7 +4295,7 @@ checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde_core",
  "wasm-bindgen",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,7 +821,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 [[package]]
 name = "datadog-api-client"
 version = "0.29.0"
-source = "git+https://github.com/DataDog/datadog-api-client-rust?rev=8fa08ce098d0218b50be712d064f0c52006d6c19#8fa08ce098d0218b50be712d064f0c52006d6c19"
+source = "git+https://github.com/DataDog/datadog-api-client-rust?rev=d70b186e29175ba7e160fe77091cd8571950c553#d70b186e29175ba7e160fe77091cd8571950c553"
 dependencies = [
  "async-stream",
  "chrono",
@@ -1809,7 +1809,7 @@ checksum = "ae8e22120c32fb4d19ec55fba35015f57095cd95a2e3b732e44457f5915b2ee8"
 dependencies = [
  "num-integer",
  "num-traits",
- "rand 0.10.1",
+ "rand 0.10.0",
  "rand_core 0.10.0",
 ]
 
@@ -2730,7 +2730,7 @@ dependencies = [
  "mockito",
  "open",
  "openssl",
- "rand 0.10.1",
+ "rand 0.10.0",
  "regex",
  "reqwest",
  "reqwest-middleware",
@@ -2807,7 +2807,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2854,9 +2854,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
@@ -3190,7 +3190,7 @@ dependencies = [
  "pkcs5",
  "pkcs8 0.11.0-rc.11",
  "polyval 0.7.1",
- "rand 0.10.1",
+ "rand 0.10.0",
  "rand_core 0.10.0",
  "rsa 0.10.0-rc.17",
  "russh-cryptovec",
@@ -3347,9 +3347,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4295,7 +4295,7 @@ checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
- "rand 0.10.1",
+ "rand 0.10.0",
  "serde_core",
  "wasm-bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,9 +120,9 @@ ssh-key = { version = "0.6", features = ["p256", "std"], optional = true }
 futures = { version = "0.3", optional = true }
 tokio-util = { version = "0.7", features = ["compat", "io"], optional = true }
 
-# Datadog API client — latest master as of 2026-04-10 (8fa08ce0)
+# Datadog API client — includes fleet tracers/clusters/instrumented-pods (d70b186e)
 # Use default-features = false; feature sets are activated per-target via features above
-datadog-api-client = { git = "https://github.com/DataDog/datadog-api-client-rust", rev = "8fa08ce098d0218b50be712d064f0c52006d6c19", optional = true, default-features = false }
+datadog-api-client = { git = "https://github.com/DataDog/datadog-api-client-rust", rev = "d70b186e29175ba7e160fe77091cd8571950c553", optional = true, default-features = false }
 
 # HTTP middleware (version-matched to DD client; compiles on all targets)
 reqwest-middleware = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,8 @@ comfy-table = { version = "7", default-features = false }
 # Auth — OAuth2 PKCE + token storage (optional — not needed for browser)
 sha2 = { version = "0.11", optional = true }
 base64 = { version = "0.22", optional = true }
-rand = { version = "0.10", optional = true }
+# Pinned to 0.10.1+ to prevent the SDK rev (d70b186e) from pulling in the older 0.10.0 patch
+rand = { version = "0.10.1", optional = true }
 url = { version = "2", optional = true }
 
 # Vendored OpenSSL for cross-compilation (optional — only for CI cross-builds)

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -73,7 +73,7 @@ pup <domain> <subgroup> <action> [options] # Nested commands
 | status-pages | pages, components, degradations | src/commands/status_pages.rs | ✅ |
 | code-coverage | branch-summary, commit-summary | src/commands/code_coverage.rs | ✅ |
 | hamr | connections (get, create) | src/commands/hamr.rs | ✅ |
-| fleet | agents (list, get, versions, tracers), deployments (list, get, configure, upgrade, cancel), schedules (list, get, create, update, delete, trigger), tracers (list) | src/commands/fleet.rs | ✅ |
+| fleet | agents (list, get, versions, tracers), deployments (list, get, configure, upgrade, cancel), schedules (list, get, create, update, delete, trigger), tracers (list), instrumented-pods (list) | src/commands/fleet.rs | ✅ |
 | skills | list, install, path | src/commands/skills.rs | ✅ |
 | runbooks | list, describe, run, import, validate | src/commands/runbooks.rs | ✅ |
 | workflows | get, create, update, delete, run, instances (list, get, cancel), connections (get, create, update, delete) | src/commands/workflows.rs | ✅ |

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -73,7 +73,7 @@ pup <domain> <subgroup> <action> [options] # Nested commands
 | status-pages | pages, components, degradations | src/commands/status_pages.rs | ✅ |
 | code-coverage | branch-summary, commit-summary | src/commands/code_coverage.rs | ✅ |
 | hamr | connections (get, create) | src/commands/hamr.rs | ✅ |
-| fleet | agents (list, get, versions), deployments (list, get, configure, upgrade, cancel), schedules (list, get, create, update, delete, trigger) | src/commands/fleet.rs | ✅ |
+| fleet | agents (list, get, versions, tracers), deployments (list, get, configure, upgrade, cancel), schedules (list, get, create, update, delete, trigger), tracers (list) | src/commands/fleet.rs | ✅ |
 | skills | list, install, path | src/commands/skills.rs | ✅ |
 | runbooks | list, describe, run, import, validate | src/commands/runbooks.rs | ✅ |
 | workflows | get, create, update, delete, run, instances (list, get, cancel), connections (get, create, update, delete) | src/commands/workflows.rs | ✅ |

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -73,7 +73,7 @@ pup <domain> <subgroup> <action> [options] # Nested commands
 | status-pages | pages, components, degradations | src/commands/status_pages.rs | ✅ |
 | code-coverage | branch-summary, commit-summary | src/commands/code_coverage.rs | ✅ |
 | hamr | connections (get, create) | src/commands/hamr.rs | ✅ |
-| fleet | agents (list, get, versions, tracers), deployments (list, get, configure, upgrade, cancel), schedules (list, get, create, update, delete, trigger), tracers (list), instrumented-pods (list) | src/commands/fleet.rs | ✅ |
+| fleet | agents (list, get, versions, tracers), deployments (list, get, configure, upgrade, cancel), schedules (list, get, create, update, delete, trigger), tracers (list), clusters (list), instrumented-pods (list) | src/commands/fleet.rs | ✅ |
 | skills | list, install, path | src/commands/skills.rs | ✅ |
 | runbooks | list, describe, run, import, validate | src/commands/runbooks.rs | ✅ |
 | workflows | get, create, update, delete, run, instances (list, get, cancel), connections (get, create, update, delete) | src/commands/workflows.rs | ✅ |
@@ -179,7 +179,7 @@ pup infrastructure hosts list
 - **on-call** - Team management (create, update, delete teams; manage memberships with roles)
 - **cases** - Case management (create, search, assign, archive, unarchive, update, projects, jira, servicenow, move)
 - **hamr** - High Availability Multi-Region connections
-- **fleet** - Fleet Automation (agents, deployments, schedules)
+- **fleet** - Fleet Automation (agents, deployments, schedules, tracers, clusters, instrumented-pods)
 - **runbooks** - Local runbook execution engine (list, describe, run, import, validate)
 - **workflows** - Workflow Automation (get, create, update, delete, run, instances, connections)
 - **investigations** - Bits AI SRE investigations (list, get, trigger)

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -377,6 +377,12 @@ pup fleet agents tracers <agent-key>
 pup fleet agents tracers <agent-key> --page-size 20
 ```
 
+### List Instrumented Pods (K8s)
+```bash
+# List pods instrumented by SSI in a cluster
+pup fleet instrumented-pods list <cluster-name>
+```
+
 ## Live Debugger
 
 ### Service Context

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -383,6 +383,20 @@ pup fleet agents tracers <agent-key> --page-size 20
 pup fleet instrumented-pods list <cluster-name>
 ```
 
+## Fleet Clusters
+
+### List Kubernetes Clusters in the Fleet
+```bash
+# List all clusters
+pup fleet clusters list
+
+# Filter by cluster name
+pup fleet clusters list --filter "cluster_name:production"
+
+# Paginate
+pup fleet clusters list --filter "env:prod" --page-size 50 --page-number 0
+```
+
 ## Live Debugger
 
 ### Service Context

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -351,6 +351,32 @@ pup apm troubleshooting list --hostname my-host
 pup apm troubleshooting list --hostname my-host --timeframe 4h
 ```
 
+## Fleet Tracers
+
+### List Tracers Across the Fleet
+```bash
+# List all tracers (telemetry-derived service names, language, runtime IDs)
+pup fleet tracers list
+
+# Filter tracers by environment
+pup fleet tracers list --filter "env:prod"
+
+# Filter tracers by hostname
+pup fleet tracers list --filter "hostname:my-host"
+
+# Paginate results
+pup fleet tracers list --filter "env:prod" --page-size 50 --page-number 0
+```
+
+### List Tracers for a Specific Agent
+```bash
+# Get tracers running on a specific agent
+pup fleet agents tracers <agent-key>
+
+# With pagination
+pup fleet agents tracers <agent-key> --page-size 20
+```
+
 ## Live Debugger
 
 ### Service Context

--- a/src/client.rs
+++ b/src/client.rs
@@ -168,10 +168,14 @@ static UNSTABLE_OPS: &[&str] = &[
     "v2.get_incident_service",
     "v2.list_incident_services",
     "v2.update_incident_service",
-    // Fleet Automation (14)
+    // Fleet Automation (18)
     "v2.list_fleet_agents",
     "v2.get_fleet_agent_info",
     "v2.list_fleet_agent_versions",
+    "v2.list_fleet_agent_tracers",
+    "v2.list_fleet_tracers",
+    "v2.list_fleet_clusters",
+    "v2.list_fleet_instrumented_pods",
     "v2.list_fleet_deployments",
     "v2.get_fleet_deployment",
     "v2.create_fleet_deployment_configure",

--- a/src/client.rs
+++ b/src/client.rs
@@ -958,7 +958,7 @@ mod tests {
 
     #[test]
     fn test_unstable_ops_count() {
-        assert_eq!(UNSTABLE_OPS.len(), 143);
+        assert_eq!(UNSTABLE_OPS.len(), 147);
     }
 
     #[test]

--- a/src/commands/cicd.rs
+++ b/src/commands/cicd.rs
@@ -302,9 +302,8 @@ pub async fn flaky_tests_search(
         page_opts = page_opts.cursor(c);
     }
     attrs = attrs.page(page_opts);
-    if include_history {
-        attrs = attrs.include_history(true);
-    }
+    // include_history was removed from the SDK in d70b186e
+    let _ = include_history;
     if let Some(s) = sort {
         let sort_val = match s.as_str() {
             "fqn" => FlakyTestsSearchSort::FQN_ASCENDING,

--- a/src/commands/cicd.rs
+++ b/src/commands/cicd.rs
@@ -279,7 +279,6 @@ pub async fn flaky_tests_search(
     query: Option<String>,
     cursor: Option<String>,
     limit: i64,
-    include_history: bool,
     sort: Option<String>,
 ) -> Result<()> {
     let dd_cfg = client::make_dd_config(cfg);
@@ -302,8 +301,6 @@ pub async fn flaky_tests_search(
         page_opts = page_opts.cursor(c);
     }
     attrs = attrs.page(page_opts);
-    // include_history was removed from the SDK in d70b186e
-    let _ = include_history;
     if let Some(s) = sort {
         let sort_val = match s.as_str() {
             "fqn" => FlakyTestsSearchSort::FQN_ASCENDING,

--- a/src/commands/fleet.rs
+++ b/src/commands/fleet.rs
@@ -285,6 +285,44 @@ pub async fn agents_tracers_list(
     formatter::output(cfg, &data)
 }
 
+pub async fn clusters_list(
+    cfg: &Config,
+    filter: Option<String>,
+    page_size: Option<i64>,
+    page_number: Option<i64>,
+    sort_attribute: Option<String>,
+    sort_descending: bool,
+) -> Result<()> {
+    let mut query: Vec<(&str, &str)> = Vec::new();
+    let filter_owned;
+    if let Some(f) = &filter {
+        filter_owned = f.clone();
+        query.push(("filter", filter_owned.as_str()));
+    }
+    let ps_owned;
+    if let Some(ps) = &page_size {
+        ps_owned = ps.to_string();
+        query.push(("page_size", ps_owned.as_str()));
+    }
+    let pn_owned;
+    if let Some(pn) = &page_number {
+        pn_owned = pn.to_string();
+        query.push(("page_number", pn_owned.as_str()));
+    }
+    let sa_owned;
+    if let Some(sa) = &sort_attribute {
+        sa_owned = sa.clone();
+        query.push(("sort_attribute", sa_owned.as_str()));
+    }
+    let sd_owned;
+    if sort_descending {
+        sd_owned = "true".to_string();
+        query.push(("sort_descending", sd_owned.as_str()));
+    }
+    let data = client::raw_get(cfg, "/api/unstable/fleet/clusters", &query).await?;
+    formatter::output(cfg, &data)
+}
+
 pub async fn instrumented_pods_list(
     cfg: &Config,
     cluster_name: String,

--- a/src/commands/fleet.rs
+++ b/src/commands/fleet.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
 use datadog_api_client::datadogV2::api_fleet_automation::{
-    FleetAutomationAPI, GetFleetDeploymentOptionalParams, ListFleetAgentsOptionalParams,
-    ListFleetDeploymentsOptionalParams,
+    FleetAutomationAPI, GetFleetDeploymentOptionalParams, ListFleetAgentTracersOptionalParams,
+    ListFleetAgentsOptionalParams, ListFleetClustersOptionalParams,
+    ListFleetDeploymentsOptionalParams, ListFleetTracersOptionalParams,
 };
 
 use crate::client;
@@ -221,34 +222,32 @@ pub async fn tracers_list(
     sort_attribute: Option<String>,
     sort_descending: bool,
 ) -> Result<()> {
-    let mut query: Vec<(&str, &str)> = Vec::new();
-    let filter_owned;
-    if let Some(f) = &filter {
-        filter_owned = f.clone();
-        query.push(("filter", filter_owned.as_str()));
+    let dd_cfg = client::make_dd_config(cfg);
+    let api = match client::make_bearer_client(cfg) {
+        Some(c) => FleetAutomationAPI::with_client_and_config(dd_cfg, c),
+        None => FleetAutomationAPI::with_config(dd_cfg),
+    };
+    let mut params = ListFleetTracersOptionalParams::default();
+    if let Some(f) = filter {
+        params = params.filter(f);
     }
-    let ps_owned;
-    if let Some(ps) = &page_size {
-        ps_owned = ps.to_string();
-        query.push(("page_size", ps_owned.as_str()));
+    if let Some(ps) = page_size {
+        params = params.page_size(ps);
     }
-    let pn_owned;
-    if let Some(pn) = &page_number {
-        pn_owned = pn.to_string();
-        query.push(("page_number", pn_owned.as_str()));
+    if let Some(pn) = page_number {
+        params = params.page_number(pn);
     }
-    let sa_owned;
-    if let Some(sa) = &sort_attribute {
-        sa_owned = sa.clone();
-        query.push(("sort_attribute", sa_owned.as_str()));
+    if let Some(sa) = sort_attribute {
+        params = params.sort_attribute(sa);
     }
-    let sd_owned;
     if sort_descending {
-        sd_owned = "true".to_string();
-        query.push(("sort_descending", sd_owned.as_str()));
+        params = params.sort_descending(true);
     }
-    let data = client::raw_get(cfg, "/api/unstable/fleet/tracers", &query).await?;
-    formatter::output(cfg, &data)
+    let resp = api
+        .list_fleet_tracers(params)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to list fleet tracers: {e:?}"))?;
+    formatter::output(cfg, &resp)
 }
 
 pub async fn agents_tracers_list(
@@ -259,30 +258,29 @@ pub async fn agents_tracers_list(
     sort_attribute: Option<String>,
     sort_descending: bool,
 ) -> Result<()> {
-    let path = format!("/api/unstable/fleet/agents/{agent_key}/tracers");
-    let mut query: Vec<(&str, &str)> = Vec::new();
-    let ps_owned;
-    if let Some(ps) = &page_size {
-        ps_owned = ps.to_string();
-        query.push(("page_size", ps_owned.as_str()));
+    let dd_cfg = client::make_dd_config(cfg);
+    let api = match client::make_bearer_client(cfg) {
+        Some(c) => FleetAutomationAPI::with_client_and_config(dd_cfg, c),
+        None => FleetAutomationAPI::with_config(dd_cfg),
+    };
+    let mut params = ListFleetAgentTracersOptionalParams::default();
+    if let Some(ps) = page_size {
+        params = params.page_size(ps);
     }
-    let pn_owned;
-    if let Some(pn) = &page_number {
-        pn_owned = pn.to_string();
-        query.push(("page_number", pn_owned.as_str()));
+    if let Some(pn) = page_number {
+        params = params.page_number(pn);
     }
-    let sa_owned;
-    if let Some(sa) = &sort_attribute {
-        sa_owned = sa.clone();
-        query.push(("sort_attribute", sa_owned.as_str()));
+    if let Some(sa) = sort_attribute {
+        params = params.sort_attribute(sa);
     }
-    let sd_owned;
     if sort_descending {
-        sd_owned = "true".to_string();
-        query.push(("sort_descending", sd_owned.as_str()));
+        params = params.sort_descending(true);
     }
-    let data = client::raw_get(cfg, &path, &query).await?;
-    formatter::output(cfg, &data)
+    let resp = api
+        .list_fleet_agent_tracers(agent_key, params)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to list agent tracers: {e:?}"))?;
+    formatter::output(cfg, &resp)
 }
 
 pub async fn clusters_list(
@@ -293,43 +291,46 @@ pub async fn clusters_list(
     sort_attribute: Option<String>,
     sort_descending: bool,
 ) -> Result<()> {
-    let mut query: Vec<(&str, &str)> = Vec::new();
-    let filter_owned;
-    if let Some(f) = &filter {
-        filter_owned = f.clone();
-        query.push(("filter", filter_owned.as_str()));
+    let dd_cfg = client::make_dd_config(cfg);
+    let api = match client::make_bearer_client(cfg) {
+        Some(c) => FleetAutomationAPI::with_client_and_config(dd_cfg, c),
+        None => FleetAutomationAPI::with_config(dd_cfg),
+    };
+    let mut params = ListFleetClustersOptionalParams::default();
+    if let Some(f) = filter {
+        params = params.filter(f);
     }
-    let ps_owned;
-    if let Some(ps) = &page_size {
-        ps_owned = ps.to_string();
-        query.push(("page_size", ps_owned.as_str()));
+    if let Some(ps) = page_size {
+        params = params.page_size(ps);
     }
-    let pn_owned;
-    if let Some(pn) = &page_number {
-        pn_owned = pn.to_string();
-        query.push(("page_number", pn_owned.as_str()));
+    if let Some(pn) = page_number {
+        params = params.page_number(pn);
     }
-    let sa_owned;
-    if let Some(sa) = &sort_attribute {
-        sa_owned = sa.clone();
-        query.push(("sort_attribute", sa_owned.as_str()));
+    if let Some(sa) = sort_attribute {
+        params = params.sort_attribute(sa);
     }
-    let sd_owned;
     if sort_descending {
-        sd_owned = "true".to_string();
-        query.push(("sort_descending", sd_owned.as_str()));
+        params = params.sort_descending(true);
     }
-    let data = client::raw_get(cfg, "/api/unstable/fleet/clusters", &query).await?;
-    formatter::output(cfg, &data)
+    let resp = api
+        .list_fleet_clusters(params)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to list fleet clusters: {e:?}"))?;
+    formatter::output(cfg, &resp)
 }
 
 pub async fn instrumented_pods_list(
     cfg: &Config,
     cluster_name: String,
 ) -> Result<()> {
-    let path = format!(
-        "/api/unstable/fleet/clusters/{cluster_name}/instrumented_pods"
-    );
-    let data = client::raw_get(cfg, &path, &[]).await?;
-    formatter::output(cfg, &data)
+    let dd_cfg = client::make_dd_config(cfg);
+    let api = match client::make_bearer_client(cfg) {
+        Some(c) => FleetAutomationAPI::with_client_and_config(dd_cfg, c),
+        None => FleetAutomationAPI::with_config(dd_cfg),
+    };
+    let resp = api
+        .list_fleet_instrumented_pods(cluster_name)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to list instrumented pods: {e:?}"))?;
+    formatter::output(cfg, &resp)
 }

--- a/src/commands/fleet.rs
+++ b/src/commands/fleet.rs
@@ -319,10 +319,7 @@ pub async fn clusters_list(
     formatter::output(cfg, &resp)
 }
 
-pub async fn instrumented_pods_list(
-    cfg: &Config,
-    cluster_name: String,
-) -> Result<()> {
+pub async fn instrumented_pods_list(cfg: &Config, cluster_name: String) -> Result<()> {
     let dd_cfg = client::make_dd_config(cfg);
     let api = match client::make_bearer_client(cfg) {
         Some(c) => FleetAutomationAPI::with_client_and_config(dd_cfg, c),

--- a/src/commands/fleet.rs
+++ b/src/commands/fleet.rs
@@ -212,3 +212,75 @@ pub async fn schedules_trigger(cfg: &Config, schedule_id: &str) -> Result<()> {
     println!("Schedule {schedule_id} triggered.");
     Ok(())
 }
+
+pub async fn tracers_list(
+    cfg: &Config,
+    filter: Option<String>,
+    page_size: Option<i64>,
+    page_number: Option<i64>,
+    sort_attribute: Option<String>,
+    sort_descending: bool,
+) -> Result<()> {
+    let mut query: Vec<(&str, &str)> = Vec::new();
+    let filter_owned;
+    if let Some(f) = &filter {
+        filter_owned = f.clone();
+        query.push(("filter", filter_owned.as_str()));
+    }
+    let ps_owned;
+    if let Some(ps) = &page_size {
+        ps_owned = ps.to_string();
+        query.push(("page_size", ps_owned.as_str()));
+    }
+    let pn_owned;
+    if let Some(pn) = &page_number {
+        pn_owned = pn.to_string();
+        query.push(("page_number", pn_owned.as_str()));
+    }
+    let sa_owned;
+    if let Some(sa) = &sort_attribute {
+        sa_owned = sa.clone();
+        query.push(("sort_attribute", sa_owned.as_str()));
+    }
+    let sd_owned;
+    if sort_descending {
+        sd_owned = "true".to_string();
+        query.push(("sort_descending", sd_owned.as_str()));
+    }
+    let data = client::raw_get(cfg, "/api/unstable/fleet/tracers", &query).await?;
+    formatter::output(cfg, &data)
+}
+
+pub async fn agents_tracers_list(
+    cfg: &Config,
+    agent_key: String,
+    page_size: Option<i64>,
+    page_number: Option<i64>,
+    sort_attribute: Option<String>,
+    sort_descending: bool,
+) -> Result<()> {
+    let path = format!("/api/unstable/fleet/agents/details/{agent_key}/tracers");
+    let mut query: Vec<(&str, &str)> = Vec::new();
+    let ps_owned;
+    if let Some(ps) = &page_size {
+        ps_owned = ps.to_string();
+        query.push(("page_size", ps_owned.as_str()));
+    }
+    let pn_owned;
+    if let Some(pn) = &page_number {
+        pn_owned = pn.to_string();
+        query.push(("page_number", pn_owned.as_str()));
+    }
+    let sa_owned;
+    if let Some(sa) = &sort_attribute {
+        sa_owned = sa.clone();
+        query.push(("sort_attribute", sa_owned.as_str()));
+    }
+    let sd_owned;
+    if sort_descending {
+        sd_owned = "true".to_string();
+        query.push(("sort_descending", sd_owned.as_str()));
+    }
+    let data = client::raw_get(cfg, &path, &query).await?;
+    formatter::output(cfg, &data)
+}

--- a/src/commands/fleet.rs
+++ b/src/commands/fleet.rs
@@ -328,7 +328,7 @@ pub async fn instrumented_pods_list(
     cluster_name: String,
 ) -> Result<()> {
     let path = format!(
-        "/api/unstable/fleet/cluster_agents/details/{cluster_name}/instrumented_pods"
+        "/api/unstable/fleet/clusters/{cluster_name}/instrumented_pods"
     );
     let data = client::raw_get(cfg, &path, &[]).await?;
     formatter::output(cfg, &data)

--- a/src/commands/fleet.rs
+++ b/src/commands/fleet.rs
@@ -259,7 +259,7 @@ pub async fn agents_tracers_list(
     sort_attribute: Option<String>,
     sort_descending: bool,
 ) -> Result<()> {
-    let path = format!("/api/unstable/fleet/agents/details/{agent_key}/tracers");
+    let path = format!("/api/unstable/fleet/agents/{agent_key}/tracers");
     let mut query: Vec<(&str, &str)> = Vec::new();
     let ps_owned;
     if let Some(ps) = &page_size {

--- a/src/commands/fleet.rs
+++ b/src/commands/fleet.rs
@@ -284,3 +284,14 @@ pub async fn agents_tracers_list(
     let data = client::raw_get(cfg, &path, &query).await?;
     formatter::output(cfg, &data)
 }
+
+pub async fn instrumented_pods_list(
+    cfg: &Config,
+    cluster_name: String,
+) -> Result<()> {
+    let path = format!(
+        "/api/unstable/fleet/cluster_agents/details/{cluster_name}/instrumented_pods"
+    );
+    let data = client::raw_get(cfg, &path, &[]).await?;
+    formatter::output(cfg, &data)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6117,10 +6117,7 @@ enum FleetClusterActions {
     /// Returns clusters with node counts, agent versions, enabled products, and services.
     /// Use this to discover cluster names for use with instrumented-pods.
     List {
-        #[arg(
-            long,
-            help = "Filter query (e.g. cluster_name:production, env:prod)"
-        )]
+        #[arg(long, help = "Filter query (e.g. cluster_name:production, env:prod)")]
         filter: Option<String>,
         #[arg(long)]
         page_size: Option<i64>,
@@ -10934,8 +10931,7 @@ async fn main_inner() -> anyhow::Result<()> {
                 },
                 FleetActions::InstrumentedPods { action } => match action {
                     FleetInstrumentedPodsActions::List { cluster_name } => {
-                        commands::fleet::instrumented_pods_list(&cfg, cluster_name)
-                            .await?;
+                        commands::fleet::instrumented_pods_list(&cfg, cluster_name).await?;
                     }
                 },
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5997,6 +5997,12 @@ enum FleetActions {
         #[command(subcommand)]
         action: FleetTracerActions,
     },
+    /// List instrumented pods in a Kubernetes cluster
+    #[command(name = "instrumented-pods")]
+    InstrumentedPods {
+        #[command(subcommand)]
+        action: FleetInstrumentedPodsActions,
+    },
 }
 
 #[derive(Subcommand)]
@@ -6096,6 +6102,18 @@ enum FleetTracerActions {
         sort_attribute: Option<String>,
         #[arg(long, default_value_t = false, help = "Sort descending")]
         sort_descending: bool,
+    },
+}
+
+#[derive(Subcommand)]
+enum FleetInstrumentedPodsActions {
+    /// List instrumented pods in a Kubernetes cluster.
+    ///
+    /// Returns pod groups with namespace, owner, injection annotations, and pod names.
+    /// Use this to verify the Admission Controller targeted pods for SSI injection.
+    List {
+        #[arg(help = "Kubernetes cluster name (required)")]
+        cluster_name: String,
     },
 }
 
@@ -10865,6 +10883,12 @@ async fn main_inner() -> anyhow::Result<()> {
                             sort_descending,
                         )
                         .await?;
+                    }
+                },
+                FleetActions::InstrumentedPods { action } => match action {
+                    FleetInstrumentedPodsActions::List { cluster_name } => {
+                        commands::fleet::instrumented_pods_list(&cfg, cluster_name)
+                            .await?;
                     }
                 },
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5992,6 +5992,11 @@ enum FleetActions {
         #[command(subcommand)]
         action: FleetScheduleActions,
     },
+    /// Query fleet tracers (telemetry-derived service names, language, runtime IDs)
+    Tracers {
+        #[command(subcommand)]
+        action: FleetTracerActions,
+    },
 }
 
 #[derive(Subcommand)]
@@ -6010,6 +6015,18 @@ enum FleetAgentActions {
     Get { agent_key: String },
     /// List available agent versions
     Versions,
+    /// List tracers for a specific agent
+    Tracers {
+        agent_key: String,
+        #[arg(long, default_value_t = 10, help = "Results per page (max 100)")]
+        page_size: i64,
+        #[arg(long, help = "Page number (0-indexed)")]
+        page_number: Option<i64>,
+        #[arg(long, help = "Sort by attribute (e.g. service, language, hostname)")]
+        sort_attribute: Option<String>,
+        #[arg(long, default_value_t = false, help = "Sort descending")]
+        sort_descending: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -6056,6 +6073,30 @@ enum FleetScheduleActions {
     Delete { schedule_id: String },
     /// Trigger a fleet schedule
     Trigger { schedule_id: String },
+}
+
+#[derive(Subcommand)]
+enum FleetTracerActions {
+    /// List tracers across the fleet.
+    ///
+    /// Returns telemetry-derived service names, language, tracer version, and runtime IDs.
+    /// Note: service names here come from the SDK telemetry pipeline and may differ from
+    /// span-derived names in APM (e.g. pup apm services list).
+    List {
+        #[arg(
+            long,
+            help = "Filter query (e.g. env:prod, hostname:my-host, service:web-api)"
+        )]
+        filter: Option<String>,
+        #[arg(long, default_value_t = 10, help = "Results per page (max 100)")]
+        page_size: i64,
+        #[arg(long, help = "Page number (0-indexed)")]
+        page_number: Option<i64>,
+        #[arg(long, help = "Sort by attribute (e.g. service, language, hostname)")]
+        sort_attribute: Option<String>,
+        #[arg(long, default_value_t = false, help = "Sort descending")]
+        sort_descending: bool,
+    },
 }
 
 // ---- Data Deletion ----
@@ -10754,6 +10795,23 @@ async fn main_inner() -> anyhow::Result<()> {
                         commands::fleet::agents_get(&cfg, &agent_key).await?;
                     }
                     FleetAgentActions::Versions => commands::fleet::agents_versions(&cfg).await?,
+                    FleetAgentActions::Tracers {
+                        agent_key,
+                        page_size,
+                        page_number,
+                        sort_attribute,
+                        sort_descending,
+                    } => {
+                        commands::fleet::agents_tracers_list(
+                            &cfg,
+                            agent_key,
+                            Some(page_size),
+                            page_number,
+                            sort_attribute,
+                            sort_descending,
+                        )
+                        .await?;
+                    }
                 },
                 FleetActions::Deployments { action } => match action {
                     FleetDeploymentActions::List { page_size } => {
@@ -10788,6 +10846,25 @@ async fn main_inner() -> anyhow::Result<()> {
                     }
                     FleetScheduleActions::Trigger { schedule_id } => {
                         commands::fleet::schedules_trigger(&cfg, &schedule_id).await?;
+                    }
+                },
+                FleetActions::Tracers { action } => match action {
+                    FleetTracerActions::List {
+                        filter,
+                        page_size,
+                        page_number,
+                        sort_attribute,
+                        sort_descending,
+                    } => {
+                        commands::fleet::tracers_list(
+                            &cfg,
+                            filter,
+                            Some(page_size),
+                            page_number,
+                            sort_attribute,
+                            sort_descending,
+                        )
+                        .await?;
                     }
                 },
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5992,6 +5992,11 @@ enum FleetActions {
         #[command(subcommand)]
         action: FleetScheduleActions,
     },
+    /// List Kubernetes clusters in the fleet
+    Clusters {
+        #[command(subcommand)]
+        action: FleetClusterActions,
+    },
     /// Query fleet tracers (telemetry-derived service names, language, runtime IDs)
     Tracers {
         #[command(subcommand)]
@@ -6099,6 +6104,29 @@ enum FleetTracerActions {
         #[arg(long, help = "Page number (0-indexed)")]
         page_number: Option<i64>,
         #[arg(long, help = "Sort by attribute (e.g. service, language, hostname)")]
+        sort_attribute: Option<String>,
+        #[arg(long, default_value_t = false, help = "Sort descending")]
+        sort_descending: bool,
+    },
+}
+
+#[derive(Subcommand)]
+enum FleetClusterActions {
+    /// List Kubernetes clusters in the fleet.
+    ///
+    /// Returns clusters with node counts, agent versions, enabled products, and services.
+    /// Use this to discover cluster names for use with instrumented-pods.
+    List {
+        #[arg(
+            long,
+            help = "Filter query (e.g. cluster_name:production, env:prod)"
+        )]
+        filter: Option<String>,
+        #[arg(long, default_value_t = 10, help = "Results per page (max 100)")]
+        page_size: i64,
+        #[arg(long, help = "Page number (0-indexed)")]
+        page_number: Option<i64>,
+        #[arg(long, help = "Sort by attribute (e.g. cluster_name, node_count)")]
         sort_attribute: Option<String>,
         #[arg(long, default_value_t = false, help = "Sort descending")]
         sort_descending: bool,
@@ -10864,6 +10892,25 @@ async fn main_inner() -> anyhow::Result<()> {
                     }
                     FleetScheduleActions::Trigger { schedule_id } => {
                         commands::fleet::schedules_trigger(&cfg, &schedule_id).await?;
+                    }
+                },
+                FleetActions::Clusters { action } => match action {
+                    FleetClusterActions::List {
+                        filter,
+                        page_size,
+                        page_number,
+                        sort_attribute,
+                        sort_descending,
+                    } => {
+                        commands::fleet::clusters_list(
+                            &cfg,
+                            filter,
+                            Some(page_size),
+                            page_number,
+                            sort_attribute,
+                            sort_descending,
+                        )
+                        .await?;
                     }
                 },
                 FleetActions::Tracers { action } => match action {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10670,14 +10670,8 @@ async fn main_inner() -> anyhow::Result<()> {
                         limit,
                         sort,
                     } => {
-                        commands::cicd::flaky_tests_search(
-                            &cfg,
-                            query,
-                            cursor,
-                            limit,
-                            sort,
-                        )
-                        .await?;
+                        commands::cicd::flaky_tests_search(&cfg, query, cursor, limit, sort)
+                            .await?;
                     }
                     CicdFlakyTestActions::Update { file } => {
                         commands::cicd::flaky_tests_update(&cfg, &file).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5555,8 +5555,6 @@ enum CicdFlakyTestActions {
         cursor: Option<String>,
         #[arg(long, default_value_t = 100, help = "Maximum results")]
         limit: i64,
-        #[arg(long, default_value_t = false, help = "Include status history")]
-        include_history: bool,
         #[arg(
             long,
             help = "Sort order (fqn, -fqn, first_flaked, -first_flaked, last_flaked, -last_flaked, failure_rate, -failure_rate, pipelines_failed, -pipelines_failed, pipelines_duration_lost, -pipelines_duration_lost)"
@@ -10670,7 +10668,6 @@ async fn main_inner() -> anyhow::Result<()> {
                         query,
                         cursor,
                         limit,
-                        include_history,
                         sort,
                     } => {
                         commands::cicd::flaky_tests_search(
@@ -10678,7 +10675,6 @@ async fn main_inner() -> anyhow::Result<()> {
                             query,
                             cursor,
                             limit,
-                            include_history,
                             sort,
                         )
                         .await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5992,17 +5992,17 @@ enum FleetActions {
         #[command(subcommand)]
         action: FleetScheduleActions,
     },
-    /// List Kubernetes clusters in the fleet
+    /// Manage fleet clusters
     Clusters {
         #[command(subcommand)]
         action: FleetClusterActions,
     },
-    /// Query fleet tracers (telemetry-derived service names, language, runtime IDs)
+    /// Manage fleet tracers
     Tracers {
         #[command(subcommand)]
         action: FleetTracerActions,
     },
-    /// List instrumented pods in a Kubernetes cluster
+    /// Manage fleet instrumented pods
     #[command(name = "instrumented-pods")]
     InstrumentedPods {
         #[command(subcommand)]
@@ -6029,8 +6029,8 @@ enum FleetAgentActions {
     /// List tracers for a specific agent
     Tracers {
         agent_key: String,
-        #[arg(long, default_value_t = 10, help = "Results per page (max 100)")]
-        page_size: i64,
+        #[arg(long)]
+        page_size: Option<i64>,
         #[arg(long, help = "Page number (0-indexed)")]
         page_number: Option<i64>,
         #[arg(long, help = "Sort by attribute (e.g. service, language, hostname)")]
@@ -6099,8 +6099,8 @@ enum FleetTracerActions {
             help = "Filter query (e.g. env:prod, hostname:my-host, service:web-api)"
         )]
         filter: Option<String>,
-        #[arg(long, default_value_t = 10, help = "Results per page (max 100)")]
-        page_size: i64,
+        #[arg(long)]
+        page_size: Option<i64>,
         #[arg(long, help = "Page number (0-indexed)")]
         page_number: Option<i64>,
         #[arg(long, help = "Sort by attribute (e.g. service, language, hostname)")]
@@ -6122,8 +6122,8 @@ enum FleetClusterActions {
             help = "Filter query (e.g. cluster_name:production, env:prod)"
         )]
         filter: Option<String>,
-        #[arg(long, default_value_t = 10, help = "Results per page (max 100)")]
-        page_size: i64,
+        #[arg(long)]
+        page_size: Option<i64>,
         #[arg(long, help = "Page number (0-indexed)")]
         page_number: Option<i64>,
         #[arg(long, help = "Sort by attribute (e.g. cluster_name, node_count)")]
@@ -10851,7 +10851,7 @@ async fn main_inner() -> anyhow::Result<()> {
                         commands::fleet::agents_tracers_list(
                             &cfg,
                             agent_key,
-                            Some(page_size),
+                            page_size,
                             page_number,
                             sort_attribute,
                             sort_descending,
@@ -10905,7 +10905,7 @@ async fn main_inner() -> anyhow::Result<()> {
                         commands::fleet::clusters_list(
                             &cfg,
                             filter,
-                            Some(page_size),
+                            page_size,
                             page_number,
                             sort_attribute,
                             sort_descending,
@@ -10924,7 +10924,7 @@ async fn main_inner() -> anyhow::Result<()> {
                         commands::fleet::tracers_list(
                             &cfg,
                             filter,
-                            Some(page_size),
+                            page_size,
                             page_number,
                             sort_attribute,
                             sort_descending,

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -1737,6 +1737,30 @@ async fn test_fleet_instrumented_pods_list() {
     cleanup_env();
 }
 #[tokio::test]
+async fn test_fleet_clusters_list() {
+    let _lock = lock_env();
+    let mut server = mockito::Server::new_async().await;
+    let cfg = test_config(&server.url());
+
+    let mock = server
+        .mock("GET", "/api/unstable/fleet/clusters")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"data":{"type":"status","id":"done","attributes":{"clusters":[]}}}"#)
+        .create_async()
+        .await;
+
+    let result =
+        crate::commands::fleet::clusters_list(&cfg, None, None, None, None, false).await;
+    assert!(
+        result.is_ok(),
+        "clusters_list failed: {:?}",
+        result.err()
+    );
+    mock.assert_async().await;
+    cleanup_env();
+}
+#[tokio::test]
 async fn test_fleet_deployments_list() {
     let _lock = lock_env();
     let mut s = mockito::Server::new_async().await;

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -1590,6 +1590,24 @@ async fn test_cicd_flaky_tests_search() {
     cleanup_env();
 }
 
+#[tokio::test]
+async fn test_cicd_flaky_tests_search_invalid_sort() {
+    let _lock = lock_env();
+    let s = mockito::Server::new_async().await;
+    let cfg = test_config(&s.url());
+    let result = crate::commands::cicd::flaky_tests_search(
+        &cfg,
+        None,
+        None,
+        10,
+        Some("bogus".into()),
+    )
+    .await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("invalid sort value"));
+    cleanup_env();
+}
+
 // --- Fleet ---
 #[tokio::test]
 async fn test_fleet_agents_list() {

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -1710,6 +1710,33 @@ async fn test_fleet_agents_tracers_list() {
     cleanup_env();
 }
 #[tokio::test]
+async fn test_fleet_instrumented_pods_list() {
+    let _lock = lock_env();
+    let mut server = mockito::Server::new_async().await;
+    let cfg = test_config(&server.url());
+
+    let mock = server
+        .mock(
+            "GET",
+            "/api/unstable/fleet/cluster_agents/details/my-cluster/instrumented_pods",
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"data":{"type":"cluster_name","id":"my-cluster","attributes":{"groups":[]}}}"#)
+        .create_async()
+        .await;
+
+    let result =
+        crate::commands::fleet::instrumented_pods_list(&cfg, "my-cluster".into()).await;
+    assert!(
+        result.is_ok(),
+        "instrumented_pods_list failed: {:?}",
+        result.err()
+    );
+    mock.assert_async().await;
+    cleanup_env();
+}
+#[tokio::test]
 async fn test_fleet_deployments_list() {
     let _lock = lock_env();
     let mut s = mockito::Server::new_async().await;

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -1643,7 +1643,7 @@ async fn test_fleet_tracers_list() {
         .mock("GET", "/api/unstable/fleet/tracers")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"data":{"type":"status","attributes":{"tracers":[]}}}"#)
+        .with_body(r#"{"data":{"id":"status","type":"status","attributes":{"tracers":[]}}}"#)
         .create_async()
         .await;
 
@@ -1666,7 +1666,7 @@ async fn test_fleet_tracers_list_with_filter() {
         ))
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"data":{"type":"status","attributes":{"tracers":[]}}}"#)
+        .with_body(r#"{"data":{"id":"status","type":"status","attributes":{"tracers":[]}}}"#)
         .create_async()
         .await;
 
@@ -1697,7 +1697,7 @@ async fn test_fleet_agents_tracers_list() {
         .mock("GET", "/api/unstable/fleet/agents/agent-123/tracers")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"data":{"type":"status","attributes":{"tracers":[]}}}"#)
+        .with_body(r#"{"data":{"id":"status","type":"status","attributes":{"tracers":[]}}}"#)
         .create_async()
         .await;
 

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -1584,7 +1584,6 @@ async fn test_cicd_flaky_tests_search() {
         Some("@test.service:my-service".into()),
         None,
         50,
-        false,
         Some("-last_flaked".into()),
     )
     .await;

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -1685,7 +1685,7 @@ async fn test_fleet_agents_tracers_list() {
     let cfg = test_config(&server.url());
 
     let mock = server
-        .mock("GET", "/api/unstable/fleet/agents/details/agent-123/tracers")
+        .mock("GET", "/api/unstable/fleet/agents/agent-123/tracers")
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(r#"{"data":{"type":"status","attributes":{"tracers":[]}}}"#)
@@ -1718,7 +1718,7 @@ async fn test_fleet_instrumented_pods_list() {
     let mock = server
         .mock(
             "GET",
-            "/api/unstable/fleet/cluster_agents/details/my-cluster/instrumented_pods",
+            "/api/unstable/fleet/clusters/my-cluster/instrumented_pods",
         )
         .with_status(200)
         .with_header("content-type", "application/json")

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -1633,13 +1633,8 @@ async fn test_fleet_tracers_list() {
         .create_async()
         .await;
 
-    let result =
-        crate::commands::fleet::tracers_list(&cfg, None, None, None, None, false).await;
-    assert!(
-        result.is_ok(),
-        "tracers_list failed: {:?}",
-        result.err()
-    );
+    let result = crate::commands::fleet::tracers_list(&cfg, None, None, None, None, false).await;
+    assert!(result.is_ok(), "tracers_list failed: {:?}", result.err());
     mock.assert_async().await;
     cleanup_env();
 }
@@ -1722,12 +1717,13 @@ async fn test_fleet_instrumented_pods_list() {
         )
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"data":{"type":"cluster_name","id":"my-cluster","attributes":{"groups":[]}}}"#)
+        .with_body(
+            r#"{"data":{"type":"cluster_name","id":"my-cluster","attributes":{"groups":[]}}}"#,
+        )
         .create_async()
         .await;
 
-    let result =
-        crate::commands::fleet::instrumented_pods_list(&cfg, "my-cluster".into()).await;
+    let result = crate::commands::fleet::instrumented_pods_list(&cfg, "my-cluster".into()).await;
     assert!(
         result.is_ok(),
         "instrumented_pods_list failed: {:?}",
@@ -1750,13 +1746,8 @@ async fn test_fleet_clusters_list() {
         .create_async()
         .await;
 
-    let result =
-        crate::commands::fleet::clusters_list(&cfg, None, None, None, None, false).await;
-    assert!(
-        result.is_ok(),
-        "clusters_list failed: {:?}",
-        result.err()
-    );
+    let result = crate::commands::fleet::clusters_list(&cfg, None, None, None, None, false).await;
+    assert!(result.is_ok(), "clusters_list failed: {:?}", result.err());
     mock.assert_async().await;
     cleanup_env();
 }

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -1595,16 +1595,13 @@ async fn test_cicd_flaky_tests_search_invalid_sort() {
     let _lock = lock_env();
     let s = mockito::Server::new_async().await;
     let cfg = test_config(&s.url());
-    let result = crate::commands::cicd::flaky_tests_search(
-        &cfg,
-        None,
-        None,
-        10,
-        Some("bogus".into()),
-    )
-    .await;
+    let result =
+        crate::commands::cicd::flaky_tests_search(&cfg, None, None, 10, Some("bogus".into())).await;
     assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains("invalid sort value"));
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("invalid sort value"));
     cleanup_env();
 }
 

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -1620,6 +1620,96 @@ async fn test_fleet_agents_versions() {
     cleanup_env();
 }
 #[tokio::test]
+async fn test_fleet_tracers_list() {
+    let _lock = lock_env();
+    let mut server = mockito::Server::new_async().await;
+    let cfg = test_config(&server.url());
+
+    let mock = server
+        .mock("GET", "/api/unstable/fleet/tracers")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"data":{"type":"status","attributes":{"tracers":[]}}}"#)
+        .create_async()
+        .await;
+
+    let result =
+        crate::commands::fleet::tracers_list(&cfg, None, None, None, None, false).await;
+    assert!(
+        result.is_ok(),
+        "tracers_list failed: {:?}",
+        result.err()
+    );
+    mock.assert_async().await;
+    cleanup_env();
+}
+#[tokio::test]
+async fn test_fleet_tracers_list_with_filter() {
+    let _lock = lock_env();
+    let mut server = mockito::Server::new_async().await;
+    let cfg = test_config(&server.url());
+
+    let mock = server
+        .mock("GET", "/api/unstable/fleet/tracers")
+        .match_query(mockito::Matcher::UrlEncoded(
+            "filter".into(),
+            "hostname:my-host".into(),
+        ))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"data":{"type":"status","attributes":{"tracers":[]}}}"#)
+        .create_async()
+        .await;
+
+    let result = crate::commands::fleet::tracers_list(
+        &cfg,
+        Some("hostname:my-host".into()),
+        None,
+        None,
+        None,
+        false,
+    )
+    .await;
+    assert!(
+        result.is_ok(),
+        "tracers_list with filter failed: {:?}",
+        result.err()
+    );
+    mock.assert_async().await;
+    cleanup_env();
+}
+#[tokio::test]
+async fn test_fleet_agents_tracers_list() {
+    let _lock = lock_env();
+    let mut server = mockito::Server::new_async().await;
+    let cfg = test_config(&server.url());
+
+    let mock = server
+        .mock("GET", "/api/unstable/fleet/agents/details/agent-123/tracers")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"data":{"type":"status","attributes":{"tracers":[]}}}"#)
+        .create_async()
+        .await;
+
+    let result = crate::commands::fleet::agents_tracers_list(
+        &cfg,
+        "agent-123".into(),
+        None,
+        None,
+        None,
+        false,
+    )
+    .await;
+    assert!(
+        result.is_ok(),
+        "agents_tracers_list failed: {:?}",
+        result.err()
+    );
+    mock.assert_async().await;
+    cleanup_env();
+}
+#[tokio::test]
 async fn test_fleet_deployments_list() {
     let _lock = lock_env();
     let mut s = mockito::Server::new_async().await;


### PR DESCRIPTION
## Summary

Builds on datadog-labs/pup#330 (contributed by @khanayan123), adding review fixes on top of the original work before merge. All command code is unchanged from that PR — this PR adds the documentation and dependency corrections flagged in review.

## Commands added (from #330)

- `pup fleet tracers list [--filter <expr>]` — list tracers across the fleet (telemetry-derived service names, language, runtime IDs)
- `pup fleet agents tracers <agent-key>` — list tracers for a specific agent
- `pup fleet clusters list [--filter <expr>]` — list Kubernetes clusters in the fleet
- `pup fleet instrumented-pods list <cluster-name>` — list pods targeted for SSI injection

## Changes on top of #330

- `docs/COMMANDS.md` — add `clusters (list)` to fleet row in command-index table; update Domain Categories bullet to include `tracers, clusters, instrumented-pods`
- `docs/EXAMPLES.md` — add `## Fleet Clusters` section with list/filter/pagination examples
- `Cargo.toml` — pin `rand` to `0.10.1` minimum with comment; the SDK rev (d70b186e) was resolving to 0.10.0
- `Cargo.lock` — restore `rand 0.10.1` and `rustls-webpki 0.103.12` via `cargo update` (both had been downgraded from main's versions)

## Dependencies (all merged)

- API spec: DataDog/datadog-api-spec#5427
- Rust SDK: DataDog/datadog-api-client-rust#1475
- Backend: DataDog/dd-source#404058

## Testing

- `cargo build` clean
- `cargo audit` — no new advisories introduced by this PR (pre-existing `rsa`/`russh` warnings present on `main`)

## Checklist

- [x] Uses typed SDK methods
- [x] Unstable operation IDs registered
- [x] Tests included (from #330)
- [x] Docs complete (tracers + clusters + instrumented-pods)
- [x] Dependency versions match or exceed `main`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)