### PR TITLE
feat(software-catalog): add --filter for client-side name matching

### DIFF
--- a/src/commands/software_catalog.rs
+++ b/src/commands/software_catalog.rs
@@ -12,6 +12,7 @@ use crate::util;
 
 pub async fn entities_list(
     cfg: &Config,
+    filter: Option<String>,
     filter_kind: Option<String>,
     filter_owner: Option<String>,
     filter_ref: Option<String>,
@@ -31,11 +32,33 @@ pub async fn entities_list(
     if let Some(v) = &filter_ref {
         params = params.filter_ref(v.clone());
     }
-    let resp = api
-        .list_catalog_entity(params)
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to list catalog entities: {e:?}"))?;
-    formatter::output(cfg, &resp)
+    // Client-side filter requires paginating through all results since the
+    // API's filter[name] only supports exact match.
+    if let Some(pattern) = &filter {
+        use futures::StreamExt;
+        let pattern = pattern.to_lowercase();
+        let mut stream = Box::pin(api.list_catalog_entity_with_pagination(params));
+        let mut filtered = Vec::new();
+        while let Some(item) = stream.next().await {
+            let entity = item
+                .map_err(|e| anyhow::anyhow!("failed to list catalog entities: {e:?}"))?;
+            let matches = entity
+                .attributes
+                .as_ref()
+                .and_then(|a| a.name.as_ref())
+                .is_some_and(|n| n.to_lowercase().contains(&pattern));
+            if matches {
+                filtered.push(entity);
+            }
+        }
+        formatter::output(cfg, &serde_json::json!({"data": filtered}))
+    } else {
+        let resp = api
+            .list_catalog_entity(params)
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to list catalog entities: {e:?}"))?;
+        formatter::output(cfg, &resp)
+    }
 }
 
 pub async fn entities_upsert(cfg: &Config, file: &str) -> Result<()> {

--- a/src/commands/software_catalog.rs
+++ b/src/commands/software_catalog.rs
@@ -34,14 +34,15 @@ pub async fn entities_list(
     }
     // Client-side filter requires paginating through all results since the
     // API's filter[name] only supports exact match.
+    #[cfg(not(target_arch = "wasm32"))]
     if let Some(pattern) = &filter {
         use futures::StreamExt;
         let pattern = pattern.to_lowercase();
         let mut stream = Box::pin(api.list_catalog_entity_with_pagination(params));
         let mut filtered = Vec::new();
         while let Some(item) = stream.next().await {
-            let entity = item
-                .map_err(|e| anyhow::anyhow!("failed to list catalog entities: {e:?}"))?;
+            let entity =
+                item.map_err(|e| anyhow::anyhow!("failed to list catalog entities: {e:?}"))?;
             let matches = entity
                 .attributes
                 .as_ref()
@@ -51,14 +52,15 @@ pub async fn entities_list(
                 filtered.push(entity);
             }
         }
-        formatter::output(cfg, &serde_json::json!({"data": filtered}))
-    } else {
-        let resp = api
-            .list_catalog_entity(params)
-            .await
-            .map_err(|e| anyhow::anyhow!("failed to list catalog entities: {e:?}"))?;
-        formatter::output(cfg, &resp)
+        return formatter::output(cfg, &serde_json::json!({"data": filtered}));
     }
+    #[cfg(target_arch = "wasm32")]
+    let _ = &filter;
+    let resp = api
+        .list_catalog_entity(params)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to list catalog entities: {e:?}"))?;
+    formatter::output(cfg, &resp)
 }
 
 pub async fn entities_upsert(cfg: &Config, file: &str) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4951,11 +4951,14 @@ enum SoftwareCatalogEntityActions {
     /// List catalog entities
     ///
     /// EXAMPLES:
-    ///   pup software-catalog entities list --filter-kind service
+    ///   pup software-catalog entities list --filter shop-
+    ///   pup software-catalog entities list --filter-kind service --filter shop-
     ///   pup software-catalog entities list --filter-owner team-claude
     ///   pup software-catalog entities list --filter-ref service:shop-frontend
     #[command(verbatim_doc_comment)]
     List {
+        #[arg(long, help = "Filter entities by name (substring match)")]
+        filter: Option<String>,
         #[arg(long, help = "Filter entities by kind (e.g. service, datastore)")]
         filter_kind: Option<String>,
         #[arg(long, help = "Filter entities by owner")]
@@ -10316,12 +10319,14 @@ async fn main_inner() -> anyhow::Result<()> {
             match action {
                 SoftwareCatalogActions::Entities { action } => match action {
                     SoftwareCatalogEntityActions::List {
+                        filter,
                         filter_kind,
                         filter_owner,
                         filter_ref,
                     } => {
                         commands::software_catalog::entities_list(
                             &cfg,
+                            filter,
                             filter_kind,
                             filter_owner,
                             filter_ref,

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -4303,7 +4303,8 @@ async fn test_software_catalog_entities_list() {
     let mut server = mockito::Server::new_async().await;
     let cfg = test_config(&server.url());
     let _mock = mock_any(&mut server, "GET", r#"{"data":[]}"#).await;
-    let result = crate::commands::software_catalog::entities_list(&cfg, None, None, None).await;
+    let result =
+        crate::commands::software_catalog::entities_list(&cfg, None, None, None, None).await;
     assert!(
         result.is_ok(),
         "software catalog entities list failed: {:?}",
@@ -4322,6 +4323,7 @@ async fn test_software_catalog_entities_list_with_filters() {
     let _mock = mock_any(&mut server, "GET", r#"{"data":[]}"#).await;
     let result = crate::commands::software_catalog::entities_list(
         &cfg,
+        Some("shop-".to_string()),
         Some("service".to_string()),
         None,
         None,
@@ -4329,7 +4331,7 @@ async fn test_software_catalog_entities_list_with_filters() {
     .await;
     assert!(
         result.is_ok(),
-        "software catalog entities list with kind filter failed: {:?}",
+        "software catalog entities list with name and kind filter failed: {:?}",
         result.err()
     );
     cleanup_env();
@@ -4384,7 +4386,8 @@ async fn test_software_catalog_entities_list_error() {
         .with_body(r#"{"errors":["Internal Server Error"]}"#)
         .create_async()
         .await;
-    let result = crate::commands::software_catalog::entities_list(&cfg, None, None, None).await;
+    let result =
+        crate::commands::software_catalog::entities_list(&cfg, None, None, None, None).await;
     assert!(
         result.is_err(),
         "expected software catalog entities list to fail on 500"


### PR DESCRIPTION
## Summary

Add `--filter` to `software-catalog entities list` for client-side substring matching on entity name. The API's `filter[name]` only supports exact match, which isn't useful for finding groups of related services (e.g. all `shop-*` services).

When `--filter` is provided, the command uses `list_catalog_entity_with_pagination` to stream through all pages before filtering — without it, a single-page fetch would miss entities beyond the first 100 results. Without `--filter`, the existing single-page call is unchanged.

Server-side filters (`--filter-kind`, `--filter-owner`, `--filter-ref` from #369) narrow the result set before the client-side filter runs.

This follows the same client-side filtering pattern used by `metrics list --filter` and `debugger` environment filtering.

## Test plan

- [x] `pup software-catalog entities list --filter shopist` returns all shopist-* entities
- [x] `pup software-catalog entities list --filter-kind service --filter shopist` combines both
- [x] No `--filter` returns first page (unchanged behavior)
- [x] `cargo test test_software_catalog` — 5 tests pass

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)