### PR TITLE
Revert "fix(auth): add on_call_read/write OAuth scopes"

### DIFF
--- a/src/auth/types.rs
+++ b/src/auth/types.rs
@@ -77,7 +77,6 @@ pub fn read_only_scopes() -> Vec<&'static str> {
         "monitors_read",
         "notebooks_read",
         "oci_configuration_read",
-        "on_call_read",
         "reference_tables_read",
         "rum_apps_read",
         "rum_retention_filters_read",
@@ -174,9 +173,6 @@ pub fn default_scopes() -> Vec<&'static str> {
         "oci_configuration_edit",
         "oci_configuration_read",
         "oci_configurations_manage",
-        // On-Call
-        "on_call_read",
-        "on_call_write",
         // Organizations
         "org_management",
         // Reference Tables
@@ -262,7 +258,7 @@ mod tests {
     #[test]
     fn test_default_scopes() {
         let scopes = default_scopes();
-        assert_eq!(scopes.len(), 81);
+        assert_eq!(scopes.len(), 79);
         assert!(scopes.contains(&"dashboards_read"));
         assert!(scopes.contains(&"monitors_read"));
         assert!(scopes.contains(&"logs_read_data"));
@@ -276,8 +272,6 @@ mod tests {
         assert!(scopes.contains(&"teams_read"));
         assert!(scopes.contains(&"apm_service_catalog_read"));
         assert!(scopes.contains(&"status_pages_settings_read"));
-        assert!(scopes.contains(&"on_call_read"));
-        assert!(scopes.contains(&"on_call_write"));
     }
 
     #[test]


### PR DESCRIPTION
Reverts datadog-labs/pup#388

This is not a valid oauth scope fixes #393 