### PR TITLE
fix(auth): add on_call_read/write OAuth scopes

### DIFF
--- a/src/auth/types.rs
+++ b/src/auth/types.rs
@@ -77,6 +77,7 @@ pub fn read_only_scopes() -> Vec<&'static str> {
         "monitors_read",
         "notebooks_read",
         "oci_configuration_read",
+        "on_call_read",
         "reference_tables_read",
         "rum_apps_read",
         "rum_retention_filters_read",
@@ -173,6 +174,9 @@ pub fn default_scopes() -> Vec<&'static str> {
         "oci_configuration_edit",
         "oci_configuration_read",
         "oci_configurations_manage",
+        // On-Call
+        "on_call_read",
+        "on_call_write",
         // Organizations
         "org_management",
         // Reference Tables
@@ -258,7 +262,7 @@ mod tests {
     #[test]
     fn test_default_scopes() {
         let scopes = default_scopes();
-        assert_eq!(scopes.len(), 79);
+        assert_eq!(scopes.len(), 81);
         assert!(scopes.contains(&"dashboards_read"));
         assert!(scopes.contains(&"monitors_read"));
         assert!(scopes.contains(&"logs_read_data"));
@@ -272,6 +276,8 @@ mod tests {
         assert!(scopes.contains(&"teams_read"));
         assert!(scopes.contains(&"apm_service_catalog_read"));
         assert!(scopes.contains(&"status_pages_settings_read"));
+        assert!(scopes.contains(&"on_call_read"));
+        assert!(scopes.contains(&"on_call_write"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Registers `on_call_read` and `on_call_write` with the DCR client so the `/api/v2/on-call/*` endpoints return 200 after `pup auth login`. Without these scopes, `pup on-call {schedules, escalation-policies, notification-channels, notification-rules, pages}` all 403.

Fixes #387.

## Change

Three inserts in `src/auth/types.rs`:

- `default_scopes()`: add `on_call_read`, `on_call_write` under a new `// On-Call` section.
- `read_only_scopes()`: add `on_call_read` (preserves the existing alphabetical ordering).
- `test_default_scopes`: bump length assertion 79 → 81 and add `contains` spot-checks for the two new scopes.

Follows the precedent of #334 / `dda4825` (cloud_cost_management).

## Test plan

- [x] `cargo test auth::types` — 9/9 pass
- [x] `cargo fmt --check`
- [x] `cargo clippy --no-deps` — clean
- [ ] Reviewer: after merge, `pup auth login` + `pup api v2/on-call/schedules` should return 200