### PR TITLE
Rename OAuth client to datadog-pup-cli

### DIFF
--- a/src/auth/dcr.rs
+++ b/src/auth/dcr.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use super::types::{ClientCredentials, TokenSet};
 
 #[cfg(not(target_arch = "wasm32"))]
-pub const DCR_CLIENT_NAME: &str = "datadog-api-claude-plugin";
+pub const DCR_CLIENT_NAME: &str = "datadog-pup-cli";
 #[cfg(not(target_arch = "wasm32"))]
 pub const DCR_REDIRECT_PORTS: &[u16] = &[8000, 8080, 8888, 9000];
 

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -50,12 +50,17 @@ pub async fn login(cfg: &Config, scopes: Vec<String>, subdomain: Option<&str>) -
     let existing_creds = with_storage(|store| store.load_client_credentials(site))?;
 
     let creds = match existing_creds {
-        Some(creds) => {
+        Some(creds) if creds.client_name == dcr::DCR_CLIENT_NAME => {
             eprintln!("✓ Using existing client registration");
             creds
         }
-        None => {
-            eprintln!("📝 Registering new OAuth2 client...");
+        other => {
+            if other.is_some() {
+                eprintln!("📝 Re-registering OAuth2 client (name changed)...");
+                with_storage(|store| store.delete_client_credentials(site))?;
+            } else {
+                eprintln!("📝 Registering new OAuth2 client...");
+            }
             let dcr_client = dcr::DcrClient::new(site);
             let creds = dcr_client.register(&redirect_uri, &scope_strs).await?;
             with_storage(|store| store.save_client_credentials(site, &creds))?;


### PR DESCRIPTION
## Motivation
When pup was created, we reused the existing `datadog-api-claude-plugin` client. But this is confusing and misleading both on the OAuth consent page and in Datadog Audit Trail, since you can use pup not only with Claude but also interactively as a human, or with Cursor, etc.

## Summary
- Renames the DCR client name from `datadog-api-claude-plugin` to `datadog-pup-cli`, which has been created on the server side with the same settings as the previous client
- On `pup auth login`, if the cached client registration has a stale name, it is automatically deleted and re-registered under the new name
- Existing refresh flows continue working until the user next runs `pup auth login`

## Test plan
- [x] `cargo build`, `cargo fmt`, `cargo clippy` all pass
- [x] Tested locally: `pup auth login` with old cached registration triggers re-registration and consent page shows "datadog-pup-cli"
```
 ~/dd/pup/target/debug/pup auth login

🔐 Starting OAuth2 login for site: datadoghq.com

📡 Callback server started on: http://127.0.0.1:8000/oauth/callback
🔑 Requesting 79 scope(s) (use --scopes to customize)
📝 Re-registering OAuth2 client (name changed)...
✓ Registered client: d8b7b700-02f1-4dc0-9765-b76c75094b1b

🌐 Opening browser for authentication...
...
```

- [x] Tested locally: `pup auth logout` (no cached credentials) followed by `pup auth login` registers with new name
- [x] Tested locally: `pup auth login` for various sites; confirmed that datadog-pup-cli appears in the consent page
```
pup auth login --site datad0g.com
pup auth login --site ap2.datadoghq.com
pup auth login --site ap1.datadoghq.com
pup auth login --site us5.datadoghq.com
pup auth login --site us3.datadoghq.com
pup auth login --site datadoghq.eu
pup auth login
pup auth login --site ddog-gov.com
```

---
Jira: https://datadoghq.atlassian.net/browse/DAL-552
