### PR TITLE
chore: pin rust toolchain to 1.94.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.94.0"
+components = ["clippy", "rustfmt", "llvm-tools-preview"]


### PR DESCRIPTION
## Summary
Pin the Rust toolchain to 1.94.0 to unblock CI. The unpinned `stable` channel picked up Rust 1.95.0, which introduced new `collapsible_match` clippy lints that fail under `-D warnings`.

## Changes
- Add `rust-toolchain.toml` pinning to 1.94.0 with required components (clippy, rustfmt, llvm-tools-preview)

## Testing
- CI will validate that the pinned toolchain resolves the clippy failures

## Follow-up
A separate PR (#378) fixes the lint warnings and will allow bumping to 1.95.0.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)