### PR TITLE
fix(ddsql): support --query - and SQL comments

### DIFF
--- a/src/commands/ddsql.rs
+++ b/src/commands/ddsql.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Result};
 use serde_json::{json, Value};
+use std::io::{self, Read};
 use std::time::Duration;
 
 use crate::client;
@@ -16,6 +17,30 @@ fn client_id() -> String {
     } else {
         format!("pup/{}", version::VERSION)
     }
+}
+
+fn read_query_from_reader(reader: &mut impl Read) -> Result<String> {
+    let mut query = String::new();
+    reader.read_to_string(&mut query)?;
+
+    if query.trim().is_empty() {
+        return Err(anyhow!("DDSQL query is empty"));
+    }
+
+    Ok(query)
+}
+
+fn resolve_query_from_reader(query: &str, reader: &mut impl Read) -> Result<String> {
+    match query {
+        "-" => read_query_from_reader(reader),
+        query => Ok(query.to_string()),
+    }
+}
+
+fn resolve_query(query: &str) -> Result<String> {
+    let stdin = io::stdin();
+    let mut handle = stdin.lock();
+    resolve_query_from_reader(query, &mut handle)
 }
 
 /// Build a request for the Advanced Query API (tabular/scalar endpoint).
@@ -182,7 +207,8 @@ pub async fn table(
     limit: Option<i32>,
     _offset: Option<i32>,
 ) -> Result<()> {
-    let rows = execute_ddsql_query(cfg, query, from, to, limit).await?;
+    let query = resolve_query(query)?;
+    let rows = execute_ddsql_query(cfg, &query, from, to, limit).await?;
     formatter::output(cfg, &rows)
 }
 
