### PR TITLE
style: fix collapsible_match clippy warnings

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.94.0"
+components = ["clippy", "rustfmt", "llvm-tools-preview"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.94.0"
+channel = "1.95.0"
 components = ["clippy", "rustfmt", "llvm-tools-preview"]

--- a/src/commands/runbooks.rs
+++ b/src/commands/runbooks.rs
@@ -142,25 +142,19 @@ pub fn validate(cfg: &Config, name: &str) -> Result<()> {
 
         // Kind-specific required fields
         match step.kind.as_str() {
-            "pup" | "shell" => {
-                if step.run.is_none() {
-                    errors.push(format!(
-                        "{step_id}: kind '{kind}' requires 'run'",
-                        kind = step.kind
-                    ));
-                }
+            "pup" | "shell" if step.run.is_none() => {
+                errors.push(format!(
+                    "{step_id}: kind '{kind}' requires 'run'",
+                    kind = step.kind
+                ));
             }
-            "datadog-workflow" => {
-                if step.workflow_id.is_none() {
-                    errors.push(format!(
-                        "{step_id}: kind 'datadog-workflow' requires 'workflow_id'"
-                    ));
-                }
+            "datadog-workflow" if step.workflow_id.is_none() => {
+                errors.push(format!(
+                    "{step_id}: kind 'datadog-workflow' requires 'workflow_id'"
+                ));
             }
-            "confirm" => {
-                if step.message.is_none() {
-                    errors.push(format!("{step_id}: kind 'confirm' requires 'message'"));
-                }
+            "confirm" if step.message.is_none() => {
+                errors.push(format!("{step_id}: kind 'confirm' requires 'message'"));
             }
             _ => {}
         }

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -113,9 +113,7 @@ impl Tunnel {
         tokio::spawn(async move {
             while let Some(msg) = ws_read.next().await {
                 match msg {
-                    Ok(Message::Binary(data))
-                        if our_write.write_all(&data).await.is_err() =>
-                    {
+                    Ok(Message::Binary(data)) if our_write.write_all(&data).await.is_err() => {
                         break;
                     }
                     Ok(Message::Close(_)) | Err(_) => break,

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -113,10 +113,10 @@ impl Tunnel {
         tokio::spawn(async move {
             while let Some(msg) = ws_read.next().await {
                 match msg {
-                    Ok(Message::Binary(data)) => {
-                        if our_write.write_all(&data).await.is_err() {
-                            break;
-                        }
+                    Ok(Message::Binary(data))
+                        if our_write.write_all(&data).await.is_err() =>
+                    {
+                        break;
                     }
                     Ok(Message::Close(_)) | Err(_) => break,
                     _ => {}


### PR DESCRIPTION
## Summary
Fix 4 `collapsible_match` clippy warnings introduced in Rust 1.95.0 by collapsing `if` blocks inside match arms into match guards.

## Changes
- `src/commands/runbooks.rs`: collapse 3 match arms (`"pup" | "shell"`, `"datadog-workflow"`, `"confirm"`) to use guards
- `src/tunnel.rs`: collapse `Ok(Message::Binary(data))` arm to use a guard

All fixes are manual — the clippy auto-fix for this lint is known to be buggy (rust-lang/rust-clippy#16860).

## Testing
- CI will validate these satisfy the `collapsible_match` lint
- No behavior change — match guards fall through to existing `_ => {}` catch-all arms

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)