### PR TITLE
feat(ddsql): add spec and schema discovery commands

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -27,7 +27,7 @@ pup <domain> <subgroup> <action> [options] # Nested commands
 | monitors | list, get, delete, search | src/commands/monitors.rs | ✅ |
 | dashboards | list, get, delete, url | src/commands/dashboards.rs | ✅ |
 | dbm | samples (search) | src/commands/dbm.rs | ✅ |
-| ddsql | table, time-series | src/commands/ddsql.rs | ✅ |
+| ddsql | table, time-series, spec, schema (tables, columns) | src/commands/ddsql.rs | ✅ |
 | debugger | probes (list, get, create, delete, watch) | src/commands/debugger.rs | ✅ |
 | slos | list, get, delete, status | src/commands/slos.rs | ✅ |
 | incidents | list, get, attachments, settings, handles, postmortem-templates | src/commands/incidents.rs | ✅ |
@@ -138,7 +138,7 @@ pup infrastructure hosts list
 - **traces** - APM spans metrics (list, get, create, update, delete)
 - **rum** - Real User Monitoring (apps, metrics, retention-filters, sessions)
 - **events** - Infrastructure events (list, search, get)
-- **ddsql** - DDSQL queries (table, csv, time-series)
+- **ddsql** - DDSQL queries and discovery (table, time-series, spec, schema)
 - **symdb** - Symbol Database queries (search scopes, probe locations)
 
 ### Monitoring & Alerting

--- a/src/client.rs
+++ b/src/client.rs
@@ -416,6 +416,19 @@ static OAUTH_EXCLUDED_ENDPOINTS: &[EndpointRequirement] = &[
         path: "/api/v2/application_keys/",
         method: "PATCH",
     },
