### PR TITLE
fix(ci): isolate Zig cache per target to avoid EEXIST race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,9 @@ jobs:
           for target in x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu; do
             (set -o pipefail
              echo "==> Starting ${target}"
-             cargo zigbuild --release --target "${target}" --features vendored-openssl 2>&1 \
+             ZIG_GLOBAL_CACHE_DIR=$(mktemp -d) \
+             ZIG_LOCAL_CACHE_DIR=$(mktemp -d) \
+               cargo zigbuild --release --target "${target}" --features vendored-openssl 2>&1 \
                | tee "/tmp/${target}.log"
             ) &
             PIDS+=($!)


### PR DESCRIPTION
## Summary
The Linux cross-compile job (`.github/workflows/ci.yml:93-110`) launches two `cargo zigbuild` invocations in parallel. Both share Zig's global cache (`~/.cache/zig`) and race to initialize it on a cold cache, producing `Error: File exists (os error 17)` — one of the two builds dies during toolchain setup while the other compiles to completion.

Fix: give each parallel invocation its own `ZIG_GLOBAL_CACHE_DIR` and `ZIG_LOCAL_CACHE_DIR` via `mktemp -d` so cache initialization is isolated.

## Evidence from a failing run
Run [24747327833, job 72403332661](https://github.com/datadog-labs/pup/actions/runs/24747327833/job/72403332661):

```
21:37:13.1545568  ==> Starting x86_64-unknown-linux-gnu
21:37:13.1546587  ==> Starting aarch64-unknown-linux-gnu     (~100µs later)
21:37:13.2402403  Error: File exists (os error 17)
21:37:17.4789424  Compiling pup v0.50.2 …                    (other build survives)
21:42:06.1406842  Finished `release` profile                 (that one finishes)
```

The error fires ~85 ms after both subshells start — long before any file is written to `/tmp/<target>.log` and before compilation begins. Only one of the two parallel invocations fails. That asymmetry rules out log-file collision (paths are distinct; `tee` truncates rather than EEXIST-ing) and points squarely at shared Zig cache state.

## Changes
- `.github/workflows/ci.yml:99-100` — prepend `ZIG_GLOBAL_CACHE_DIR=$(mktemp -d)` and `ZIG_LOCAL_CACHE_DIR=$(mktemp -d)` inside each backgrounded subshell.

## Testing
- CI run on this branch will exercise the Linux cross-compile job directly. The race reproduced intermittently on #388; this job's green/red will validate the fix across a few runs.
- No code or test changes; workflow-only.

## Notes
- macOS job uses plain `cargo build` (no Zig) and doesn't exhibit this race, so it's left untouched.
- Per-run temp dirs trade a small amount of first-run Zig cache population work (not persisted across CI runs anyway) for deterministic parallel startup.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)