### PR TITLE
fix(notebooks,app-builder): align --help text with actual --file flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -340,10 +340,10 @@ enum Commands {
     ///   pup app-builder get <app-id>
     ///
     ///   # Create an app from file
-    ///   pup app-builder create --body @app.json
+    ///   pup app-builder create --file app.json
     ///
     ///   # Update an app
-    ///   pup app-builder update <app-id> --body @updated.json
+    ///   pup app-builder update <app-id> --file updated.json
     ///
     ///   # Delete an app
     ///   pup app-builder delete <app-id>
@@ -1880,13 +1880,10 @@ enum Commands {
     ///   pup notebooks get notebook-id
     ///
     ///   # Create a notebook from file
-    ///   pup notebooks create --body @notebook.json
-    ///
-    ///   # Create from stdin
-    ///   cat notebook.json | pup notebooks create --body -
+    ///   pup notebooks create --file notebook.json
     ///
     ///   # Update a notebook
-    ///   pup notebooks update 12345 --body @updated.json
+    ///   pup notebooks update 12345 --file updated.json
     ///
     ///   # Delete a notebook
     ///   pup notebooks delete 12345
@@ -5119,11 +5116,7 @@ enum AppBuilderActions {
     },
     /// Create a new App Builder application
     Create {
-        #[arg(
-            long,
-            name = "body",
-            help = "JSON body (@filepath or - for stdin) (required)"
-        )]
+        #[arg(long, help = "JSON file with app data (required)")]
         file: String,
     },
     /// Update an App Builder application
@@ -5131,11 +5124,7 @@ enum AppBuilderActions {
         /// App ID (UUID)
         #[arg(name = "app-id")]
         app_id: String,
-        #[arg(
-            long,
-            name = "body",
-            help = "JSON body (@filepath or - for stdin) (required)"
-        )]
+        #[arg(long, help = "JSON file with app data (required)")]
         file: String,
     },
     /// Delete an App Builder application (DESTRUCTIVE)
@@ -5277,21 +5266,13 @@ enum NotebookActions {
     Get { notebook_id: i64 },
     /// Create a new notebook
     Create {
-        #[arg(
-            long,
-            name = "body",
-            help = "JSON body (@filepath or - for stdin) (required)"
-        )]
+        #[arg(long, help = "JSON file with notebook data (required)")]
         file: String,
     },
     /// Update a notebook
     Update {
         notebook_id: i64,
-        #[arg(
-            long,
-            name = "body",
-            help = "JSON body (@filepath or - for stdin) (required)"
-        )]
+        #[arg(long, help = "JSON file with notebook data (required)")]
         file: String,
     },
     /// Delete a notebook


### PR DESCRIPTION
## Summary

A user reported a help-text discrepancy: `pup notebooks --help` advertised examples like `pup notebooks update 12345 --body @updated.json`, but `pup notebooks update --help` showed the flag was actually `--file` (with a confusing `<body>` metavar). They verified the working invocation was `pup notebooks update --file /tmp/nb-update-payload.json 12345678` — no `@` prefix.

The same parallel bug existed for `pup app-builder create/update`, so the fix covers both.

Root causes (`src/main.rs`):
- `#[arg(long, name = "body", ...)]` on a field named `file` kept the long flag as `--file` (derived from the field name) but set the clap arg id to `"body"`, which became the usage metavar `<body>`. The doc-comment EXAMPLES also spelled the flag `--body`.
- The advertised `@filepath` and `-` stdin syntaxes were never implemented — `util::read_json_file` at `src/util.rs:122` passes the path straight to `std::fs::read_to_string`, so `@foo.json` or `-` would always fail.

## Changes

- `src/main.rs:343,346` and `src/main.rs:1883,1889`: Doc-comment EXAMPLES now invoke `--file <path>` (no `@` prefix). Removed the non-working notebooks stdin example.
- `src/main.rs:5119,5127` (app-builder) and `src/main.rs:5269,5275` (notebooks): Replaced `#[arg(long, name = "body", help = "JSON body (@filepath or - for stdin) (required)")]` with `#[arg(long, help = "JSON file with <domain> data (required)")]`. Clap now renders `--file <FILE>` using the default metavar from the field name, matching the dominant pattern at `src/main.rs:3041` and 15+ similar spots.

## Testing

- [x] `cargo build --release`
- [x] `cargo clippy --release -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --release --bin pup` — 858 passed, 0 failed
- [x] Manually verified `pup notebooks --help`, `pup notebooks update --help`, `pup app-builder --help`, `pup app-builder update --help` now render the correct `--file <FILE>` usage and matching examples.

Before:
```
Usage: pup notebooks update [OPTIONS] --file <body> <NOTEBOOK_ID>
```
After:
```
Usage: pup notebooks update [OPTIONS] --file <FILE> <NOTEBOOK_ID>
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)