+    // DDSQL editor tools (3)
+    EndpointRequirement {
+        path: "/api/unstable/ddsql-editor/tools/ddsql-docs",
+        method: "GET",
+    },
+    EndpointRequirement {
+        path: "/api/unstable/ddsql-editor/tools/table-names",
+        method: "GET",
+    },
+    EndpointRequirement {
+        path: "/api/unstable/ddsql-editor/tools/table-data",
+        method: "POST",
+    },
     EndpointRequirement {
         path: "/api/v2/application_keys/",
         method: "DELETE",
@@ -600,19 +613,12 @@ pub async fn raw_request(
 ) -> anyhow::Result<HttpResponse> {
     let url = format!("{}{}", cfg.api_base_url(), path);
     let client = reqwest::Client::new();
-    let method = reqwest::Method::from_bytes(method.to_uppercase().as_bytes())
+    let method_name = method.to_uppercase();
+    let method = reqwest::Method::from_bytes(method_name.as_bytes())
         .map_err(|_| anyhow::anyhow!("unsupported HTTP method: {method}"))?;
     let mut req = client.request(method, &url);
 
-    if let Some(token) = &cfg.access_token {
-        req = req.header("Authorization", format!("Bearer {token}"));
-    } else if let (Some(api_key), Some(app_key)) = (&cfg.api_key, &cfg.app_key) {
-        req = req
-            .header("DD-API-KEY", api_key.as_str())
-            .header("DD-APPLICATION-KEY", app_key.as_str());
-    } else {
-        anyhow::bail!("no authentication configured");
-    }
+    req = apply_auth(req, cfg, &method_name, path)?;
 
     req = req
         .header("Accept", accept)
@@ -669,15 +675,7 @@ pub async fn raw_get(
     let client = reqwest::Client::new();
     let mut req = client.get(&url);
 
-    if let Some(token) = &cfg.access_token {
-        req = req.header("Authorization", format!("Bearer {token}"));
-    } else if let (Some(api_key), Some(app_key)) = (&cfg.api_key, &cfg.app_key) {
-        req = req
-            .header("DD-API-KEY", api_key.as_str())
-            .header("DD-APPLICATION-KEY", app_key.as_str());
-    } else {
-        anyhow::bail!("no authentication configured");
-    }
+    req = apply_auth(req, cfg, "GET", path)?;
 
     if !query.is_empty() {
         req = req.query(query);
@@ -708,15 +706,7 @@ pub async fn raw_patch(
     let client = reqwest::Client::new();
     let mut req = client.patch(&url);
 
-    if let Some(token) = &cfg.access_token {
-        req = req.header("Authorization", format!("Bearer {token}"));
-    } else if let (Some(api_key), Some(app_key)) = (&cfg.api_key, &cfg.app_key) {
-        req = req
-            .header("DD-API-KEY", api_key.as_str())
-            .header("DD-APPLICATION-KEY", app_key.as_str());
-    } else {
-        anyhow::bail!("no authentication configured");
-    }
+    req = apply_auth(req, cfg, "PATCH", path)?;
 
     let resp = req
         .header("Content-Type", "application/json")
@@ -741,7 +731,7 @@ pub async fn raw_post(
     body: serde_json::Value,
 ) -> anyhow::Result<serde_json::Value> {
     let url = format!("{}{}", cfg.api_base_url(), path);
-    raw_post_impl(cfg, &url, body, useragent::get()).await
+    raw_post_impl(cfg, path, &url, body, useragent::get()).await
 }
 
 /// Like `raw_post`, but with a custom User-Agent string for audit log differentiation.
@@ -752,11 +742,12 @@ pub async fn raw_post_with_ua(
     ua: String,
 ) -> anyhow::Result<serde_json::Value> {
     let url = format!("{}{}", cfg.api_base_url(), path);
-    raw_post_impl(cfg, &url, body, ua).await
+    raw_post_impl(cfg, path, &url, body, ua).await
 }
 
 async fn raw_post_impl(
     cfg: &Config,
+    path: &str,
     url: &str,
     body: serde_json::Value,
     ua: String,
@@ -764,15 +755,7 @@ async fn raw_post_impl(
     let client = reqwest::Client::new();
     let mut req = client.post(url);
 
-    if let Some(token) = &cfg.access_token {
-        req = req.header("Authorization", format!("Bearer {token}"));
-    } else if let (Some(api_key), Some(app_key)) = (&cfg.api_key, &cfg.app_key) {
-        req = req
-            .header("DD-API-KEY", api_key.as_str())
-            .header("DD-APPLICATION-KEY", app_key.as_str());
-    } else {
-        anyhow::bail!("no authentication configured");
-    }
+    req = apply_auth(req, cfg, "POST", path)?;
 
     let resp = req
         .header("Content-Type", "application/json")
@@ -787,6 +770,40 @@ async fn raw_post_impl(
         anyhow::bail!("POST {url} failed (HTTP {status}): {body}");
     }
     Ok(resp.json().await?)
+}
+
+fn apply_auth(
+    mut req: reqwest::RequestBuilder,
+    cfg: &Config,
+    method: &str,
+    path: &str,
+) -> anyhow::Result<reqwest::RequestBuilder> {
+    if requires_api_key_fallback(method, path) {
+        if let (Some(api_key), Some(app_key)) = (&cfg.api_key, &cfg.app_key) {
+            req = req
+                .header("DD-API-KEY", api_key.as_str())
+                .header("DD-APPLICATION-KEY", app_key.as_str());
+            return Ok(req);
+        }
+
+        anyhow::bail!(
+            "{method} {path} requires DD_API_KEY and DD_APP_KEY; OAuth2 bearer tokens are not supported"
+        );
+    }
+
+    if let Some(token) = &cfg.access_token {
+        req = req.header("Authorization", format!("Bearer {token}"));
+        return Ok(req);
+    }
+
+    if let (Some(api_key), Some(app_key)) = (&cfg.api_key, &cfg.app_key) {
+        req = req
+            .header("DD-API-KEY", api_key.as_str())
+            .header("DD-APPLICATION-KEY", app_key.as_str());
+        return Ok(req);
+    }
+
+    anyhow::bail!("no authentication configured")
 }
 
 /// Like `raw_post`, but returns the parsed JSON body even on non-2xx responses.
@@ -963,7 +980,7 @@ mod tests {
 
     #[test]
     fn test_oauth_excluded_count() {
-        assert_eq!(OAUTH_EXCLUDED_ENDPOINTS.len(), 45);
+        assert_eq!(OAUTH_EXCLUDED_ENDPOINTS.len(), 48);
     }
 
     #[test]
@@ -1054,6 +1071,22 @@ mod tests {
         assert!(requires_api_key_fallback(
             "DELETE",
             "/api/v2/api_keys/key-123"
+        ));
+    }
+
+    #[test]
+    fn test_requires_api_key_fallback_ddsql_editor_tools() {
+        assert!(requires_api_key_fallback(
+            "GET",
+            "/api/unstable/ddsql-editor/tools/ddsql-docs"
+        ));
+        assert!(requires_api_key_fallback(
+            "GET",
+            "/api/unstable/ddsql-editor/tools/table-names"
+        ));
+        assert!(requires_api_key_fallback(
+            "POST",
+            "/api/unstable/ddsql-editor/tools/table-data"
         ));
     }
 

--- a/src/commands/ddsql.rs
+++ b/src/commands/ddsql.rs
@@ -1,10 +1,11 @@
 use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::io::{self, Read};
 use std::time::Duration;
 
 use crate::client;
-use crate::config::Config;
+use crate::config::{Config, OutputFormat};
 use crate::formatter;
 use crate::useragent;
 use crate::util;
@@ -41,6 +42,473 @@ fn resolve_query(query: &str) -> Result<String> {
     let stdin = io::stdin();
     let mut handle = stdin.lock();
     resolve_query_from_reader(query, &mut handle)
+}
+
+const DDSQL_DOCS_PATH: &str = "/api/unstable/ddsql-editor/tools/ddsql-docs";
+const DDSQL_TABLE_NAMES_PATH: &str = "/api/unstable/ddsql-editor/tools/table-names";
+const DDSQL_TABLE_DATA_PATH: &str = "/api/unstable/ddsql-editor/tools/table-data";
+const REFERENCE_TABLES_PATH: &str = "/api/v2/reference-tables/tables";
+
+#[derive(Debug, Deserialize, Serialize)]
+struct DdsqlDocsResponse {
+    docs: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DdsqlTableNamesResponse {
+    tables: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DdsqlTableDataResponse {
+    tables: Vec<DdsqlTableDataEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DdsqlTableDataEntry {
+    #[serde(rename = "Table")]
+    table: DdsqlToolTable,
+}
+
+#[derive(Debug, Deserialize)]
+struct DdsqlToolTable {
+    #[serde(rename = "TableName")]
+    table_name: String,
+    #[serde(rename = "Columns")]
+    columns: Vec<DdsqlToolColumn>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DdsqlToolColumn {
+    #[serde(rename = "Name")]
+    name: String,
+    #[serde(rename = "Type")]
+    ty: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReferenceTablesResponse {
+    data: Vec<ReferenceTableRecord>,
+    meta: Option<ReferenceTablesMeta>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReferenceTablesMeta {
+    page: Option<ReferenceTablesPage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReferenceTablesPage {
+    next_offset: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReferenceTableRecord {
+    attributes: ReferenceTableAttributes,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReferenceTableAttributes {
+    description: String,
+    row_count: i64,
+    schema: ReferenceTableSchema,
+    source: String,
+    status: String,
+    table_name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReferenceTableSchema {
+    primary_keys: Vec<String>,
+    fields: Vec<ReferenceTableField>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReferenceTableField {
+    name: String,
+    #[serde(rename = "type")]
+    ty: String,
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+struct DdsqlSchemaTable {
+    name: String,
+    id: String,
+    kind: String,
+    provider: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    row_count: Option<i64>,
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+struct DdsqlSchemaColumn {
+    name: String,
+    #[serde(rename = "type")]
+    ty: String,
+    raw_type: String,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    primary_key: bool,
+}
+
+fn print_plain_text(text: &str) {
+    println!("{text}");
+}
+
+fn filter_tables<'a>(
+    tables: impl IntoIterator<Item = &'a str>,
+    query: Option<&str>,
+) -> Vec<String> {
+    let needle = query.map(str::to_lowercase);
+    let mut items: Vec<String> = tables
+        .into_iter()
+        .filter(|table| {
+            needle
+                .as_ref()
+                .map(|needle| table.to_lowercase().contains(needle))
+                .unwrap_or(true)
+        })
+        .map(str::to_string)
+        .collect();
+    items.sort();
+    items
+}
+
+fn normalize_column_name(name: &str) -> String {
+    name.trim_matches('"').to_string()
+}
+
+fn table_matches_query(name: &str, query: Option<&str>) -> bool {
+    query
+        .map(|query| name.to_lowercase().contains(&query.to_lowercase()))
+        .unwrap_or(true)
+}
+
+fn normalize_ddsql_type(raw_type: &str) -> String {
+    match raw_type.to_ascii_lowercase().as_str() {
+        "string" => "VARCHAR".to_string(),
+        "int32" | "int64" => "BIGINT".to_string(),
+        "bool" | "boolean" => "BOOLEAN".to_string(),
+        "float32" | "float64" | "double" | "decimal" => "DECIMAL".to_string(),
+        "timestamp" => "TIMESTAMP".to_string(),
+        "json" => "JSON".to_string(),
+        "hstore_csv" | "hstore" => "HSTORE".to_string(),
+        other => other.to_ascii_uppercase(),
+    }
+}
+
+fn is_rate_limited(err: &anyhow::Error) -> bool {
+    err.to_string().contains("HTTP 429 Too Many Requests")
+}
+
+fn output_items<T: Serialize>(
+    cfg: &Config,
+    items: &T,
+    count: usize,
+    truncated: bool,
+    next_action: Option<String>,
+) -> Result<()> {
+    let meta = formatter::Metadata {
+        count: Some(count),
+        truncated,
+        command: None,
+        next_action,
+    };
+    formatter::format_and_print(items, &cfg.output_format, cfg.agent_mode, Some(&meta))
+}
+
+fn parse_ddsql_docs(resp: Value) -> Result<DdsqlDocsResponse> {
+    serde_json::from_value(resp).map_err(|e| anyhow!("failed to parse DDSQL docs response: {e}"))
+}
+
+fn parse_table_names(resp: Value) -> Result<Vec<String>> {
+    let parsed: DdsqlTableNamesResponse = serde_json::from_value(resp)
+        .map_err(|e| anyhow!("failed to parse DDSQL table list: {e}"))?;
+    Ok(parsed.tables)
+}
+
+fn parse_public_columns(resp: Value) -> Result<Vec<DdsqlSchemaColumn>> {
+    let parsed: DdsqlTableDataResponse = serde_json::from_value(resp)
+        .map_err(|e| anyhow!("failed to parse DDSQL table data: {e}"))?;
+
+    let table = parsed
+        .tables
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow!("no DDSQL table metadata returned"))?
+        .table;
+
+    let _ = table.table_name;
+    Ok(table
+        .columns
+        .into_iter()
+        .map(|column| DdsqlSchemaColumn {
+            name: normalize_column_name(&column.name),
+            ty: normalize_ddsql_type(&column.ty),
+            raw_type: column.ty,
+            primary_key: false,
+        })
+        .collect())
+}
+
+fn parse_reference_tables(resp: Value) -> Result<(Vec<ReferenceTableRecord>, Option<i64>)> {
+    let parsed: ReferenceTablesResponse = serde_json::from_value(resp)
+        .map_err(|e| anyhow!("failed to parse reference table response: {e}"))?;
+    let next_offset = parsed
+        .meta
+        .and_then(|meta| meta.page)
+        .and_then(|page| page.next_offset);
+
+    Ok((parsed.data, next_offset))
+}
+
+fn build_reference_table_columns(table: ReferenceTableRecord) -> Vec<DdsqlSchemaColumn> {
+    let primary_keys = table.attributes.schema.primary_keys;
+
+    table
+        .attributes
+        .schema
+        .fields
+        .into_iter()
+        .map(|field| {
+            let is_primary = primary_keys.iter().any(|primary| primary == &field.name);
+            DdsqlSchemaColumn {
+                name: field.name,
+                ty: normalize_ddsql_type(&field.ty),
+                raw_type: field.ty,
+                primary_key: is_primary,
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+fn parse_reference_table_columns(resp: Value, table_name: &str) -> Result<Vec<DdsqlSchemaColumn>> {
+    let (tables, _) = parse_reference_tables(resp)?;
+
+    let table = tables
+        .into_iter()
+        .find(|table| table.attributes.table_name == table_name)
+        .ok_or_else(|| anyhow!("reference table `{table_name}` not found"))?;
+
+    Ok(build_reference_table_columns(table))
+}
+
+fn build_reference_table_item(table: ReferenceTableRecord) -> DdsqlSchemaTable {
+    DdsqlSchemaTable {
+        id: format!("reference_tables.{}", table.attributes.table_name),
+        kind: "reference_table".to_string(),
+        provider: "reference_tables".to_string(),
+        name: table.attributes.table_name,
+        description: if table.attributes.description.is_empty() {
+            None
+        } else {
+            Some(table.attributes.description)
+        },
+        source: Some(table.attributes.source),
+        status: Some(table.attributes.status),
+        row_count: Some(table.attributes.row_count),
+    }
+}
+
+fn parse_reference_table_items(resp: Value) -> Result<(Vec<DdsqlSchemaTable>, Option<i64>)> {
+    let (tables, next_offset) = parse_reference_tables(resp)?;
+
+    let mut items: Vec<DdsqlSchemaTable> =
+        tables.into_iter().map(build_reference_table_item).collect();
+    items.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok((items, next_offset))
+}
+
+fn build_public_table_items(table_names: &[String], query: Option<&str>) -> Vec<DdsqlSchemaTable> {
+    filter_tables(table_names.iter().map(|name| name.as_str()), query)
+        .into_iter()
+        .map(|name| DdsqlSchemaTable {
+            provider: name.split('.').next().unwrap_or("unknown").to_string(),
+            id: format!("public.{name}"),
+            kind: "public".to_string(),
+            name,
+            description: None,
+            source: None,
+            status: None,
+            row_count: None,
+        })
+        .collect()
+}
+
+async fn get_ddsql_docs(cfg: &Config) -> Result<DdsqlDocsResponse> {
+    let resp = client::raw_get(cfg, DDSQL_DOCS_PATH, &[]).await?;
+    parse_ddsql_docs(resp)
+}
+
+async fn get_public_table_names(cfg: &Config) -> Result<Vec<String>> {
+    let resp = client::raw_get(cfg, DDSQL_TABLE_NAMES_PATH, &[]).await?;
+    parse_table_names(resp)
+}
+
+async fn search_reference_tables(
+    cfg: &Config,
+    query: Option<&str>,
+    max_results: usize,
+) -> Result<(Vec<DdsqlSchemaTable>, bool)> {
+    let mut results = Vec::new();
+    let mut page_offset = 0_i64;
+    let target = max_results.max(1);
+    let page_limit = target.clamp(25, 100);
+
+    loop {
+        let mut params: Vec<(String, String)> = vec![
+            ("page[limit]".to_string(), page_limit.to_string()),
+            ("page[offset]".to_string(), page_offset.to_string()),
+        ];
+        if let Some(query) = query {
+            params.push(("filter[table_name_contains]".to_string(), query.to_string()));
+        }
+
+        let refs: Vec<(&str, &str)> = params
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
+        let resp = client::raw_get(cfg, REFERENCE_TABLES_PATH, &refs).await?;
+        let (mut items, next_offset) = parse_reference_table_items(resp)?;
+        items.retain(|item| table_matches_query(&item.name, query));
+        results.append(&mut items);
+        if results.len() > target {
+            results.sort_by(|a, b| a.name.cmp(&b.name));
+            return Ok((results, true));
+        }
+
+        match next_offset {
+            Some(next_offset) => page_offset = next_offset,
+            None => break,
+        }
+    }
+
+    results.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok((results, false))
+}
+
+async fn get_reference_table_columns(
+    cfg: &Config,
+    table_name: &str,
+) -> Result<Vec<DdsqlSchemaColumn>> {
+    let mut page_offset = 0_i64;
+
+    loop {
+        let offset_param = page_offset.to_string();
+        let params = [
+            ("page[limit]", "100"),
+            ("page[offset]", offset_param.as_str()),
+            ("filter[table_name_contains]", table_name),
+        ];
+        let resp = client::raw_get(cfg, REFERENCE_TABLES_PATH, &params).await?;
+        let (tables, next_offset) = parse_reference_tables(resp)?;
+
+        if let Some(table) = tables
+            .into_iter()
+            .find(|table| table.attributes.table_name == table_name)
+        {
+            return Ok(build_reference_table_columns(table));
+        }
+
+        match next_offset {
+            Some(next_offset) => page_offset = next_offset,
+            None => break,
+        }
+    }
+
+    Err(anyhow!("reference table `{table_name}` not found"))
+}
+
+fn normalize_table_lookup(table_id: &str) -> (&str, String) {
+    if let Some(name) = table_id.strip_prefix("public.") {
+        ("public", name.to_string())
+    } else if let Some(name) = table_id.strip_prefix("reference_tables.") {
+        ("reference_table", name.to_string())
+    } else {
+        ("public", table_id.to_string())
+    }
+}
+
+pub async fn spec(cfg: &Config) -> Result<()> {
+    let resp = get_ddsql_docs(cfg).await?;
+    match cfg.output_format {
+        OutputFormat::Json | OutputFormat::Yaml => formatter::output(cfg, &resp),
+        _ => {
+            print_plain_text(&resp.docs);
+            Ok(())
+        }
+    }
+}
+
+pub async fn schema_tables(
+    cfg: &Config,
+    query: Option<&str>,
+    limit: usize,
+    offset: usize,
+) -> Result<()> {
+    let public_table_names = get_public_table_names(cfg).await?;
+    let mut items = build_public_table_items(&public_table_names, query);
+    let reference_target = offset.saturating_add(limit).saturating_add(1);
+    let (reference_items, references_truncated, rate_limit_note) =
+        match search_reference_tables(cfg, query, reference_target).await {
+            Ok((items, truncated)) => (items, truncated, None),
+            Err(err) if is_rate_limited(&err) => (
+                Vec::new(),
+                true,
+                Some(
+                    "reference table search hit rate limit; rerun later or use `pup reference-tables list`"
+                        .to_string(),
+                ),
+            ),
+            Err(err) => return Err(err),
+        };
+    items.extend(reference_items);
+    items.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let total = items.len();
+    let paged: Vec<DdsqlSchemaTable> = items.into_iter().skip(offset).take(limit).collect();
+    let truncated = references_truncated || offset.saturating_add(paged.len()) < total;
+    let next_action = rate_limit_note.unwrap_or_else(|| {
+        "use `pup ddsql schema columns --table-id <id>` for column details".to_string()
+    });
+    output_items(cfg, &paged, paged.len(), truncated, Some(next_action))
+}
+
+pub async fn schema_columns(
+    cfg: &Config,
+    table_id: &str,
+    limit: usize,
+    offset: usize,
+) -> Result<()> {
+    let (kind, table_name) = normalize_table_lookup(table_id);
+    let columns = if kind == "reference_table" {
+        get_reference_table_columns(cfg, &table_name).await?
+    } else {
+        let resp = client::raw_post(
+            cfg,
+            DDSQL_TABLE_DATA_PATH,
+            json!({ "tables": [table_name] }),
+        )
+        .await?;
+        parse_public_columns(resp)?
+    };
+
+    let total = columns.len();
+    let paged: Vec<DdsqlSchemaColumn> = columns.into_iter().skip(offset).take(limit).collect();
+    let truncated = offset.saturating_add(paged.len()) < total;
+    output_items(
+        cfg,
+        &paged,
+        paged.len(),
+        truncated,
+        Some("rerun with `--offset <n>` to inspect additional columns".to_string()),
+    )
 }
 
 /// Build a request for the Advanced Query API (tabular/scalar endpoint).
@@ -480,5 +948,199 @@ mod tests {
         assert!(arr[0]["b"].is_null());
         assert!(arr[1]["a"].is_null());
         assert_eq!(arr[1]["b"], "x");
+    }
+
+    #[test]
+    fn test_filter_tables_case_insensitive() {
+        let filtered = filter_tables(
+            ["aws.ec2_instance", "dd.hosts", "reference_tables.ec2info"],
+            Some("EC2"),
+        );
+        assert_eq!(
+            filtered,
+            vec![
+                "aws.ec2_instance".to_string(),
+                "reference_tables.ec2info".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_normalize_ddsql_type() {
+        assert_eq!(normalize_ddsql_type("string"), "VARCHAR");
+        assert_eq!(normalize_ddsql_type("int64"), "BIGINT");
+        assert_eq!(normalize_ddsql_type("bool"), "BOOLEAN");
+        assert_eq!(normalize_ddsql_type("json"), "JSON");
+        assert_eq!(normalize_ddsql_type("hstore_csv"), "HSTORE");
+    }
+
+    #[test]
+    fn test_parse_public_columns() {
+        let resp: Value = serde_json::from_str(
+            r#"{
+                "tables": [{
+                    "Table": {
+                        "TableName": "aws.ec2_instance",
+                        "Columns": [
+                            {"Name":"\"instance_id\"","Type":"string"},
+                            {"Name":"\"launch_time\"","Type":"timestamp"},
+                            {"Name":"\"tags\"","Type":"hstore_csv"}
+                        ]
+                    },
+                    "SampleData": ""
+                }]
+            }"#,
+        )
+        .unwrap();
+
+        let columns = parse_public_columns(resp).unwrap();
+        assert_eq!(
+            columns,
+            vec![
+                DdsqlSchemaColumn {
+                    name: "instance_id".to_string(),
+                    ty: "VARCHAR".to_string(),
+                    raw_type: "string".to_string(),
+                    primary_key: false,
+                },
+                DdsqlSchemaColumn {
+                    name: "launch_time".to_string(),
+                    ty: "TIMESTAMP".to_string(),
+                    raw_type: "timestamp".to_string(),
+                    primary_key: false,
+                },
+                DdsqlSchemaColumn {
+                    name: "tags".to_string(),
+                    ty: "HSTORE".to_string(),
+                    raw_type: "hstore_csv".to_string(),
+                    primary_key: false,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_reference_table_columns() {
+        let resp: Value = serde_json::from_str(
+            r#"{
+                "data": [
+                    {
+                        "attributes": {
+                            "description": "",
+                            "row_count": 1,
+                            "source": "LOCAL_FILE",
+                            "status": "DONE",
+                            "table_name": "other_table",
+                            "schema": {
+                                "primary_keys": ["ignored"],
+                                "fields": [
+                                    {"name":"ignored","type":"STRING"}
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "attributes": {
+                            "description": "",
+                            "row_count": 2,
+                            "source": "LOCAL_FILE",
+                            "status": "DONE",
+                            "table_name": "ec2info",
+                            "schema": {
+                                "primary_keys": ["id"],
+                                "fields": [
+                                    {"name":"id","type":"STRING"},
+                                    {"name":"score","type":"INT32"}
+                                ]
+                            }
+                        }
+                    }
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        let columns = parse_reference_table_columns(resp, "ec2info").unwrap();
+        assert_eq!(
+            columns,
+            vec![
+                DdsqlSchemaColumn {
+                    name: "id".to_string(),
+                    ty: "VARCHAR".to_string(),
+                    raw_type: "STRING".to_string(),
+                    primary_key: true,
+                },
+                DdsqlSchemaColumn {
+                    name: "score".to_string(),
+                    ty: "BIGINT".to_string(),
+                    raw_type: "INT32".to_string(),
+                    primary_key: false,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_reference_table_columns_missing_table() {
+        let resp: Value = serde_json::from_str(
+            r#"{
+                "data": [{
+                    "attributes": {
+                        "description": "",
+                        "row_count": 1,
+                        "source": "LOCAL_FILE",
+                        "status": "DONE",
+                        "table_name": "other_table",
+                        "schema": {
+                            "primary_keys": [],
+                            "fields": []
+                        }
+                    }
+                }]
+            }"#,
+        )
+        .unwrap();
+
+        let err = parse_reference_table_columns(resp, "ec2info").unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("reference table `ec2info` not found"));
+    }
+
+    #[test]
+    fn test_build_public_table_items() {
+        let items = build_public_table_items(
+            &["dd.hosts".to_string(), "aws.ec2_instance".to_string()],
+            Some("ec2"),
+        );
+        assert_eq!(
+            items,
+            vec![DdsqlSchemaTable {
+                name: "aws.ec2_instance".to_string(),
+                id: "public.aws.ec2_instance".to_string(),
+                kind: "public".to_string(),
+                provider: "aws".to_string(),
+                description: None,
+                source: None,
+                status: None,
+                row_count: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn test_normalize_table_lookup() {
+        assert_eq!(
+            normalize_table_lookup("public.aws.ec2_instance"),
+            ("public", "aws.ec2_instance".to_string())
+        );
+        assert_eq!(
+            normalize_table_lookup("reference_tables.ec2info"),
+            ("reference_table", "ec2info".to_string())
+        );
+        assert_eq!(
+            normalize_table_lookup("dd.hosts"),
+            ("public", "dd.hosts".to_string())
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1051,17 +1051,23 @@ enum Commands {
     /// DDSQL lets you query metrics, logs, and reference tables using SQL syntax.
     ///
     /// COMMANDS:
-    ///   table        Execute query and return table data (supports -o json/yaml/table/csv)
-    ///   time-series  Execute query and return time series data
+    ///   table         Execute query and return table data (supports -o json/yaml/table/csv)
+    ///   time-series   Execute query and return time series data
+    ///   spec          Print DDSQL reference guidance used by the editor tooling
+    ///   schema        Discover DDSQL tables and columns
     ///
     /// EXAMPLES:
     ///   pup ddsql table --query "SELECT * FROM reference_tables.offices_ips LIMIT 5"
     ///   pup ddsql table --query "SELECT * FROM reference_tables.offices_ips" -o csv > results.csv
     ///   cat query.sql | pup ddsql table --query - -o table
     ///   pup ddsql time-series --query "SELECT avg(system.cpu.user) FROM metrics GROUP BY host" --from 1h --interval 300000
+    ///   pup ddsql spec
+    ///   pup ddsql schema tables --query ec2 --limit 100
+    ///   pup ddsql schema columns --table-id public.aws.ec2_instance
     ///
     /// AUTHENTICATION:
-    ///   Requires OAuth2 (via 'pup auth login') or API key + Application key.
+    ///   Query commands support OAuth2 (via 'pup auth login') or API key + Application key.
+    ///   Discovery commands (`spec`, `schema ...`) currently require DD_API_KEY + DD_APP_KEY.
     #[command(verbatim_doc_comment)]
     Ddsql {
         #[command(subcommand)]
@@ -3785,6 +3791,46 @@ enum DdsqlActions {
             help = "Maximum number of rows to return"
         )]
         limit: i32,
+    },
+    /// Print DDSQL reference guidance from the editor tooling
+    Spec,
+    /// Discover DDSQL tables and columns
+    Schema {
+        #[command(subcommand)]
+        action: DdsqlSchemaActions,
+    },
+}
+
+#[derive(Subcommand)]
+enum DdsqlSchemaActions {
+    /// List DDSQL tables visible to your org
+    Tables {
+        #[arg(long, help = "Case-insensitive substring filter for table names")]
+        query: Option<String>,
+        #[arg(
+            long,
+            default_value_t = 100,
+            help = "Maximum number of tables to return"
+        )]
+        limit: usize,
+        #[arg(long, default_value_t = 0, help = "Number of tables to skip")]
+        offset: usize,
+    },
+    /// Show columns for a DDSQL table
+    Columns {
+        #[arg(
+            long,
+            help = "Table ID, for example public.aws.ec2_instance or reference_tables.my_table"
+        )]
+        table_id: String,
+        #[arg(
+            long,
+            default_value_t = 100,
+            help = "Maximum number of columns to return"
+        )]
+        limit: usize,
+        #[arg(long, default_value_t = 0, help = "Number of columns to skip")]
+        offset: usize,
     },
 }
 
@@ -11782,6 +11828,26 @@ async fn main_inner() -> anyhow::Result<()> {
                 } => {
                     commands::ddsql::time_series(&cfg, &query, &from, &to, interval, limit).await?;
                 }
+                DdsqlActions::Spec => {
+                    commands::ddsql::spec(&cfg).await?;
+                }
+                DdsqlActions::Schema { action } => match action {
+                    DdsqlSchemaActions::Tables {
+                        query,
+                        limit,
+                        offset,
+                    } => {
+                        commands::ddsql::schema_tables(&cfg, query.as_deref(), limit, offset)
+                            .await?;
+                    }
+                    DdsqlSchemaActions::Columns {
+                        table_id,
+                        limit,
+                        offset,
+                    } => {
+                        commands::ddsql::schema_columns(&cfg, &table_id, limit, offset).await?;
+                    }
+                },
             }
         }
         // --- Investigations ---


### PR DESCRIPTION
## Summary
Add first-cut DDSQL discovery commands to `pup ddsql` so agents can discover tables, columns, and DDSQL guidance directly from the CLI.

## Changes
- add `pup ddsql spec`
- add `pup ddsql schema tables` and `pup ddsql schema columns`
- use API/app-key auth for DDSQL editor tool endpoints that do not accept OAuth bearer tokens
- paginate schema output and default table/column limits to `100`
- degrade `schema tables` gracefully when reference-table search is rate-limited
- keep the newer stdin query support from `main` while rebasing the DDSQL changes

## Testing
- `cargo fmt --check`
- `cargo test ddsql -- --nocapture`
- `cargo test client -- --nocapture`
- `cargo clippy --bin pup -- -D warnings`
- smoke-tested `ddsql spec`, `schema tables`, and `schema columns`