@@ -194,7 +220,8 @@ pub async fn time_series(
     _interval: Option<i64>,
     limit: i32,
 ) -> Result<()> {
-    let body = build_advanced_table_request(query, from, to, Some(limit))?;
+    let query = resolve_query(query)?;
+    let body = build_advanced_table_request(&query, from, to, Some(limit))?;
     let data = execute_async_query(cfg, body, None).await?;
     let rows = columnar_to_rows(&data)?;
     formatter::output(cfg, &rows)
@@ -297,6 +324,22 @@ mod tests {
     fn test_build_advanced_table_invalid_from() {
         let err = build_advanced_table_request("SELECT 1", "garbage", "now", None).unwrap_err();
         assert!(err.to_string().contains("invalid --from"));
+    }
+
+    #[test]
+    fn test_resolve_query_accepts_comment_prefix() {
+        let query = "-- comment\nSELECT 1";
+        assert_eq!(
+            resolve_query_from_reader(query, &mut io::empty()).unwrap(),
+            query
+        );
+    }
+
+    #[test]
+    fn test_resolve_query_reads_explicit_stdin_marker() {
+        let mut stdin = io::Cursor::new("-- comment\nSELECT 1");
+        let query = resolve_query_from_reader("-", &mut stdin).unwrap();
+        assert_eq!(query, "-- comment\nSELECT 1");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1057,6 +1057,7 @@ enum Commands {
     /// EXAMPLES:
     ///   pup ddsql table --query "SELECT * FROM reference_tables.offices_ips LIMIT 5"
     ///   pup ddsql table --query "SELECT * FROM reference_tables.offices_ips" -o csv > results.csv
+    ///   cat query.sql | pup ddsql table --query - -o table
     ///   pup ddsql time-series --query "SELECT avg(system.cpu.user) FROM metrics GROUP BY host" --from 1h --interval 300000
     ///
     /// AUTHENTICATION:
@@ -3742,7 +3743,11 @@ enum DbmSamplesActions {
 enum DdsqlActions {
     /// Execute DDSQL query and return columnar table data
     Table {
-        #[arg(long, help = "DDSQL query string")]
+        #[arg(
+            long,
+            allow_hyphen_values = true,
+            help = "DDSQL query string, or use --query - to read from stdin"
+        )]
         query: String,
         #[arg(
             long,
@@ -3762,7 +3767,11 @@ enum DdsqlActions {
     /// Execute DDSQL query and return time series data
     #[command(name = "time-series")]
     TimeSeries {
-        #[arg(long, help = "DDSQL query string")]
+        #[arg(
+            long,
+            allow_hyphen_values = true,
+            help = "DDSQL query string, or use --query - to read from stdin"
+        )]
         query: String,
         #[arg(long, default_value = "1h", help = "Start time")]
         from: String,

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -4151,6 +4151,70 @@ fn test_dbm_samples_search_parses() {
     }
 }
 
+#[test]
+fn test_ddsql_table_query_accepts_leading_comment() {
+    use clap::Parser;
+
+    let query = "-- owner breakdown\nSELECT 1";
+    let cli = crate::Cli::try_parse_from(["pup", "ddsql", "table", "--query", query])
+        .expect("ddsql table with leading SQL comment should parse");
+
+    match cli.command {
+        crate::Commands::Ddsql { action } => match action {
+            crate::DdsqlActions::Table { query: parsed, .. } => {
+                assert_eq!(parsed, query);
+            }
+            _ => panic!("expected DdsqlActions::Table"),
+        },
+        _ => panic!("expected Commands::Ddsql"),
+    }
+}
+
+#[test]
+fn test_ddsql_table_query_accepts_explicit_stdin_marker() {
+    use clap::Parser;
+
+    let cli = crate::Cli::try_parse_from(["pup", "ddsql", "table", "--query", "-"])
+        .expect("ddsql table --query - should parse");
+
+    match cli.command {
+        crate::Commands::Ddsql { action } => match action {
+            crate::DdsqlActions::Table { query, .. } => {
+                assert_eq!(query, "-");
+            }
+            _ => panic!("expected DdsqlActions::Table"),
+        },
+        _ => panic!("expected Commands::Ddsql"),
+    }
+}
+
+#[test]
+fn test_ddsql_time_series_query_accepts_explicit_stdin_marker() {
+    use clap::Parser;
+
+    let cli = crate::Cli::try_parse_from(["pup", "ddsql", "time-series", "--query", "-"])
+        .expect("ddsql time-series --query - should parse");
+
+    match cli.command {
+        crate::Commands::Ddsql { action } => match action {
+            crate::DdsqlActions::TimeSeries { query, .. } => {
+                assert_eq!(query, "-");
+            }
+            _ => panic!("expected DdsqlActions::TimeSeries"),
+        },
+        _ => panic!("expected Commands::Ddsql"),
+    }
+}
+
+#[test]
+fn test_ddsql_table_query_requires_explicit_value() {
+    let result = crate::Cli::command().try_get_matches_from(["pup", "ddsql", "table", "--query"]);
+    assert!(
+        result.is_err(),
+        "expected ddsql table --query to require a value"
+    );
+}
+
 // ---- Debugger ----
 
 #[tokio::test]


### PR DESCRIPTION
## What does this PR do?

Fixes `pup ddsql table --query` so it handles two valid DDSQL input patterns that currently fail:
- SQL queries whose first tokens are `--` comments
- stdin-fed queries via `--query -`

## Motivation

Right now longer DDSQL queries are awkward to run from files because comment-prefixed SQL can be parsed as flags, and piping a query into `pup ddsql table` requires manual shell rewriting instead of letting `pup` read stdin explicitly.

## Additional Notes

Examples of what this fixes:

```bash
pup ddsql table --query "$(cat ~/test/catalogs/public_ddsql/aws/ebs_footprint_by_owner.sql)" -o table

cat ~/test/catalogs/public_ddsql/aws/ebs_footprint_by_owner.sql | pup ddsql table --query - -o table
```

Implementation details:
- allow hyphen-prefixed `--query` values so SQL starting with `--` is passed through to DDSQL unchanged
- resolve `--query -` by reading stdin in the ddsql command layer
- add parser and command tests for explicit stdin, comment-prefixed queries, and the error case where `--query` is given without a value

Local validation:
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo fmt --check`

## Checklist

- [x] The code change follows the project conventions (see [CONTRIBUTING.md](../docs/CONTRIBUTING.md))
- [x] Tests have been added/updated (if applicable)
- [x] Documentation has been updated (if applicable)
- [ ] All CI checks pass
- [x] Code coverage is maintained or improved

## Related Issues

None.
