### PR TITLE
refactor(client): extract make_api! macro for API client init

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -132,6 +132,18 @@ pub fn make_bearer_client(cfg: &Config) -> Option<ClientWithMiddleware> {
     None
 }
 
+#[macro_export]
+macro_rules! make_api {
+    ($api:ty, $cfg:expr) => {{
+        let cfg = $cfg;
+        let dd_cfg = $crate::client::make_dd_config(cfg);
+        match $crate::client::make_bearer_client(cfg) {
+            Some(c) => <$api>::with_client_and_config(dd_cfg, c),
+            None => <$api>::with_config(dd_cfg),
+        }
+    }};
+}
+
 // ---------------------------------------------------------------------------
 // Unstable operations table — used by make_dd_config
 // ---------------------------------------------------------------------------
@@ -1020,6 +1032,25 @@ mod tests {
         let mut cfg = test_cfg();
         cfg.access_token = Some("test-token".into());
         assert!(make_bearer_client(&cfg).is_some());
+    }
+
+    #[test]
+    fn test_make_api_macro_without_bearer_token() {
+        use datadog_api_client::datadogV1::api_monitors::MonitorsAPI;
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        std::env::remove_var("PUP_MOCK_SERVER");
+        let cfg = test_cfg();
+        let _api: MonitorsAPI = crate::make_api!(MonitorsAPI, &cfg);
+    }
+
+    #[test]
+    fn test_make_api_macro_with_bearer_token() {
+        use datadog_api_client::datadogV1::api_monitors::MonitorsAPI;
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        std::env::remove_var("PUP_MOCK_SERVER");
+        let mut cfg = test_cfg();
+        cfg.access_token = Some("test-token".into());
+        let _api: MonitorsAPI = crate::make_api!(MonitorsAPI, &cfg);
     }
 
     #[test]

--- a/src/commands/agentless_scanning.rs
+++ b/src/commands/agentless_scanning.rs
@@ -1,17 +1,12 @@
 use anyhow::Result;
 use datadog_api_client::datadogV2::api_agentless_scanning::AgentlessScanningAPI;
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
 pub async fn aws_scan_options_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AgentlessScanningAPI::with_client_and_config(dd_cfg, c),
-        None => AgentlessScanningAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AgentlessScanningAPI, cfg);
     let resp = api
         .list_aws_scan_options()
         .await
@@ -20,11 +15,7 @@ pub async fn aws_scan_options_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn aws_scan_options_get(cfg: &Config, account_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AgentlessScanningAPI::with_client_and_config(dd_cfg, c),
-        None => AgentlessScanningAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AgentlessScanningAPI, cfg);
     let resp = api
         .get_aws_scan_options(account_id.to_string())
         .await
@@ -33,11 +24,7 @@ pub async fn aws_scan_options_get(cfg: &Config, account_id: &str) -> Result<()> 
 }
 
 pub async fn aws_scan_options_create(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AgentlessScanningAPI::with_client_and_config(dd_cfg, c),
-        None => AgentlessScanningAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AgentlessScanningAPI, cfg);
     let body = util::read_json_file(file)?;
     let resp = api
         .create_aws_scan_options(body)
@@ -47,11 +34,7 @@ pub async fn aws_scan_options_create(cfg: &Config, file: &str) -> Result<()> {
 }
 
 pub async fn aws_scan_options_update(cfg: &Config, account_id: &str, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AgentlessScanningAPI::with_client_and_config(dd_cfg, c),
-        None => AgentlessScanningAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AgentlessScanningAPI, cfg);
     let body = util::read_json_file(file)?;
     api.update_aws_scan_options(account_id.to_string(), body)
         .await
@@ -61,11 +44,7 @@ pub async fn aws_scan_options_update(cfg: &Config, account_id: &str, file: &str)
 }
 
 pub async fn aws_scan_options_delete(cfg: &Config, account_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AgentlessScanningAPI::with_client_and_config(dd_cfg, c),
-        None => AgentlessScanningAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AgentlessScanningAPI, cfg);
     api.delete_aws_scan_options(account_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete AWS scan options: {e:?}"))?;
@@ -74,11 +53,7 @@ pub async fn aws_scan_options_delete(cfg: &Config, account_id: &str) -> Result<(
 }
 
 pub async fn aws_on_demand_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AgentlessScanningAPI::with_client_and_config(dd_cfg, c),
-        None => AgentlessScanningAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AgentlessScanningAPI, cfg);
     let resp = api
         .list_aws_on_demand_tasks()
         .await
@@ -87,11 +62,7 @@ pub async fn aws_on_demand_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn aws_on_demand_get(cfg: &Config, task_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AgentlessScanningAPI::with_client_and_config(dd_cfg, c),
-        None => AgentlessScanningAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AgentlessScanningAPI, cfg);
     let resp = api
         .get_aws_on_demand_task(task_id.to_string())
         .await
@@ -100,11 +71,7 @@ pub async fn aws_on_demand_get(cfg: &Config, task_id: &str) -> Result<()> {
 }
 
 pub async fn aws_on_demand_create(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AgentlessScanningAPI::with_client_and_config(dd_cfg, c),
-        None => AgentlessScanningAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AgentlessScanningAPI, cfg);
     let body = util::read_json_file(file)?;
     let resp = api
         .create_aws_on_demand_task(body)
@@ -114,11 +81,7 @@ pub async fn aws_on_demand_create(cfg: &Config, file: &str) -> Result<()> {
 }
 
 pub async fn azure_scan_options_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AgentlessScanningAPI::with_client_and_config(dd_cfg, c),
-        None => AgentlessScanningAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AgentlessScanningAPI, cfg);
     let resp = api
         .list_azure_scan_options()
         .await
@@ -127,11 +90,7 @@ pub async fn azure_scan_options_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn azure_scan_options_get(cfg: &Config, subscription_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AgentlessScanningAPI::with_client_and_config(dd_cfg, c),
-        None => AgentlessScanningAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AgentlessScanningAPI, cfg);
     let resp = api
         .get_azure_scan_options(subscription_id.to_string())
         .await
@@ -140,11 +99,7 @@ pub async fn azure_scan_options_get(cfg: &Config, subscription_id: &str) -> Resu
 }
 
 pub async fn azure_scan_options_create(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AgentlessScanningAPI::with_client_and_config(dd_cfg, c),
-        None => AgentlessScanningAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AgentlessScanningAPI, cfg);
     let body = util::read_json_file(file)?;
     let resp = api
         .create_azure_scan_options(body)
@@ -158,11 +113,7 @@ pub async fn azure_scan_options_update(
     subscription_id: &str,
     file: &str,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AgentlessScanningAPI::with_client_and_config(dd_cfg, c),
-        None => AgentlessScanningAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AgentlessScanningAPI, cfg);
     let body = util::read_json_file(file)?;
     let resp = api
         .update_azure_scan_options(subscription_id.to_string(), body)
@@ -172,11 +123,7 @@ pub async fn azure_scan_options_update(
 }
 
 pub async fn azure_scan_options_delete(cfg: &Config, subscription_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AgentlessScanningAPI::with_client_and_config(dd_cfg, c),
-        None => AgentlessScanningAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AgentlessScanningAPI, cfg);
     api.delete_azure_scan_options(subscription_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete Azure scan options: {e:?}"))?;
@@ -185,11 +132,7 @@ pub async fn azure_scan_options_delete(cfg: &Config, subscription_id: &str) -> R
 }
 
 pub async fn gcp_scan_options_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AgentlessScanningAPI::with_client_and_config(dd_cfg, c),
-        None => AgentlessScanningAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AgentlessScanningAPI, cfg);
     let resp = api
         .list_gcp_scan_options()
         .await
@@ -198,11 +141,7 @@ pub async fn gcp_scan_options_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn gcp_scan_options_get(cfg: &Config, project_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AgentlessScanningAPI::with_client_and_config(dd_cfg, c),
-        None => AgentlessScanningAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AgentlessScanningAPI, cfg);
     let resp = api
         .get_gcp_scan_options(project_id.to_string())
         .await
@@ -211,11 +150,7 @@ pub async fn gcp_scan_options_get(cfg: &Config, project_id: &str) -> Result<()> 
 }
 
 pub async fn gcp_scan_options_create(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AgentlessScanningAPI::with_client_and_config(dd_cfg, c),
-        None => AgentlessScanningAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AgentlessScanningAPI, cfg);
     let body = util::read_json_file(file)?;
     let resp = api
         .create_gcp_scan_options(body)
@@ -225,11 +160,7 @@ pub async fn gcp_scan_options_create(cfg: &Config, file: &str) -> Result<()> {
 }
 
 pub async fn gcp_scan_options_update(cfg: &Config, project_id: &str, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AgentlessScanningAPI::with_client_and_config(dd_cfg, c),
-        None => AgentlessScanningAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AgentlessScanningAPI, cfg);
     let body = util::read_json_file(file)?;
     let resp = api
         .update_gcp_scan_options(project_id.to_string(), body)
@@ -239,11 +170,7 @@ pub async fn gcp_scan_options_update(cfg: &Config, project_id: &str, file: &str)
 }
 
 pub async fn gcp_scan_options_delete(cfg: &Config, project_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AgentlessScanningAPI::with_client_and_config(dd_cfg, c),
-        None => AgentlessScanningAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AgentlessScanningAPI, cfg);
     api.delete_gcp_scan_options(project_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete GCP scan options: {e:?}"))?;

--- a/src/commands/api_keys.rs
+++ b/src/commands/api_keys.rs
@@ -3,16 +3,11 @@ use datadog_api_client::datadogV2::api_key_management::{
     GetAPIKeyOptionalParams, KeyManagementAPI, ListAPIKeysOptionalParams,
 };
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 
 pub async fn list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => KeyManagementAPI::with_client_and_config(dd_cfg, c),
-        None => KeyManagementAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(KeyManagementAPI, cfg);
     let resp = api
         .list_api_keys(ListAPIKeysOptionalParams::default())
         .await
@@ -21,11 +16,7 @@ pub async fn list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn get(cfg: &Config, key_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => KeyManagementAPI::with_client_and_config(dd_cfg, c),
-        None => KeyManagementAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(KeyManagementAPI, cfg);
     let resp = api
         .get_api_key(key_id.to_string(), GetAPIKeyOptionalParams::default())
         .await
@@ -41,11 +32,7 @@ pub async fn create(cfg: &Config, name: &str) -> Result<()> {
         APIKeyCreateAttributes::new(name.to_string()),
         APIKeysType::API_KEYS,
     ));
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => KeyManagementAPI::with_client_and_config(dd_cfg, c),
-        None => KeyManagementAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(KeyManagementAPI, cfg);
     let resp = api
         .create_api_key(body)
         .await
@@ -54,11 +41,7 @@ pub async fn create(cfg: &Config, name: &str) -> Result<()> {
 }
 
 pub async fn delete(cfg: &Config, key_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => KeyManagementAPI::with_client_and_config(dd_cfg, c),
-        None => KeyManagementAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(KeyManagementAPI, cfg);
     api.delete_api_key(key_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete API key: {e:?}"))?;

--- a/src/commands/app_builder.rs
+++ b/src/commands/app_builder.rs
@@ -5,17 +5,12 @@ use datadog_api_client::datadogV2::model::{
     UpdateAppRequest,
 };
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
 pub async fn list(cfg: &Config, query: Option<&str>) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AppBuilderAPI::with_client_and_config(dd_cfg, c),
-        None => AppBuilderAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AppBuilderAPI, cfg);
     let mut params = ListAppsOptionalParams::default();
     if let Some(q) = query {
         params = params.filter_query(q.to_string());
@@ -28,11 +23,7 @@ pub async fn list(cfg: &Config, query: Option<&str>) -> Result<()> {
 }
 
 pub async fn get(cfg: &Config, app_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AppBuilderAPI::with_client_and_config(dd_cfg, c),
-        None => AppBuilderAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AppBuilderAPI, cfg);
     let uuid = util::parse_uuid(app_id, "app")?;
     let resp = api
         .get_app(uuid, Default::default())
@@ -42,11 +33,7 @@ pub async fn get(cfg: &Config, app_id: &str) -> Result<()> {
 }
 
 pub async fn create(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AppBuilderAPI::with_client_and_config(dd_cfg, c),
-        None => AppBuilderAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AppBuilderAPI, cfg);
     let body: CreateAppRequest = util::read_json_file(file)?;
     let resp = api
         .create_app(body)
@@ -56,11 +43,7 @@ pub async fn create(cfg: &Config, file: &str) -> Result<()> {
 }
 
 pub async fn update(cfg: &Config, app_id: &str, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AppBuilderAPI::with_client_and_config(dd_cfg, c),
-        None => AppBuilderAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AppBuilderAPI, cfg);
     let uuid = util::parse_uuid(app_id, "app")?;
     let body: UpdateAppRequest = util::read_json_file(file)?;
     let resp = api
@@ -71,11 +54,7 @@ pub async fn update(cfg: &Config, app_id: &str, file: &str) -> Result<()> {
 }
 
 pub async fn delete(cfg: &Config, app_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AppBuilderAPI::with_client_and_config(dd_cfg, c),
-        None => AppBuilderAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AppBuilderAPI, cfg);
     let uuid = util::parse_uuid(app_id, "app")?;
     api.delete_app(uuid)
         .await
@@ -85,11 +64,7 @@ pub async fn delete(cfg: &Config, app_id: &str) -> Result<()> {
 }
 
 pub async fn delete_batch(cfg: &Config, app_ids: &[String]) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AppBuilderAPI::with_client_and_config(dd_cfg, c),
-        None => AppBuilderAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AppBuilderAPI, cfg);
     let items: Result<Vec<_>> = app_ids
         .iter()
         .map(|id| {
@@ -109,11 +84,7 @@ pub async fn delete_batch(cfg: &Config, app_ids: &[String]) -> Result<()> {
 }
 
 pub async fn publish(cfg: &Config, app_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AppBuilderAPI::with_client_and_config(dd_cfg, c),
-        None => AppBuilderAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AppBuilderAPI, cfg);
     let uuid = util::parse_uuid(app_id, "app")?;
     let resp = api
         .publish_app(uuid)
@@ -123,11 +94,7 @@ pub async fn publish(cfg: &Config, app_id: &str) -> Result<()> {
 }
 
 pub async fn unpublish(cfg: &Config, app_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AppBuilderAPI::with_client_and_config(dd_cfg, c),
-        None => AppBuilderAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AppBuilderAPI, cfg);
     let uuid = util::parse_uuid(app_id, "app")?;
     api.unpublish_app(uuid)
         .await

--- a/src/commands/app_keys.rs
+++ b/src/commands/app_keys.rs
@@ -5,7 +5,6 @@ use datadog_api_client::datadogV2::api_key_management::{
 };
 use datadog_api_client::datadogV2::model::ApplicationKeysSort;
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 
@@ -34,11 +33,7 @@ pub async fn list(
     filter: &str,
     sort: &str,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => KeyManagementAPI::with_client_and_config(dd_cfg, c),
-        None => KeyManagementAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(KeyManagementAPI, cfg);
 
     let mut params = ListCurrentUserApplicationKeysOptionalParams::default();
     if page_size > 0 {
@@ -72,11 +67,7 @@ pub async fn list_all(
     filter: &str,
     sort: &str,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => KeyManagementAPI::with_client_and_config(dd_cfg, c),
-        None => KeyManagementAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(KeyManagementAPI, cfg);
 
     let mut params = ListApplicationKeysOptionalParams::default();
     if page_size > 0 {
@@ -104,11 +95,7 @@ pub async fn list_all(
 // ---------------------------------------------------------------------------
 
 pub async fn get(cfg: &Config, key_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => KeyManagementAPI::with_client_and_config(dd_cfg, c),
-        None => KeyManagementAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(KeyManagementAPI, cfg);
     let resp = api
         .get_current_user_application_key(key_id.to_string())
         .await
@@ -141,11 +128,7 @@ pub async fn create(cfg: &Config, name: &str, scopes: &str) -> Result<()> {
         ApplicationKeysType::APPLICATION_KEYS,
     ));
 
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => KeyManagementAPI::with_client_and_config(dd_cfg, c),
-        None => KeyManagementAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(KeyManagementAPI, cfg);
     let resp = api
         .create_current_user_application_key(body)
         .await
@@ -182,11 +165,7 @@ pub async fn update(cfg: &Config, key_id: &str, name: &str, scopes: &str) -> Res
         ApplicationKeysType::APPLICATION_KEYS,
     ));
 
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => KeyManagementAPI::with_client_and_config(dd_cfg, c),
-        None => KeyManagementAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(KeyManagementAPI, cfg);
     let resp = api
         .update_current_user_application_key(key_id.to_string(), body)
         .await
@@ -199,11 +178,7 @@ pub async fn update(cfg: &Config, key_id: &str, name: &str, scopes: &str) -> Res
 // ---------------------------------------------------------------------------
 
 pub async fn delete(cfg: &Config, key_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => KeyManagementAPI::with_client_and_config(dd_cfg, c),
-        None => KeyManagementAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(KeyManagementAPI, cfg);
     api.delete_current_user_application_key(key_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete application key: {e:?}"))?;

--- a/src/commands/audit_logs.rs
+++ b/src/commands/audit_logs.rs
@@ -6,17 +6,12 @@ use datadog_api_client::datadogV2::model::{
     AuditLogsQueryFilter, AuditLogsQueryPageOptions, AuditLogsSearchEventsRequest, AuditLogsSort,
 };
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
 pub async fn list(cfg: &Config, from: String, to: String, limit: i32) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AuditAPI::with_client_and_config(dd_cfg, c),
-        None => AuditAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AuditAPI, cfg);
 
     let from_dt =
         chrono::DateTime::from_timestamp_millis(util::parse_time_to_unix_millis(&from)?).unwrap();
@@ -42,11 +37,7 @@ pub async fn search(
     to: String,
     limit: i32,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AuditAPI::with_client_and_config(dd_cfg, c),
-        None => AuditAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AuditAPI, cfg);
 
     let from_ms = util::parse_time_to_unix_millis(&from)?;
     let to_ms = util::parse_time_to_unix_millis(&to)?;

--- a/src/commands/cases.rs
+++ b/src/commands/cases.rs
@@ -22,11 +22,7 @@ use crate::formatter;
 // ---------------------------------------------------------------------------
 
 fn make_api(cfg: &Config) -> CaseManagementAPI {
-    let dd_cfg = client::make_dd_config(cfg);
-    match client::make_bearer_client(cfg) {
-        Some(c) => CaseManagementAPI::with_client_and_config(dd_cfg, c),
-        None => CaseManagementAPI::with_config(dd_cfg),
-    }
+    crate::make_api!(CaseManagementAPI, cfg)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/commands/change_management.rs
+++ b/src/commands/change_management.rs
@@ -5,17 +5,12 @@ use datadog_api_client::datadogV2::model::{
     ChangeRequestDecisionUpdateRequest, ChangeRequestUpdateRequest,
 };
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
 fn make_api(cfg: &Config) -> ChangeManagementAPI {
-    let dd_cfg = client::make_dd_config(cfg);
-    match client::make_bearer_client(cfg) {
-        Some(c) => ChangeManagementAPI::with_client_and_config(dd_cfg, c),
-        None => ChangeManagementAPI::with_config(dd_cfg),
-    }
+    crate::make_api!(ChangeManagementAPI, cfg)
 }
 
 pub async fn create(cfg: &Config, file: &str) -> Result<()> {

--- a/src/commands/cicd.rs
+++ b/src/commands/cicd.rs
@@ -15,7 +15,6 @@ use datadog_api_client::datadogV2::model::{
     FlakyTestsSearchRequest, UpdateFlakyTestsRequest,
 };
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
@@ -27,11 +26,7 @@ pub async fn pipelines_list(
     to: String,
     limit: i32,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => CIVisibilityPipelinesAPI::with_client_and_config(dd_cfg, c),
-        None => CIVisibilityPipelinesAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(CIVisibilityPipelinesAPI, cfg);
 
     let from_ms = util::parse_time_to_unix_millis(&from)?;
     let to_ms = util::parse_time_to_unix_millis(&to)?;
@@ -67,11 +62,7 @@ pub async fn tests_list(
     to: String,
     limit: i32,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => CIVisibilityTestsAPI::with_client_and_config(dd_cfg, c),
-        None => CIVisibilityTestsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(CIVisibilityTestsAPI, cfg);
 
     let from_dt =
         chrono::DateTime::from_timestamp_millis(util::parse_time_to_unix_millis(&from)?).unwrap();
@@ -100,11 +91,7 @@ pub async fn events_search(
     to: String,
     limit: i32,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => CIVisibilityPipelinesAPI::with_client_and_config(dd_cfg, c),
-        None => CIVisibilityPipelinesAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(CIVisibilityPipelinesAPI, cfg);
 
     let from_ms = util::parse_time_to_unix_millis(&from)?;
     let to_ms = util::parse_time_to_unix_millis(&to)?;
@@ -134,11 +121,7 @@ pub async fn events_search(
 }
 
 pub async fn events_aggregate(cfg: &Config, query: String, from: String, to: String) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => CIVisibilityPipelinesAPI::with_client_and_config(dd_cfg, c),
-        None => CIVisibilityPipelinesAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(CIVisibilityPipelinesAPI, cfg);
 
     let from_ms = util::parse_time_to_unix_millis(&from)?;
     let to_ms = util::parse_time_to_unix_millis(&to)?;
@@ -171,11 +154,7 @@ pub async fn tests_search(
     to: String,
     limit: i32,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => CIVisibilityTestsAPI::with_client_and_config(dd_cfg, c),
-        None => CIVisibilityTestsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(CIVisibilityTestsAPI, cfg);
 
     let from_ms = util::parse_time_to_unix_millis(&from)?;
     let to_ms = util::parse_time_to_unix_millis(&to)?;
@@ -205,11 +184,7 @@ pub async fn tests_search(
 }
 
 pub async fn tests_aggregate(cfg: &Config, query: String, from: String, to: String) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => CIVisibilityTestsAPI::with_client_and_config(dd_cfg, c),
-        None => CIVisibilityTestsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(CIVisibilityTestsAPI, cfg);
 
     let from_ms = util::parse_time_to_unix_millis(&from)?;
     let to_ms = util::parse_time_to_unix_millis(&to)?;
@@ -238,11 +213,7 @@ pub async fn tests_aggregate(cfg: &Config, query: String, from: String, to: Stri
 // ---- Pipelines Get ----
 
 pub async fn pipelines_get(cfg: &Config, pipeline_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => CIVisibilityPipelinesAPI::with_client_and_config(dd_cfg, c),
-        None => CIVisibilityPipelinesAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(CIVisibilityPipelinesAPI, cfg);
 
     let filter = CIAppPipelinesQueryFilter::new().query(pipeline_id.to_string());
 
@@ -259,11 +230,7 @@ pub async fn pipelines_get(cfg: &Config, pipeline_id: &str) -> Result<()> {
 // ---- DORA Metrics ----
 
 pub async fn dora_patch_deployment(cfg: &Config, deployment_id: &str, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => DORAMetricsAPI::with_client_and_config(dd_cfg, c),
-        None => DORAMetricsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(DORAMetricsAPI, cfg);
     let body: DORADeploymentPatchRequest = crate::util::read_json_file(file)?;
     api.patch_dora_deployment(deployment_id.to_string(), body)
         .await
@@ -281,11 +248,7 @@ pub async fn flaky_tests_search(
     limit: i64,
     sort: Option<String>,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => TestOptimizationAPI::with_client_and_config(dd_cfg, c),
-        None => TestOptimizationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(TestOptimizationAPI, cfg);
 
     use datadog_api_client::datadogV2::model::{
         FlakyTestsSearchFilter, FlakyTestsSearchPageOptions, FlakyTestsSearchRequestAttributes,
@@ -333,11 +296,7 @@ pub async fn flaky_tests_search(
 }
 
 pub async fn flaky_tests_update(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => TestOptimizationAPI::with_client_and_config(dd_cfg, c),
-        None => TestOptimizationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(TestOptimizationAPI, cfg);
     let body: UpdateFlakyTestsRequest = crate::util::read_json_file(file)?;
     let resp = api
         .update_flaky_tests(body)

--- a/src/commands/cloud.rs
+++ b/src/commands/cloud.rs
@@ -9,16 +9,11 @@ use datadog_api_client::datadogV2::model::{
     CreateTenancyConfigRequest, UpdateTenancyConfigRequest,
 };
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 
 pub async fn aws_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AWSIntegrationAPI::with_client_and_config(dd_cfg, c),
-        None => AWSIntegrationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AWSIntegrationAPI, cfg);
     let resp = api
         .list_aws_accounts(ListAWSAccountsOptionalParams::default())
         .await
@@ -27,11 +22,7 @@ pub async fn aws_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn gcp_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => GCPIntegrationAPI::with_client_and_config(dd_cfg, c),
-        None => GCPIntegrationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(GCPIntegrationAPI, cfg);
     let resp = api
         .list_gcp_integration()
         .await
@@ -40,11 +31,7 @@ pub async fn gcp_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn azure_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AzureIntegrationAPI::with_client_and_config(dd_cfg, c),
-        None => AzureIntegrationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AzureIntegrationAPI, cfg);
     let resp = api
         .list_azure_integration()
         .await
@@ -57,11 +44,7 @@ pub async fn azure_list(cfg: &Config) -> Result<()> {
 // ---------------------------------------------------------------------------
 
 fn make_oci_api(cfg: &Config) -> OCIIntegrationAPI {
-    let dd_cfg = client::make_dd_config(cfg);
-    match client::make_bearer_client(cfg) {
-        Some(c) => OCIIntegrationAPI::with_client_and_config(dd_cfg, c),
-        None => OCIIntegrationAPI::with_config(dd_cfg),
-    }
+    crate::make_api!(OCIIntegrationAPI, cfg)
 }
 
 pub async fn oci_tenancies_list(cfg: &Config) -> Result<()> {

--- a/src/commands/cloud_auth.rs
+++ b/src/commands/cloud_auth.rs
@@ -2,17 +2,12 @@ use anyhow::Result;
 use datadog_api_client::datadogV2::api_cloud_authentication::CloudAuthenticationAPI;
 use datadog_api_client::datadogV2::model::AWSCloudAuthPersonaMappingCreateRequest;
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
 fn make_api(cfg: &Config) -> CloudAuthenticationAPI {
-    let dd_cfg = client::make_dd_config(cfg);
-    match client::make_bearer_client(cfg) {
-        Some(c) => CloudAuthenticationAPI::with_client_and_config(dd_cfg, c),
-        None => CloudAuthenticationAPI::with_config(dd_cfg),
-    }
+    crate::make_api!(CloudAuthenticationAPI, cfg)
 }
 
 pub async fn persona_mappings_list(cfg: &Config) -> Result<()> {

--- a/src/commands/code_coverage.rs
+++ b/src/commands/code_coverage.rs
@@ -7,16 +7,11 @@ use datadog_api_client::datadogV2::model::{
     CommitCoverageSummaryRequestData, CommitCoverageSummaryRequestType,
 };
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 
 pub async fn branch_summary(cfg: &Config, repo: String, branch: String) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => CodeCoverageAPI::with_client_and_config(dd_cfg, c),
-        None => CodeCoverageAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(CodeCoverageAPI, cfg);
     let body = BranchCoverageSummaryRequest::new(BranchCoverageSummaryRequestData::new(
         BranchCoverageSummaryRequestAttributes::new(branch, repo),
         BranchCoverageSummaryRequestType::CI_APP_COVERAGE_BRANCH_SUMMARY_REQUEST,
@@ -29,11 +24,7 @@ pub async fn branch_summary(cfg: &Config, repo: String, branch: String) -> Resul
 }
 
 pub async fn commit_summary(cfg: &Config, repo: String, commit: String) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => CodeCoverageAPI::with_client_and_config(dd_cfg, c),
-        None => CodeCoverageAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(CodeCoverageAPI, cfg);
     let body = CommitCoverageSummaryRequest::new(CommitCoverageSummaryRequestData::new(
         CommitCoverageSummaryRequestAttributes::new(commit, repo),
         CommitCoverageSummaryRequestType::CI_APP_COVERAGE_COMMIT_SUMMARY_REQUEST,

--- a/src/commands/containers.rs
+++ b/src/commands/containers.rs
@@ -4,7 +4,6 @@ use datadog_api_client::datadogV2::api_container_images::{
 };
 use datadog_api_client::datadogV2::api_containers::{ContainersAPI, ListContainersOptionalParams};
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 
@@ -15,11 +14,7 @@ pub async fn list(
     sort: Option<String>,
     page_size: Option<i32>,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ContainersAPI::with_client_and_config(dd_cfg, c),
-        None => ContainersAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(ContainersAPI, cfg);
     let mut params = ListContainersOptionalParams::default();
     if let Some(v) = filter_tags {
         params = params.filter_tags(v);
@@ -47,11 +42,7 @@ pub async fn images_list(
     sort: Option<String>,
     page_size: Option<i32>,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ContainerImagesAPI::with_client_and_config(dd_cfg, c),
-        None => ContainerImagesAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(ContainerImagesAPI, cfg);
     let mut params = ListContainerImagesOptionalParams::default();
     if let Some(v) = filter_tags {
         params = params.filter_tags(v);

--- a/src/commands/cost.rs
+++ b/src/commands/cost.rs
@@ -5,17 +5,12 @@ use datadog_api_client::datadogV2::api_usage_metering::{
     GetProjectedCostOptionalParams, UsageMeteringAPI as UsageMeteringV2API,
 };
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
 fn make_usage_api(cfg: &Config) -> UsageMeteringV2API {
-    let dd_cfg = client::make_dd_config(cfg);
-    match client::make_bearer_client(cfg) {
-        Some(c) => UsageMeteringV2API::with_client_and_config(dd_cfg, c),
-        None => UsageMeteringV2API::with_config(dd_cfg),
-    }
+    crate::make_api!(UsageMeteringV2API, cfg)
 }
 
 pub async fn projected(cfg: &Config) -> Result<()> {
@@ -67,11 +62,7 @@ pub async fn attribution(cfg: &Config, start: String, fields: Option<String>) ->
 // ---- Cloud Cost Management — AWS CUR Config ----
 
 fn make_ccm_api(cfg: &Config) -> CloudCostManagementAPI {
-    let dd_cfg = client::make_dd_config(cfg);
-    match client::make_bearer_client(cfg) {
-        Some(c) => CloudCostManagementAPI::with_client_and_config(dd_cfg, c),
-        None => CloudCostManagementAPI::with_config(dd_cfg),
-    }
+    crate::make_api!(CloudCostManagementAPI, cfg)
 }
 
 pub async fn aws_config_list(cfg: &Config) -> Result<()> {

--- a/src/commands/csm_threats.rs
+++ b/src/commands/csm_threats.rs
@@ -11,17 +11,12 @@ use datadog_api_client::datadogV2::model::{
     SecurityMonitoringRuleValidatePayload,
 };
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
 fn make_csm_api(cfg: &Config) -> CSMThreatsAPI {
-    let dd_cfg = client::make_dd_config(cfg);
-    match client::make_bearer_client(cfg) {
-        Some(c) => CSMThreatsAPI::with_client_and_config(dd_cfg, c),
-        None => CSMThreatsAPI::with_config(dd_cfg),
-    }
+    crate::make_api!(CSMThreatsAPI, cfg)
 }
 
 pub async fn agent_policies_list(cfg: &Config) -> Result<()> {
@@ -157,11 +152,7 @@ pub async fn policy_download(cfg: &Config) -> Result<()> {
 // ---- Backend Rules (Workload Security detection rules) ----
 
 fn make_sec_api(cfg: &Config) -> SecurityMonitoringAPI {
-    let dd_cfg = client::make_dd_config(cfg);
-    match client::make_bearer_client(cfg) {
-        Some(c) => SecurityMonitoringAPI::with_client_and_config(dd_cfg, c),
-        None => SecurityMonitoringAPI::with_config(dd_cfg),
-    }
+    crate::make_api!(SecurityMonitoringAPI, cfg)
 }
 
 pub async fn backend_rules_list(cfg: &Config, query: Option<String>) -> Result<()> {

--- a/src/commands/dashboards.rs
+++ b/src/commands/dashboards.rs
@@ -2,17 +2,12 @@ use anyhow::Result;
 use datadog_api_client::datadogV1::api_dashboards::{DashboardsAPI, ListDashboardsOptionalParams};
 use datadog_api_client::datadogV1::model::Dashboard;
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
 pub async fn list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => DashboardsAPI::with_client_and_config(dd_cfg, c),
-        None => DashboardsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(DashboardsAPI, cfg);
     let resp = api
         .list_dashboards(ListDashboardsOptionalParams::default())
         .await
@@ -21,11 +16,7 @@ pub async fn list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn get(cfg: &Config, id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => DashboardsAPI::with_client_and_config(dd_cfg, c),
-        None => DashboardsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(DashboardsAPI, cfg);
     let resp = api
         .get_dashboard(id.to_string())
         .await
@@ -35,11 +26,7 @@ pub async fn get(cfg: &Config, id: &str) -> Result<()> {
 
 pub async fn create(cfg: &Config, file: &str) -> Result<()> {
     let body: Dashboard = util::read_json_file(file)?;
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => DashboardsAPI::with_client_and_config(dd_cfg, c),
-        None => DashboardsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(DashboardsAPI, cfg);
     let resp = api
         .create_dashboard(body)
         .await
@@ -49,11 +36,7 @@ pub async fn create(cfg: &Config, file: &str) -> Result<()> {
 
 pub async fn update(cfg: &Config, id: &str, file: &str) -> Result<()> {
     let body: Dashboard = util::read_json_file(file)?;
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => DashboardsAPI::with_client_and_config(dd_cfg, c),
-        None => DashboardsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(DashboardsAPI, cfg);
     let resp = api
         .update_dashboard(id.to_string(), body)
         .await
@@ -62,11 +45,7 @@ pub async fn update(cfg: &Config, id: &str, file: &str) -> Result<()> {
 }
 
 pub async fn delete(cfg: &Config, id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => DashboardsAPI::with_client_and_config(dd_cfg, c),
-        None => DashboardsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(DashboardsAPI, cfg);
     let resp = api
         .delete_dashboard(id.to_string())
         .await

--- a/src/commands/data_governance.rs
+++ b/src/commands/data_governance.rs
@@ -1,16 +1,11 @@
 use anyhow::Result;
 use datadog_api_client::datadogV2::api_sensitive_data_scanner::SensitiveDataScannerAPI;
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 
 pub async fn scanner_rules_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SensitiveDataScannerAPI::with_client_and_config(dd_cfg, c),
-        None => SensitiveDataScannerAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SensitiveDataScannerAPI, cfg);
     let resp = api
         .list_scanning_groups()
         .await

--- a/src/commands/debugger.rs
+++ b/src/commands/debugger.rs
@@ -471,11 +471,7 @@ pub async fn probes_watch(
     };
 
     // Set up logs API
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => LogsAPI::with_client_and_config(dd_cfg, c),
-        None => LogsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(LogsAPI, cfg);
 
     let query = format!("@debugger.snapshot.probe.id:{id}");
     let mut from_ms = from_ms_init;

--- a/src/commands/deployment_gates.rs
+++ b/src/commands/deployment_gates.rs
@@ -4,7 +4,6 @@ use datadog_api_client::datadogV2::api_deployment_gates::{
     DeploymentGatesAPI, ListDeploymentGatesOptionalParams,
 };
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
@@ -14,11 +13,7 @@ use crate::util;
 // ---------------------------------------------------------------------------
 
 fn make_api(cfg: &Config) -> DeploymentGatesAPI {
-    let dd_cfg = client::make_dd_config(cfg);
-    match client::make_bearer_client(cfg) {
-        Some(c) => DeploymentGatesAPI::with_client_and_config(dd_cfg, c),
-        None => DeploymentGatesAPI::with_config(dd_cfg),
-    }
+    crate::make_api!(DeploymentGatesAPI, cfg)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/commands/downtime.rs
+++ b/src/commands/downtime.rs
@@ -3,16 +3,11 @@ use datadog_api_client::datadogV2::api_downtimes::{
     DowntimesAPI, GetDowntimeOptionalParams, ListDowntimesOptionalParams,
 };
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 
 pub async fn list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => DowntimesAPI::with_client_and_config(dd_cfg, c),
-        None => DowntimesAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(DowntimesAPI, cfg);
     let resp = api
         .list_downtimes(ListDowntimesOptionalParams::default())
         .await
@@ -21,11 +16,7 @@ pub async fn list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn get(cfg: &Config, id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => DowntimesAPI::with_client_and_config(dd_cfg, c),
-        None => DowntimesAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(DowntimesAPI, cfg);
     let resp = api
         .get_downtime(id.to_string(), GetDowntimeOptionalParams::default())
         .await
@@ -36,11 +27,7 @@ pub async fn get(cfg: &Config, id: &str) -> Result<()> {
 pub async fn create(cfg: &Config, file: &str) -> Result<()> {
     let body: datadog_api_client::datadogV2::model::DowntimeCreateRequest =
         crate::util::read_json_file(file)?;
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => DowntimesAPI::with_client_and_config(dd_cfg, c),
-        None => DowntimesAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(DowntimesAPI, cfg);
     let resp = api
         .create_downtime(body)
         .await
@@ -49,11 +36,7 @@ pub async fn create(cfg: &Config, file: &str) -> Result<()> {
 }
 
 pub async fn cancel(cfg: &Config, id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => DowntimesAPI::with_client_and_config(dd_cfg, c),
-        None => DowntimesAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(DowntimesAPI, cfg);
     api.cancel_downtime(id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to cancel downtime: {e:?}"))?;

--- a/src/commands/error_tracking.rs
+++ b/src/commands/error_tracking.rs
@@ -9,7 +9,6 @@ use datadog_api_client::datadogV2::model::{
     IssuesSearchRequestDataType,
 };
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 
@@ -20,11 +19,7 @@ pub async fn issues_search(
     track: Option<String>,
     persona: Option<String>,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ErrorTrackingAPI::with_client_and_config(dd_cfg, c),
-        None => ErrorTrackingAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(ErrorTrackingAPI, cfg);
 
     let now = Utc::now().timestamp_millis();
     let one_day_ago = now - 86_400_000; // 24 hours in millis
@@ -75,11 +70,7 @@ pub async fn issues_search(
 }
 
 pub async fn issues_get(cfg: &Config, issue_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ErrorTrackingAPI::with_client_and_config(dd_cfg, c),
-        None => ErrorTrackingAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(ErrorTrackingAPI, cfg);
     let resp = api
         .get_issue(issue_id.to_string(), GetIssueOptionalParams::default())
         .await

--- a/src/commands/events.rs
+++ b/src/commands/events.rs
@@ -9,17 +9,12 @@ use datadog_api_client::datadogV2::model::{
     EventsListRequest, EventsQueryFilter, EventsRequestPage, EventsSort,
 };
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
 pub async fn list(cfg: &Config, start: i64, end: i64, tags: Option<String>) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => EventsV1API::with_client_and_config(dd_cfg, c),
-        None => EventsV1API::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(EventsV1API, cfg);
 
     // Default to last hour if not specified
     let now = chrono::Utc::now().timestamp();
@@ -44,11 +39,7 @@ pub async fn search(
     to: String,
     limit: i32,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => EventsV2API::with_client_and_config(dd_cfg, c),
-        None => EventsV2API::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(EventsV2API, cfg);
 
     let from_ms = util::parse_time_to_unix_millis(&from)?;
     let to_ms = util::parse_time_to_unix_millis(&to)?;
@@ -79,11 +70,7 @@ pub async fn search(
 }
 
 pub async fn get(cfg: &Config, id: i64) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => EventsV1API::with_client_and_config(dd_cfg, c),
-        None => EventsV1API::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(EventsV1API, cfg);
     let resp = api
         .get_event(id)
         .await

--- a/src/commands/feature_flags.rs
+++ b/src/commands/feature_flags.rs
@@ -3,7 +3,6 @@ use datadog_api_client::datadogV2::api_feature_flags::{
     FeatureFlagsAPI, ListFeatureFlagsEnvironmentsOptionalParams, ListFeatureFlagsOptionalParams,
 };
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
@@ -13,11 +12,7 @@ use crate::util;
 // ---------------------------------------------------------------------------
 
 fn make_api(cfg: &Config) -> FeatureFlagsAPI {
-    let dd_cfg = client::make_dd_config(cfg);
-    match client::make_bearer_client(cfg) {
-        Some(c) => FeatureFlagsAPI::with_client_and_config(dd_cfg, c),
-        None => FeatureFlagsAPI::with_config(dd_cfg),
-    }
+    crate::make_api!(FeatureFlagsAPI, cfg)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/commands/fleet.rs
+++ b/src/commands/fleet.rs
@@ -5,7 +5,6 @@ use datadog_api_client::datadogV2::api_fleet_automation::{
     ListFleetDeploymentsOptionalParams, ListFleetTracersOptionalParams,
 };
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
@@ -15,11 +14,7 @@ pub async fn agents_list(
     page_size: Option<i64>,
     filter: Option<String>,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => FleetAutomationAPI::with_client_and_config(dd_cfg, c),
-        None => FleetAutomationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(FleetAutomationAPI, cfg);
     let mut params = ListFleetAgentsOptionalParams::default();
     if let Some(ps) = page_size {
         params = params.page_size(ps);
@@ -35,11 +30,7 @@ pub async fn agents_list(
 }
 
 pub async fn agents_get(cfg: &Config, agent_key: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => FleetAutomationAPI::with_client_and_config(dd_cfg, c),
-        None => FleetAutomationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(FleetAutomationAPI, cfg);
     let resp = api
         .get_fleet_agent_info(agent_key.to_string())
         .await
@@ -48,11 +39,7 @@ pub async fn agents_get(cfg: &Config, agent_key: &str) -> Result<()> {
 }
 
 pub async fn agents_versions(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => FleetAutomationAPI::with_client_and_config(dd_cfg, c),
-        None => FleetAutomationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(FleetAutomationAPI, cfg);
     let resp = api
         .list_fleet_agent_versions()
         .await
@@ -61,11 +48,7 @@ pub async fn agents_versions(cfg: &Config) -> Result<()> {
 }
 
 pub async fn deployments_list(cfg: &Config, page_size: Option<i64>) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => FleetAutomationAPI::with_client_and_config(dd_cfg, c),
-        None => FleetAutomationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(FleetAutomationAPI, cfg);
     let mut params = ListFleetDeploymentsOptionalParams::default();
     if let Some(ps) = page_size {
         params = params.page_size(ps);
@@ -78,11 +61,7 @@ pub async fn deployments_list(cfg: &Config, page_size: Option<i64>) -> Result<()
 }
 
 pub async fn deployments_get(cfg: &Config, deployment_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => FleetAutomationAPI::with_client_and_config(dd_cfg, c),
-        None => FleetAutomationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(FleetAutomationAPI, cfg);
     let resp = api
         .get_fleet_deployment(
             deployment_id.to_string(),
@@ -94,11 +73,7 @@ pub async fn deployments_get(cfg: &Config, deployment_id: &str) -> Result<()> {
 }
 
 pub async fn schedules_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => FleetAutomationAPI::with_client_and_config(dd_cfg, c),
-        None => FleetAutomationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(FleetAutomationAPI, cfg);
     let resp = api
         .list_fleet_schedules()
         .await
@@ -107,11 +82,7 @@ pub async fn schedules_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn schedules_get(cfg: &Config, schedule_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => FleetAutomationAPI::with_client_and_config(dd_cfg, c),
-        None => FleetAutomationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(FleetAutomationAPI, cfg);
     let resp = api
         .get_fleet_schedule(schedule_id.to_string())
         .await
@@ -120,11 +91,7 @@ pub async fn schedules_get(cfg: &Config, schedule_id: &str) -> Result<()> {
 }
 
 pub async fn schedules_update(cfg: &Config, schedule_id: &str, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => FleetAutomationAPI::with_client_and_config(dd_cfg, c),
-        None => FleetAutomationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(FleetAutomationAPI, cfg);
     let body = util::read_json_file(file)?;
     let resp = api
         .update_fleet_schedule(schedule_id.to_string(), body)
@@ -134,11 +101,7 @@ pub async fn schedules_update(cfg: &Config, schedule_id: &str, file: &str) -> Re
 }
 
 pub async fn schedules_delete(cfg: &Config, schedule_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => FleetAutomationAPI::with_client_and_config(dd_cfg, c),
-        None => FleetAutomationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(FleetAutomationAPI, cfg);
     api.delete_fleet_schedule(schedule_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete schedule: {e:?}"))?;
@@ -147,11 +110,7 @@ pub async fn schedules_delete(cfg: &Config, schedule_id: &str) -> Result<()> {
 }
 
 pub async fn deployments_cancel(cfg: &Config, deployment_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => FleetAutomationAPI::with_client_and_config(dd_cfg, c),
-        None => FleetAutomationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(FleetAutomationAPI, cfg);
     api.cancel_fleet_deployment(deployment_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to cancel deployment: {e:?}"))?;
@@ -160,11 +119,7 @@ pub async fn deployments_cancel(cfg: &Config, deployment_id: &str) -> Result<()>
 }
 
 pub async fn deployments_configure(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => FleetAutomationAPI::with_client_and_config(dd_cfg, c),
-        None => FleetAutomationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(FleetAutomationAPI, cfg);
     let body = util::read_json_file(file)?;
     let resp = api
         .create_fleet_deployment_configure(body)
@@ -174,11 +129,7 @@ pub async fn deployments_configure(cfg: &Config, file: &str) -> Result<()> {
 }
 
 pub async fn deployments_upgrade(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => FleetAutomationAPI::with_client_and_config(dd_cfg, c),
-        None => FleetAutomationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(FleetAutomationAPI, cfg);
     let body = util::read_json_file(file)?;
     let resp = api
         .create_fleet_deployment_upgrade(body)
@@ -188,11 +139,7 @@ pub async fn deployments_upgrade(cfg: &Config, file: &str) -> Result<()> {
 }
 
 pub async fn schedules_create(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => FleetAutomationAPI::with_client_and_config(dd_cfg, c),
-        None => FleetAutomationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(FleetAutomationAPI, cfg);
     let body = util::read_json_file(file)?;
     let resp = api
         .create_fleet_schedule(body)
@@ -202,11 +149,7 @@ pub async fn schedules_create(cfg: &Config, file: &str) -> Result<()> {
 }
 
 pub async fn schedules_trigger(cfg: &Config, schedule_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => FleetAutomationAPI::with_client_and_config(dd_cfg, c),
-        None => FleetAutomationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(FleetAutomationAPI, cfg);
     api.trigger_fleet_schedule(schedule_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to trigger schedule: {e:?}"))?;
@@ -222,11 +165,7 @@ pub async fn tracers_list(
     sort_attribute: Option<String>,
     sort_descending: bool,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => FleetAutomationAPI::with_client_and_config(dd_cfg, c),
-        None => FleetAutomationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(FleetAutomationAPI, cfg);
     let mut params = ListFleetTracersOptionalParams::default();
     if let Some(f) = filter {
         params = params.filter(f);
@@ -258,11 +197,7 @@ pub async fn agents_tracers_list(
     sort_attribute: Option<String>,
     sort_descending: bool,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => FleetAutomationAPI::with_client_and_config(dd_cfg, c),
-        None => FleetAutomationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(FleetAutomationAPI, cfg);
     let mut params = ListFleetAgentTracersOptionalParams::default();
     if let Some(ps) = page_size {
         params = params.page_size(ps);
@@ -291,11 +226,7 @@ pub async fn clusters_list(
     sort_attribute: Option<String>,
     sort_descending: bool,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => FleetAutomationAPI::with_client_and_config(dd_cfg, c),
-        None => FleetAutomationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(FleetAutomationAPI, cfg);
     let mut params = ListFleetClustersOptionalParams::default();
     if let Some(f) = filter {
         params = params.filter(f);
@@ -320,11 +251,7 @@ pub async fn clusters_list(
 }
 
 pub async fn instrumented_pods_list(cfg: &Config, cluster_name: String) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => FleetAutomationAPI::with_client_and_config(dd_cfg, c),
-        None => FleetAutomationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(FleetAutomationAPI, cfg);
     let resp = api
         .list_fleet_instrumented_pods(cluster_name)
         .await

--- a/src/commands/google_chat.rs
+++ b/src/commands/google_chat.rs
@@ -4,17 +4,12 @@ use datadog_api_client::datadogV2::model::{
     GoogleChatCreateOrganizationHandleRequest, GoogleChatUpdateOrganizationHandleRequest,
 };
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
 fn make_api(cfg: &Config) -> GoogleChatIntegrationAPI {
-    let dd_cfg = client::make_dd_config(cfg);
-    match client::make_bearer_client(cfg) {
-        Some(c) => GoogleChatIntegrationAPI::with_client_and_config(dd_cfg, c),
-        None => GoogleChatIntegrationAPI::with_config(dd_cfg),
-    }
+    crate::make_api!(GoogleChatIntegrationAPI, cfg)
 }
 
 pub async fn handles_list(cfg: &Config, org_id: &str) -> Result<()> {

--- a/src/commands/hamr.rs
+++ b/src/commands/hamr.rs
@@ -2,17 +2,12 @@ use anyhow::Result;
 use datadog_api_client::datadogV2::api_high_availability_multi_region::HighAvailabilityMultiRegionAPI;
 use datadog_api_client::datadogV2::model::HamrOrgConnectionRequest;
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
 pub async fn connections_get(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => HighAvailabilityMultiRegionAPI::with_client_and_config(dd_cfg, c),
-        None => HighAvailabilityMultiRegionAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(HighAvailabilityMultiRegionAPI, cfg);
     let resp = api
         .get_hamr_org_connection()
         .await
@@ -22,11 +17,7 @@ pub async fn connections_get(cfg: &Config) -> Result<()> {
 
 pub async fn connections_create(cfg: &Config, file: &str) -> Result<()> {
     let body: HamrOrgConnectionRequest = util::read_json_file(file)?;
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => HighAvailabilityMultiRegionAPI::with_client_and_config(dd_cfg, c),
-        None => HighAvailabilityMultiRegionAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(HighAvailabilityMultiRegionAPI, cfg);
     let resp = api
         .create_hamr_org_connection(body)
         .await

--- a/src/commands/incidents.rs
+++ b/src/commands/incidents.rs
@@ -13,7 +13,6 @@ use datadog_api_client::datadogV2::api_incidents::{
 };
 use datadog_api_client::datadogV2::model::{IncidentImportRequest, IncidentSearchSortOrder};
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
@@ -23,11 +22,7 @@ use crate::util;
 // ---------------------------------------------------------------------------
 
 fn make_api(cfg: &Config) -> IncidentsAPI {
-    let dd_cfg = client::make_dd_config(cfg);
-    match client::make_bearer_client(cfg) {
-        Some(c) => IncidentsAPI::with_client_and_config(dd_cfg, c),
-        None => IncidentsAPI::with_config(dd_cfg),
-    }
+    crate::make_api!(IncidentsAPI, cfg)
 }
 
 // ---------------------------------------------------------------------------
@@ -235,11 +230,7 @@ pub async fn postmortem_templates_delete(cfg: &Config, template_id: &str) -> Res
 // ---------------------------------------------------------------------------
 
 fn make_teams_api(cfg: &Config) -> IncidentTeamsAPI {
-    let dd_cfg = client::make_dd_config(cfg);
-    match client::make_bearer_client(cfg) {
-        Some(c) => IncidentTeamsAPI::with_client_and_config(dd_cfg, c),
-        None => IncidentTeamsAPI::with_config(dd_cfg),
-    }
+    crate::make_api!(IncidentTeamsAPI, cfg)
 }
 
 pub async fn teams_list(cfg: &Config) -> Result<()> {
@@ -297,11 +288,7 @@ pub async fn teams_delete(cfg: &Config, team_id: &str) -> Result<()> {
 // ---------------------------------------------------------------------------
 
 fn make_services_api(cfg: &Config) -> IncidentServicesAPI {
-    let dd_cfg = client::make_dd_config(cfg);
-    match client::make_bearer_client(cfg) {
-        Some(c) => IncidentServicesAPI::with_client_and_config(dd_cfg, c),
-        None => IncidentServicesAPI::with_config(dd_cfg),
-    }
+    crate::make_api!(IncidentServicesAPI, cfg)
 }
 
 pub async fn services_list(cfg: &Config) -> Result<()> {

--- a/src/commands/infrastructure.rs
+++ b/src/commands/infrastructure.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use datadog_api_client::datadogV1::api_hosts::{HostsAPI, ListHostsOptionalParams};
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 
@@ -11,11 +10,7 @@ pub async fn hosts_list(
     sort: String,
     count: i64,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => HostsAPI::with_client_and_config(dd_cfg, c),
-        None => HostsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(HostsAPI, cfg);
     let mut params = ListHostsOptionalParams::default()
         .count(count)
         .sort_field(sort);
@@ -32,11 +27,7 @@ pub async fn hosts_list(
 pub async fn hosts_get(cfg: &Config, hostname: &str) -> Result<()> {
     // The V1 HostsAPI does not have a direct get-host method.
     // Use list_hosts with a filter to find the specific host.
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => HostsAPI::with_client_and_config(dd_cfg, c),
-        None => HostsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(HostsAPI, cfg);
     let params = ListHostsOptionalParams::default()
         .filter(hostname.to_string())
         .count(1);

--- a/src/commands/integrations.rs
+++ b/src/commands/integrations.rs
@@ -1,4 +1,3 @@
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
@@ -16,11 +15,7 @@ use datadog_api_client::datadogV2::model::{
 // ---- Jira ----
 
 pub async fn jira_accounts_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => JiraIntegrationAPI::with_client_and_config(dd_cfg, c),
-        None => JiraIntegrationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(JiraIntegrationAPI, cfg);
     let resp = api
         .list_jira_accounts()
         .await
@@ -29,11 +24,7 @@ pub async fn jira_accounts_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn jira_templates_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => JiraIntegrationAPI::with_client_and_config(dd_cfg, c),
-        None => JiraIntegrationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(JiraIntegrationAPI, cfg);
     let resp = api
         .list_jira_issue_templates()
         .await
@@ -42,11 +33,7 @@ pub async fn jira_templates_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn jira_templates_get(cfg: &Config, template_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => JiraIntegrationAPI::with_client_and_config(dd_cfg, c),
-        None => JiraIntegrationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(JiraIntegrationAPI, cfg);
     let uuid = util::parse_uuid(template_id, "template")?;
     let resp = api
         .get_jira_issue_template(uuid)
@@ -56,11 +43,7 @@ pub async fn jira_templates_get(cfg: &Config, template_id: &str) -> Result<()> {
 }
 
 pub async fn jira_accounts_delete(cfg: &Config, account_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => JiraIntegrationAPI::with_client_and_config(dd_cfg, c),
-        None => JiraIntegrationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(JiraIntegrationAPI, cfg);
     let uuid = util::parse_uuid(account_id, "account")?;
     api.delete_jira_account(uuid)
         .await
@@ -70,11 +53,7 @@ pub async fn jira_accounts_delete(cfg: &Config, account_id: &str) -> Result<()> 
 }
 
 pub async fn jira_templates_create(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => JiraIntegrationAPI::with_client_and_config(dd_cfg, c),
-        None => JiraIntegrationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(JiraIntegrationAPI, cfg);
     let body: JiraIssueTemplateCreateRequest = crate::util::read_json_file(file)?;
     let resp = api
         .create_jira_issue_template(body)
@@ -84,11 +63,7 @@ pub async fn jira_templates_create(cfg: &Config, file: &str) -> Result<()> {
 }
 
 pub async fn jira_templates_update(cfg: &Config, template_id: &str, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => JiraIntegrationAPI::with_client_and_config(dd_cfg, c),
-        None => JiraIntegrationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(JiraIntegrationAPI, cfg);
     let uuid = util::parse_uuid(template_id, "template")?;
     let body: JiraIssueTemplateUpdateRequest = crate::util::read_json_file(file)?;
     let resp = api
@@ -99,11 +74,7 @@ pub async fn jira_templates_update(cfg: &Config, template_id: &str, file: &str) 
 }
 
 pub async fn jira_templates_delete(cfg: &Config, template_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => JiraIntegrationAPI::with_client_and_config(dd_cfg, c),
-        None => JiraIntegrationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(JiraIntegrationAPI, cfg);
     let uuid = util::parse_uuid(template_id, "template")?;
     api.delete_jira_issue_template(uuid)
         .await
@@ -115,11 +86,7 @@ pub async fn jira_templates_delete(cfg: &Config, template_id: &str) -> Result<()
 // ---- ServiceNow ----
 
 pub async fn servicenow_instances_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceNowIntegrationAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceNowIntegrationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(ServiceNowIntegrationAPI, cfg);
     let resp = api
         .list_service_now_instances()
         .await
@@ -128,11 +95,7 @@ pub async fn servicenow_instances_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn servicenow_templates_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceNowIntegrationAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceNowIntegrationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(ServiceNowIntegrationAPI, cfg);
     let resp = api
         .list_service_now_templates()
         .await
@@ -141,11 +104,7 @@ pub async fn servicenow_templates_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn servicenow_templates_get(cfg: &Config, template_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceNowIntegrationAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceNowIntegrationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(ServiceNowIntegrationAPI, cfg);
     let uuid = util::parse_uuid(template_id, "template")?;
     let resp = api
         .get_service_now_template(uuid)
@@ -155,11 +114,7 @@ pub async fn servicenow_templates_get(cfg: &Config, template_id: &str) -> Result
 }
 
 pub async fn servicenow_templates_create(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceNowIntegrationAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceNowIntegrationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(ServiceNowIntegrationAPI, cfg);
     let body: ServiceNowTemplateCreateRequest = crate::util::read_json_file(file)?;
     let resp = api
         .create_service_now_template(body)
@@ -173,11 +128,7 @@ pub async fn servicenow_templates_update(
     template_id: &str,
     file: &str,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceNowIntegrationAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceNowIntegrationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(ServiceNowIntegrationAPI, cfg);
     let uuid = util::parse_uuid(template_id, "template")?;
     let body: ServiceNowTemplateUpdateRequest = crate::util::read_json_file(file)?;
     let resp = api
@@ -188,11 +139,7 @@ pub async fn servicenow_templates_update(
 }
 
 pub async fn servicenow_templates_delete(cfg: &Config, template_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceNowIntegrationAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceNowIntegrationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(ServiceNowIntegrationAPI, cfg);
     let uuid = util::parse_uuid(template_id, "template")?;
     api.delete_service_now_template(uuid)
         .await
@@ -202,11 +149,7 @@ pub async fn servicenow_templates_delete(cfg: &Config, template_id: &str) -> Res
 }
 
 pub async fn servicenow_users_list(cfg: &Config, instance_name: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceNowIntegrationAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceNowIntegrationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(ServiceNowIntegrationAPI, cfg);
     let resp = api
         .list_service_now_users(util::parse_uuid(instance_name, "instance")?)
         .await
@@ -215,11 +158,7 @@ pub async fn servicenow_users_list(cfg: &Config, instance_name: &str) -> Result<
 }
 
 pub async fn servicenow_assignment_groups_list(cfg: &Config, instance_name: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceNowIntegrationAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceNowIntegrationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(ServiceNowIntegrationAPI, cfg);
     let resp = api
         .list_service_now_assignment_groups(util::parse_uuid(instance_name, "instance")?)
         .await
@@ -228,11 +167,7 @@ pub async fn servicenow_assignment_groups_list(cfg: &Config, instance_name: &str
 }
 
 pub async fn servicenow_business_services_list(cfg: &Config, instance_name: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceNowIntegrationAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceNowIntegrationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(ServiceNowIntegrationAPI, cfg);
     let resp = api
         .list_service_now_business_services(util::parse_uuid(instance_name, "instance")?)
         .await
@@ -243,11 +178,7 @@ pub async fn servicenow_business_services_list(cfg: &Config, instance_name: &str
 // ---- Slack ----
 
 pub async fn slack_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SlackIntegrationAPI::with_client_and_config(dd_cfg, c),
-        None => SlackIntegrationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SlackIntegrationAPI, cfg);
     let resp = api
         .get_slack_integration_channels("main".to_string())
         .await
@@ -267,11 +198,7 @@ pub async fn pagerduty_list(_cfg: &Config) -> Result<()> {
 // ---- Webhooks ----
 
 pub async fn webhooks_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => WebhooksIntegrationAPI::with_client_and_config(dd_cfg, c),
-        None => WebhooksIntegrationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(WebhooksIntegrationAPI, cfg);
     let resp = api
         .get_webhooks_integration("main".to_string())
         .await
@@ -282,11 +209,7 @@ pub async fn webhooks_list(cfg: &Config) -> Result<()> {
 // ---- Integrations v2 list ----
 
 pub async fn list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => IntegrationsAPI::with_client_and_config(dd_cfg, c),
-        None => IntegrationsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(IntegrationsAPI, cfg);
     let resp = api
         .list_integrations()
         .await

--- a/src/commands/investigations.rs
+++ b/src/commands/investigations.rs
@@ -1,17 +1,12 @@
 use anyhow::Result;
 use datadog_api_client::datadogV2::api_bits_ai::{BitsAIAPI, ListInvestigationsOptionalParams};
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
 fn make_api(cfg: &Config) -> BitsAIAPI {
-    let dd_cfg = client::make_dd_config(cfg);
-    match client::make_bearer_client(cfg) {
-        Some(c) => BitsAIAPI::with_client_and_config(dd_cfg, c),
-        None => BitsAIAPI::with_config(dd_cfg),
-    }
+    crate::make_api!(BitsAIAPI, cfg)
 }
 
 pub async fn list(cfg: &Config, page_limit: i64, page_offset: i64) -> Result<()> {

--- a/src/commands/llm_obs.rs
+++ b/src/commands/llm_obs.rs
@@ -15,11 +15,7 @@ use crate::formatter;
 use crate::util;
 
 fn make_api(cfg: &Config) -> LLMObservabilityAPI {
-    let dd_cfg = client::make_dd_config(cfg);
-    match client::make_bearer_client(cfg) {
-        Some(c) => LLMObservabilityAPI::with_client_and_config(dd_cfg, c),
-        None => LLMObservabilityAPI::with_config(dd_cfg),
-    }
+    crate::make_api!(LLMObservabilityAPI, cfg)
 }
 
 // ---- Projects ----

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -235,11 +235,7 @@ pub async fn search(
     sort: String,
     storage: Option<String>,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => LogsAPI::with_client_and_config(dd_cfg, c),
-        None => LogsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(LogsAPI, cfg);
 
     let from_ms = util::parse_time_to_unix_millis(&from)?;
     let to_ms = util::parse_time_to_unix_millis(&to)?;
@@ -340,11 +336,7 @@ pub async fn aggregate(cfg: &Config, args: AggregateArgs) -> Result<()> {
 }
 
 pub async fn archives_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => LogsArchivesAPI::with_client_and_config(dd_cfg, c),
-        None => LogsArchivesAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(LogsArchivesAPI, cfg);
 
     let resp = api
         .list_logs_archives()
@@ -356,11 +348,7 @@ pub async fn archives_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn archives_get(cfg: &Config, archive_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => LogsArchivesAPI::with_client_and_config(dd_cfg, c),
-        None => LogsArchivesAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(LogsArchivesAPI, cfg);
 
     let resp = api
         .get_logs_archive(archive_id.to_string())
@@ -372,11 +360,7 @@ pub async fn archives_get(cfg: &Config, archive_id: &str) -> Result<()> {
 }
 
 pub async fn archives_delete(cfg: &Config, archive_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => LogsArchivesAPI::with_client_and_config(dd_cfg, c),
-        None => LogsArchivesAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(LogsArchivesAPI, cfg);
 
     api.delete_logs_archive(archive_id.to_string())
         .await
@@ -387,11 +371,7 @@ pub async fn archives_delete(cfg: &Config, archive_id: &str) -> Result<()> {
 }
 
 pub async fn custom_destinations_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => LogsCustomDestinationsAPI::with_client_and_config(dd_cfg, c),
-        None => LogsCustomDestinationsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(LogsCustomDestinationsAPI, cfg);
 
     let resp = api
         .list_logs_custom_destinations()
@@ -403,11 +383,7 @@ pub async fn custom_destinations_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn custom_destinations_get(cfg: &Config, destination_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => LogsCustomDestinationsAPI::with_client_and_config(dd_cfg, c),
-        None => LogsCustomDestinationsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(LogsCustomDestinationsAPI, cfg);
 
     let resp = api
         .get_logs_custom_destination(destination_id.to_string())
@@ -419,11 +395,7 @@ pub async fn custom_destinations_get(cfg: &Config, destination_id: &str) -> Resu
 }
 
 pub async fn metrics_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => LogsMetricsAPI::with_client_and_config(dd_cfg, c),
-        None => LogsMetricsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(LogsMetricsAPI, cfg);
 
     let resp = api
         .list_logs_metrics()
@@ -435,11 +407,7 @@ pub async fn metrics_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn metrics_get(cfg: &Config, metric_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => LogsMetricsAPI::with_client_and_config(dd_cfg, c),
-        None => LogsMetricsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(LogsMetricsAPI, cfg);
 
     let resp = api
         .get_logs_metric(metric_id.to_string())
@@ -451,11 +419,7 @@ pub async fn metrics_get(cfg: &Config, metric_id: &str) -> Result<()> {
 }
 
 pub async fn metrics_delete(cfg: &Config, metric_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => LogsMetricsAPI::with_client_and_config(dd_cfg, c),
-        None => LogsMetricsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(LogsMetricsAPI, cfg);
 
     api.delete_logs_metric(metric_id.to_string())
         .await

--- a/src/commands/metrics.rs
+++ b/src/commands/metrics.rs
@@ -36,17 +36,12 @@ use datadog_api_client::datadogV1::model::MetricMetadata;
 use datadog_api_client::datadogV2::api_metrics::MetricsAPI as MetricsV2API;
 use datadog_api_client::datadogV2::model::MetricPayload;
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
 pub async fn list(cfg: &Config, filter: Option<String>, from: String) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => MetricsV1API::with_client_and_config(dd_cfg, c),
-        None => MetricsV1API::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(MetricsV1API, cfg);
 
     let from_ts = util::parse_time_to_unix(&from)?;
     let params = ListActiveMetricsOptionalParams::default();
@@ -76,11 +71,7 @@ pub async fn list(cfg: &Config, filter: Option<String>, from: String) -> Result<
 }
 
 pub async fn search(cfg: &Config, query: String, from: String, to: String) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => MetricsV1API::with_client_and_config(dd_cfg, c),
-        None => MetricsV1API::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(MetricsV1API, cfg);
 
     let from_ts = util::parse_time_to_unix(&from)?;
     let to_ts = util::parse_time_to_unix(&to)?;
@@ -93,11 +84,7 @@ pub async fn search(cfg: &Config, query: String, from: String, to: String) -> Re
 }
 
 pub async fn metadata_get(cfg: &Config, metric_name: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => MetricsV1API::with_client_and_config(dd_cfg, c),
-        None => MetricsV1API::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(MetricsV1API, cfg);
     let resp = api
         .get_metric_metadata(metric_name.to_string())
         .await
@@ -106,11 +93,7 @@ pub async fn metadata_get(cfg: &Config, metric_name: &str) -> Result<()> {
 }
 
 pub async fn query(cfg: &Config, query: String, from: String, to: String) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => MetricsV1API::with_client_and_config(dd_cfg, c),
-        None => MetricsV1API::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(MetricsV1API, cfg);
 
     let from_ts = util::parse_time_to_unix(&from)?;
     let to_ts = util::parse_time_to_unix(&to)?;
@@ -123,11 +106,7 @@ pub async fn query(cfg: &Config, query: String, from: String, to: String) -> Res
 }
 
 pub async fn metadata_update(cfg: &Config, metric_name: &str, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => MetricsV1API::with_client_and_config(dd_cfg, c),
-        None => MetricsV1API::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(MetricsV1API, cfg);
     let body: MetricMetadata = util::read_json_file(file)?;
     let resp = api
         .update_metric_metadata(metric_name.to_string(), body)
@@ -137,11 +116,7 @@ pub async fn metadata_update(cfg: &Config, metric_name: &str, file: &str) -> Res
 }
 
 pub async fn submit(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => MetricsV2API::with_client_and_config(dd_cfg, c),
-        None => MetricsV2API::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(MetricsV2API, cfg);
     let body: MetricPayload = util::read_json_file(file)?;
     let resp = api
         .submit_metrics(
@@ -156,11 +131,7 @@ pub async fn submit(cfg: &Config, file: &str) -> Result<()> {
 pub async fn tags_list(cfg: &Config, metric_name: &str) -> Result<()> {
     use datadog_api_client::datadogV2::api_metrics::ListTagsByMetricNameOptionalParams;
 
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => MetricsV2API::with_client_and_config(dd_cfg, c),
-        None => MetricsV2API::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(MetricsV2API, cfg);
     let resp = api
         .list_tags_by_metric_name(
             metric_name.to_string(),

--- a/src/commands/misc.rs
+++ b/src/commands/misc.rs
@@ -2,16 +2,11 @@ use anyhow::Result;
 use datadog_api_client::datadogV1::api_authentication::AuthenticationAPI;
 use datadog_api_client::datadogV1::api_ip_ranges::IPRangesAPI;
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 
 pub async fn ip_ranges(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => IPRangesAPI::with_client_and_config(dd_cfg, c),
-        None => IPRangesAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(IPRangesAPI, cfg);
     let resp = api
         .get_ip_ranges()
         .await
@@ -27,11 +22,7 @@ pub async fn status(cfg: &Config) -> Result<()> {
         });
         return formatter::output(cfg, &transformed);
     }
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => AuthenticationAPI::with_client_and_config(dd_cfg, c),
-        None => AuthenticationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(AuthenticationAPI, cfg);
     let _resp = api
         .validate()
         .await

--- a/src/commands/monitors.rs
+++ b/src/commands/monitors.rs
@@ -5,7 +5,6 @@ use datadog_api_client::datadogV1::api_monitors::{
 };
 use datadog_api_client::datadogV1::model::Monitor;
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter::{self, Metadata};
 use crate::util;
@@ -16,12 +15,7 @@ pub async fn list(
     tags: Option<String>,
     limit: i32,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = if let Some(http_client) = client::make_bearer_client(cfg) {
-        MonitorsAPI::with_client_and_config(dd_cfg, http_client)
-    } else {
-        MonitorsAPI::with_config(dd_cfg)
-    };
+    let api = crate::make_api!(MonitorsAPI, cfg);
 
     let mut params = ListMonitorsOptionalParams::default();
     if let Some(name) = name {
@@ -56,12 +50,7 @@ pub async fn list(
 }
 
 pub async fn get(cfg: &Config, monitor_id: i64) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = if let Some(http_client) = client::make_bearer_client(cfg) {
-        MonitorsAPI::with_client_and_config(dd_cfg, http_client)
-    } else {
-        MonitorsAPI::with_config(dd_cfg)
-    };
+    let api = crate::make_api!(MonitorsAPI, cfg);
     let resp = api
         .get_monitor(monitor_id, GetMonitorOptionalParams::default())
         .await
@@ -77,12 +66,7 @@ pub async fn get(cfg: &Config, monitor_id: i64) -> Result<()> {
 
 pub async fn create(cfg: &Config, file: &str) -> Result<()> {
     let body: Monitor = util::read_json_file(file)?;
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = if let Some(http_client) = client::make_bearer_client(cfg) {
-        MonitorsAPI::with_client_and_config(dd_cfg, http_client)
-    } else {
-        MonitorsAPI::with_config(dd_cfg)
-    };
+    let api = crate::make_api!(MonitorsAPI, cfg);
     let resp = api
         .create_monitor(body)
         .await
@@ -93,12 +77,7 @@ pub async fn create(cfg: &Config, file: &str) -> Result<()> {
 pub async fn update(cfg: &Config, monitor_id: i64, file: &str) -> Result<()> {
     let body: datadog_api_client::datadogV1::model::MonitorUpdateRequest =
         util::read_json_file(file)?;
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = if let Some(http_client) = client::make_bearer_client(cfg) {
-        MonitorsAPI::with_client_and_config(dd_cfg, http_client)
-    } else {
-        MonitorsAPI::with_config(dd_cfg)
-    };
+    let api = crate::make_api!(MonitorsAPI, cfg);
     let resp = api
         .update_monitor(monitor_id, body)
         .await
@@ -107,12 +86,7 @@ pub async fn update(cfg: &Config, monitor_id: i64, file: &str) -> Result<()> {
 }
 
 pub async fn search(cfg: &Config, query: Option<String>) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = if let Some(http_client) = client::make_bearer_client(cfg) {
-        MonitorsAPI::with_client_and_config(dd_cfg, http_client)
-    } else {
-        MonitorsAPI::with_config(dd_cfg)
-    };
+    let api = crate::make_api!(MonitorsAPI, cfg);
 
     let mut params = SearchMonitorsOptionalParams::default();
     if let Some(q) = query {
@@ -127,12 +101,7 @@ pub async fn search(cfg: &Config, query: Option<String>) -> Result<()> {
 }
 
 pub async fn delete(cfg: &Config, monitor_id: i64) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = if let Some(http_client) = client::make_bearer_client(cfg) {
-        MonitorsAPI::with_client_and_config(dd_cfg, http_client)
-    } else {
-        MonitorsAPI::with_config(dd_cfg)
-    };
+    let api = crate::make_api!(MonitorsAPI, cfg);
     let resp = api
         .delete_monitor(monitor_id, DeleteMonitorOptionalParams::default())
         .await

--- a/src/commands/ms_teams.rs
+++ b/src/commands/ms_teams.rs
@@ -4,7 +4,6 @@ use datadog_api_client::datadogV2::api_microsoft_teams_integration::{
     MicrosoftTeamsIntegrationAPI,
 };
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
@@ -14,11 +13,7 @@ use crate::util;
 // ---------------------------------------------------------------------------
 
 fn make_api(cfg: &Config) -> MicrosoftTeamsIntegrationAPI {
-    let dd_cfg = client::make_dd_config(cfg);
-    match client::make_bearer_client(cfg) {
-        Some(c) => MicrosoftTeamsIntegrationAPI::with_client_and_config(dd_cfg, c),
-        None => MicrosoftTeamsIntegrationAPI::with_config(dd_cfg),
-    }
+    crate::make_api!(MicrosoftTeamsIntegrationAPI, cfg)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/commands/network.rs
+++ b/src/commands/network.rs
@@ -4,17 +4,12 @@ use datadog_api_client::datadogV2::api_network_device_monitoring::{
 };
 use datadog_api_client::datadogV2::model::{ListInterfaceTagsResponse, ListTagsResponse};
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
 fn make_api(cfg: &Config) -> NetworkDeviceMonitoringAPI {
-    let dd_cfg = client::make_dd_config(cfg);
-    match client::make_bearer_client(cfg) {
-        Some(c) => NetworkDeviceMonitoringAPI::with_client_and_config(dd_cfg, c),
-        None => NetworkDeviceMonitoringAPI::with_config(dd_cfg),
-    }
+    crate::make_api!(NetworkDeviceMonitoringAPI, cfg)
 }
 
 // ---- Devices ----

--- a/src/commands/notebooks.rs
+++ b/src/commands/notebooks.rs
@@ -2,17 +2,12 @@ use anyhow::Result;
 use datadog_api_client::datadogV1::api_notebooks::{ListNotebooksOptionalParams, NotebooksAPI};
 use datadog_api_client::datadogV1::model::{NotebookCreateRequest, NotebookUpdateRequest};
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
 pub async fn list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => NotebooksAPI::with_client_and_config(dd_cfg, c),
-        None => NotebooksAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(NotebooksAPI, cfg);
     let resp = api
         .list_notebooks(ListNotebooksOptionalParams::default())
         .await
@@ -21,11 +16,7 @@ pub async fn list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn get(cfg: &Config, notebook_id: i64) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => NotebooksAPI::with_client_and_config(dd_cfg, c),
-        None => NotebooksAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(NotebooksAPI, cfg);
     let resp = api
         .get_notebook(notebook_id)
         .await
@@ -34,11 +25,7 @@ pub async fn get(cfg: &Config, notebook_id: i64) -> Result<()> {
 }
 
 pub async fn delete(cfg: &Config, notebook_id: i64) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => NotebooksAPI::with_client_and_config(dd_cfg, c),
-        None => NotebooksAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(NotebooksAPI, cfg);
     api.delete_notebook(notebook_id)
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete notebook: {e:?}"))?;
@@ -47,11 +34,7 @@ pub async fn delete(cfg: &Config, notebook_id: i64) -> Result<()> {
 }
 
 pub async fn create(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => NotebooksAPI::with_client_and_config(dd_cfg, c),
-        None => NotebooksAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(NotebooksAPI, cfg);
     let body: NotebookCreateRequest = util::read_json_file(file)?;
     let resp = api
         .create_notebook(body)
@@ -61,11 +44,7 @@ pub async fn create(cfg: &Config, file: &str) -> Result<()> {
 }
 
 pub async fn update(cfg: &Config, notebook_id: i64, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => NotebooksAPI::with_client_and_config(dd_cfg, c),
-        None => NotebooksAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(NotebooksAPI, cfg);
     let body: NotebookUpdateRequest = util::read_json_file(file)?;
     let resp = api
         .update_notebook(notebook_id, body)

--- a/src/commands/on_call.rs
+++ b/src/commands/on_call.rs
@@ -20,17 +20,12 @@ use datadog_api_client::datadogV2::model::{
     UserTeamUpdateRequest, UserTeamUserType,
 };
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
 pub async fn teams_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => TeamsAPI::with_client_and_config(dd_cfg, c),
-        None => TeamsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(TeamsAPI, cfg);
     let resp = api
         .list_teams(ListTeamsOptionalParams::default())
         .await
@@ -39,11 +34,7 @@ pub async fn teams_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn teams_get(cfg: &Config, team_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => TeamsAPI::with_client_and_config(dd_cfg, c),
-        None => TeamsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(TeamsAPI, cfg);
     let resp = api
         .get_team(team_id.to_string())
         .await
@@ -52,11 +43,7 @@ pub async fn teams_get(cfg: &Config, team_id: &str) -> Result<()> {
 }
 
 pub async fn teams_delete(cfg: &Config, team_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => TeamsAPI::with_client_and_config(dd_cfg, c),
-        None => TeamsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(TeamsAPI, cfg);
     api.delete_team(team_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete team: {e:?}"))?;
@@ -65,11 +52,7 @@ pub async fn teams_delete(cfg: &Config, team_id: &str) -> Result<()> {
 }
 
 pub async fn teams_create(cfg: &Config, name: &str, handle: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => TeamsAPI::with_client_and_config(dd_cfg, c),
-        None => TeamsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(TeamsAPI, cfg);
     let attrs = TeamCreateAttributes::new(handle.to_string(), name.to_string());
     let data = TeamCreate::new(attrs, TeamType::TEAM);
     let body = TeamCreateRequest::new(data);
@@ -81,11 +64,7 @@ pub async fn teams_create(cfg: &Config, name: &str, handle: &str) -> Result<()> 
 }
 
 pub async fn teams_update(cfg: &Config, team_id: &str, name: &str, handle: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => TeamsAPI::with_client_and_config(dd_cfg, c),
-        None => TeamsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(TeamsAPI, cfg);
     let attrs = TeamUpdateAttributes::new(handle.to_string(), name.to_string());
     let data = TeamUpdate::new(attrs, TeamType::TEAM);
     let body = TeamUpdateRequest::new(data);
@@ -97,11 +76,7 @@ pub async fn teams_update(cfg: &Config, team_id: &str, name: &str, handle: &str)
 }
 
 pub async fn memberships_list(cfg: &Config, team_id: &str, page_size: i64) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => TeamsAPI::with_client_and_config(dd_cfg, c),
-        None => TeamsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(TeamsAPI, cfg);
     let params = GetTeamMembershipsOptionalParams::default().page_size(page_size);
     let resp = api
         .get_team_memberships(team_id.to_string(), params)
@@ -116,11 +91,7 @@ pub async fn memberships_add(
     user_id: &str,
     role: Option<String>,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => TeamsAPI::with_client_and_config(dd_cfg, c),
-        None => TeamsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(TeamsAPI, cfg);
     let mut attrs = UserTeamAttributes::new();
     if let Some(r) = role {
         let team_role = match r.to_lowercase().as_str() {
@@ -150,11 +121,7 @@ pub async fn memberships_update(
     user_id: &str,
     role: &str,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => TeamsAPI::with_client_and_config(dd_cfg, c),
-        None => TeamsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(TeamsAPI, cfg);
     let team_role = match role.to_lowercase().as_str() {
         "admin" => UserTeamRole::ADMIN,
         _ => UserTeamRole::ADMIN,
@@ -170,11 +137,7 @@ pub async fn memberships_update(
 }
 
 pub async fn memberships_remove(cfg: &Config, team_id: &str, user_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => TeamsAPI::with_client_and_config(dd_cfg, c),
-        None => TeamsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(TeamsAPI, cfg);
     api.delete_team_membership(team_id.to_string(), user_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to remove membership: {e:?}"))?;
@@ -185,11 +148,7 @@ pub async fn memberships_remove(cfg: &Config, team_id: &str, user_id: &str) -> R
 // ---- Escalation Policies ----
 
 pub async fn escalation_policies_get(cfg: &Config, policy_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => OnCallAPI::with_client_and_config(dd_cfg, c),
-        None => OnCallAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(OnCallAPI, cfg);
     let resp = api
         .get_on_call_escalation_policy(
             policy_id.to_string(),
@@ -201,11 +160,7 @@ pub async fn escalation_policies_get(cfg: &Config, policy_id: &str) -> Result<()
 }
 
 pub async fn escalation_policies_create(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => OnCallAPI::with_client_and_config(dd_cfg, c),
-        None => OnCallAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(OnCallAPI, cfg);
     let body: EscalationPolicyCreateRequest = util::read_json_file(file)?;
     let resp = api
         .create_on_call_escalation_policy(
@@ -218,11 +173,7 @@ pub async fn escalation_policies_create(cfg: &Config, file: &str) -> Result<()> 
 }
 
 pub async fn escalation_policies_update(cfg: &Config, policy_id: &str, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => OnCallAPI::with_client_and_config(dd_cfg, c),
-        None => OnCallAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(OnCallAPI, cfg);
     let body: EscalationPolicyUpdateRequest = util::read_json_file(file)?;
     let resp = api
         .update_on_call_escalation_policy(
@@ -236,11 +187,7 @@ pub async fn escalation_policies_update(cfg: &Config, policy_id: &str, file: &st
 }
 
 pub async fn escalation_policies_delete(cfg: &Config, policy_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => OnCallAPI::with_client_and_config(dd_cfg, c),
-        None => OnCallAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(OnCallAPI, cfg);
     api.delete_on_call_escalation_policy(policy_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete escalation policy: {e:?}"))?;
@@ -251,11 +198,7 @@ pub async fn escalation_policies_delete(cfg: &Config, policy_id: &str) -> Result
 // ---- Schedules ----
 
 pub async fn schedules_get(cfg: &Config, schedule_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => OnCallAPI::with_client_and_config(dd_cfg, c),
-        None => OnCallAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(OnCallAPI, cfg);
     let resp = api
         .get_on_call_schedule(
             schedule_id.to_string(),
@@ -267,11 +210,7 @@ pub async fn schedules_get(cfg: &Config, schedule_id: &str) -> Result<()> {
 }
 
 pub async fn schedules_create(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => OnCallAPI::with_client_and_config(dd_cfg, c),
-        None => OnCallAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(OnCallAPI, cfg);
     let body: ScheduleCreateRequest = util::read_json_file(file)?;
     let resp = api
         .create_on_call_schedule(body, CreateOnCallScheduleOptionalParams::default())
@@ -281,11 +220,7 @@ pub async fn schedules_create(cfg: &Config, file: &str) -> Result<()> {
 }
 
 pub async fn schedules_update(cfg: &Config, schedule_id: &str, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => OnCallAPI::with_client_and_config(dd_cfg, c),
-        None => OnCallAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(OnCallAPI, cfg);
     let body: ScheduleUpdateRequest = util::read_json_file(file)?;
     let resp = api
         .update_on_call_schedule(
@@ -299,11 +234,7 @@ pub async fn schedules_update(cfg: &Config, schedule_id: &str, file: &str) -> Re
 }
 
 pub async fn schedules_delete(cfg: &Config, schedule_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => OnCallAPI::with_client_and_config(dd_cfg, c),
-        None => OnCallAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(OnCallAPI, cfg);
     api.delete_on_call_schedule(schedule_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete schedule: {e:?}"))?;
@@ -314,11 +245,7 @@ pub async fn schedules_delete(cfg: &Config, schedule_id: &str) -> Result<()> {
 // ---- Notification Channels ----
 
 pub async fn notification_channels_list(cfg: &Config, user_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => OnCallAPI::with_client_and_config(dd_cfg, c),
-        None => OnCallAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(OnCallAPI, cfg);
     let resp = api
         .list_user_notification_channels(user_id.to_string())
         .await
@@ -331,11 +258,7 @@ pub async fn notification_channels_get(
     user_id: &str,
     channel_id: &str,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => OnCallAPI::with_client_and_config(dd_cfg, c),
-        None => OnCallAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(OnCallAPI, cfg);
     let resp = api
         .get_user_notification_channel(user_id.to_string(), channel_id.to_string())
         .await
@@ -344,11 +267,7 @@ pub async fn notification_channels_get(
 }
 
 pub async fn notification_channels_create(cfg: &Config, user_id: &str, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => OnCallAPI::with_client_and_config(dd_cfg, c),
-        None => OnCallAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(OnCallAPI, cfg);
     let body: CreateUserNotificationChannelRequest = util::read_json_file(file)?;
     let resp = api
         .create_user_notification_channel(user_id.to_string(), body)
@@ -362,11 +281,7 @@ pub async fn notification_channels_delete(
     user_id: &str,
     channel_id: &str,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => OnCallAPI::with_client_and_config(dd_cfg, c),
-        None => OnCallAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(OnCallAPI, cfg);
     api.delete_user_notification_channel(user_id.to_string(), channel_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete notification channel: {e:?}"))?;
@@ -377,11 +292,7 @@ pub async fn notification_channels_delete(
 // ---- Notification Rules ----
 
 pub async fn notification_rules_list(cfg: &Config, user_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => OnCallAPI::with_client_and_config(dd_cfg, c),
-        None => OnCallAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(OnCallAPI, cfg);
     let resp = api
         .list_user_notification_rules(
             user_id.to_string(),
@@ -393,11 +304,7 @@ pub async fn notification_rules_list(cfg: &Config, user_id: &str) -> Result<()> 
 }
 
 pub async fn notification_rules_get(cfg: &Config, user_id: &str, rule_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => OnCallAPI::with_client_and_config(dd_cfg, c),
-        None => OnCallAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(OnCallAPI, cfg);
     let resp = api
         .get_user_notification_rule(
             user_id.to_string(),
@@ -410,11 +317,7 @@ pub async fn notification_rules_get(cfg: &Config, user_id: &str, rule_id: &str) 
 }
 
 pub async fn notification_rules_create(cfg: &Config, user_id: &str, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => OnCallAPI::with_client_and_config(dd_cfg, c),
-        None => OnCallAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(OnCallAPI, cfg);
     let body: CreateOnCallNotificationRuleRequest = util::read_json_file(file)?;
     let resp = api
         .create_user_notification_rule(user_id.to_string(), body)
@@ -429,11 +332,7 @@ pub async fn notification_rules_update(
     rule_id: &str,
     file: &str,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => OnCallAPI::with_client_and_config(dd_cfg, c),
-        None => OnCallAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(OnCallAPI, cfg);
     let body: UpdateOnCallNotificationRuleRequest = util::read_json_file(file)?;
     let resp = api
         .update_user_notification_rule(
@@ -448,11 +347,7 @@ pub async fn notification_rules_update(
 }
 
 pub async fn notification_rules_delete(cfg: &Config, user_id: &str, rule_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => OnCallAPI::with_client_and_config(dd_cfg, c),
-        None => OnCallAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(OnCallAPI, cfg);
     api.delete_user_notification_rule(user_id.to_string(), rule_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete notification rule: {e:?}"))?;
@@ -463,11 +358,7 @@ pub async fn notification_rules_delete(cfg: &Config, user_id: &str, rule_id: &st
 // ---- Pages ----
 
 pub async fn pages_create(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => OnCallPagingAPI::with_client_and_config(dd_cfg, c),
-        None => OnCallPagingAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(OnCallPagingAPI, cfg);
     let body: CreatePageRequest = util::read_json_file(file)?;
     let resp = api
         .create_on_call_page(body)

--- a/src/commands/organizations.rs
+++ b/src/commands/organizations.rs
@@ -1,16 +1,11 @@
 use anyhow::Result;
 use datadog_api_client::datadogV1::api_organizations::OrganizationsAPI;
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 
 pub async fn list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => OrganizationsAPI::with_client_and_config(dd_cfg, c),
-        None => OrganizationsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(OrganizationsAPI, cfg);
     let resp = api
         .list_orgs()
         .await
@@ -19,11 +14,7 @@ pub async fn list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn get(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => OrganizationsAPI::with_client_and_config(dd_cfg, c),
-        None => OrganizationsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(OrganizationsAPI, cfg);
     let resp = api
         .get_org("current".to_string())
         .await

--- a/src/commands/processes.rs
+++ b/src/commands/processes.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use datadog_api_client::datadogV2::api_processes::{ListProcessesOptionalParams, ProcessesAPI};
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 
@@ -11,11 +10,7 @@ pub async fn list(
     tags: Option<String>,
     page_limit: Option<i32>,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ProcessesAPI::with_client_and_config(dd_cfg, c),
-        None => ProcessesAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(ProcessesAPI, cfg);
     let mut params = ListProcessesOptionalParams::default();
     if let Some(s) = search {
         params = params.search(s);

--- a/src/commands/product_analytics.rs
+++ b/src/commands/product_analytics.rs
@@ -4,18 +4,13 @@ use datadog_api_client::datadogV2::model::{
     ProductAnalyticsAnalyticsRequest, ProductAnalyticsServerSideEventItem,
 };
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
 pub async fn events_send(cfg: &Config, file: &str) -> Result<()> {
     let body: ProductAnalyticsServerSideEventItem = util::read_json_file(file)?;
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ProductAnalyticsAPI::with_client_and_config(dd_cfg, c),
-        None => ProductAnalyticsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(ProductAnalyticsAPI, cfg);
     let resp = api
         .submit_product_analytics_event(body)
         .await
@@ -26,11 +21,7 @@ pub async fn events_send(cfg: &Config, file: &str) -> Result<()> {
 // ---- Query ----
 
 fn make_api(cfg: &Config) -> ProductAnalyticsAPI {
-    let dd_cfg = client::make_dd_config(cfg);
-    match client::make_bearer_client(cfg) {
-        Some(c) => ProductAnalyticsAPI::with_client_and_config(dd_cfg, c),
-        None => ProductAnalyticsAPI::with_config(dd_cfg),
-    }
+    crate::make_api!(ProductAnalyticsAPI, cfg)
 }
 
 pub async fn query_scalar(cfg: &Config, file: &str) -> Result<()> {

--- a/src/commands/reference_tables.rs
+++ b/src/commands/reference_tables.rs
@@ -3,17 +3,12 @@ use datadog_api_client::datadogV2::api_reference_tables::{
     ListTablesOptionalParams, ReferenceTablesAPI,
 };
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
 fn make_api(cfg: &Config) -> ReferenceTablesAPI {
-    let dd_cfg = client::make_dd_config(cfg);
-    match client::make_bearer_client(cfg) {
-        Some(c) => ReferenceTablesAPI::with_client_and_config(dd_cfg, c),
-        None => ReferenceTablesAPI::with_config(dd_cfg),
-    }
+    crate::make_api!(ReferenceTablesAPI, cfg)
 }
 
 pub async fn list(cfg: &Config, limit: i64) -> Result<()> {

--- a/src/commands/rum.rs
+++ b/src/commands/rum.rs
@@ -21,11 +21,7 @@ use crate::formatter;
 use crate::util;
 
 pub async fn apps_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => RUMAPI::with_client_and_config(dd_cfg, c),
-        None => RUMAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(RUMAPI, cfg);
     let resp = api
         .get_rum_applications()
         .await
@@ -34,11 +30,7 @@ pub async fn apps_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn apps_get(cfg: &Config, app_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => RUMAPI::with_client_and_config(dd_cfg, c),
-        None => RUMAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(RUMAPI, cfg);
     let resp = api
         .get_rum_application(app_id.to_string())
         .await
@@ -47,11 +39,7 @@ pub async fn apps_get(cfg: &Config, app_id: &str) -> Result<()> {
 }
 
 pub async fn apps_create(cfg: &Config, name: &str, app_type: Option<String>) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => RUMAPI::with_client_and_config(dd_cfg, c),
-        None => RUMAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(RUMAPI, cfg);
     let mut attrs = RUMApplicationCreateAttributes::new(name.to_string());
     if let Some(t) = app_type {
         attrs = attrs.type_(t);
@@ -66,11 +54,7 @@ pub async fn apps_create(cfg: &Config, name: &str, app_type: Option<String>) -> 
 }
 
 pub async fn apps_delete(cfg: &Config, app_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => RUMAPI::with_client_and_config(dd_cfg, c),
-        None => RUMAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(RUMAPI, cfg);
     api.delete_rum_application(app_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete RUM app: {e:?}"))?;
@@ -85,11 +69,7 @@ pub async fn events_list(
     to: String,
     limit: i32,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => RUMAPI::with_client_and_config(dd_cfg, c),
-        None => RUMAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(RUMAPI, cfg);
 
     let from_dt =
         chrono::DateTime::from_timestamp_millis(util::parse_time_to_unix_millis(&from)?).unwrap();
@@ -118,11 +98,7 @@ pub async fn sessions_search(
     to: String,
     _limit: i32,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => RUMAPI::with_client_and_config(dd_cfg, c),
-        None => RUMAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(RUMAPI, cfg);
 
     let from_str = chrono::DateTime::from_timestamp_millis(util::parse_time_to_unix_millis(&from)?)
         .unwrap()
@@ -148,11 +124,7 @@ pub async fn sessions_search(
 }
 
 pub async fn apps_update(cfg: &Config, app_id: &str, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => RUMAPI::with_client_and_config(dd_cfg, c),
-        None => RUMAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(RUMAPI, cfg);
     let body: RUMApplicationUpdateRequest = crate::util::read_json_file(file)?;
     let resp = api
         .update_rum_application(app_id.to_string(), body)
@@ -164,11 +136,7 @@ pub async fn apps_update(cfg: &Config, app_id: &str, file: &str) -> Result<()> {
 // ---- RUM Metrics ----
 
 pub async fn metrics_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => RumMetricsAPI::with_client_and_config(dd_cfg, c),
-        None => RumMetricsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(RumMetricsAPI, cfg);
     let resp = api
         .list_rum_metrics()
         .await
@@ -177,11 +145,7 @@ pub async fn metrics_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn metrics_get(cfg: &Config, metric_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => RumMetricsAPI::with_client_and_config(dd_cfg, c),
-        None => RumMetricsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(RumMetricsAPI, cfg);
     let resp = api
         .get_rum_metric(metric_id.to_string())
         .await
@@ -190,11 +154,7 @@ pub async fn metrics_get(cfg: &Config, metric_id: &str) -> Result<()> {
 }
 
 pub async fn metrics_create(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => RumMetricsAPI::with_client_and_config(dd_cfg, c),
-        None => RumMetricsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(RumMetricsAPI, cfg);
     let body: RumMetricCreateRequest = crate::util::read_json_file(file)?;
     let resp = api
         .create_rum_metric(body)
@@ -204,11 +164,7 @@ pub async fn metrics_create(cfg: &Config, file: &str) -> Result<()> {
 }
 
 pub async fn metrics_update(cfg: &Config, metric_id: &str, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => RumMetricsAPI::with_client_and_config(dd_cfg, c),
-        None => RumMetricsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(RumMetricsAPI, cfg);
     let body: RumMetricUpdateRequest = crate::util::read_json_file(file)?;
     let resp = api
         .update_rum_metric(metric_id.to_string(), body)
@@ -218,11 +174,7 @@ pub async fn metrics_update(cfg: &Config, metric_id: &str, file: &str) -> Result
 }
 
 pub async fn metrics_delete(cfg: &Config, metric_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => RumMetricsAPI::with_client_and_config(dd_cfg, c),
-        None => RumMetricsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(RumMetricsAPI, cfg);
     api.delete_rum_metric(metric_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete RUM metric: {e:?}"))?;
@@ -233,11 +185,7 @@ pub async fn metrics_delete(cfg: &Config, metric_id: &str) -> Result<()> {
 // ---- RUM Retention Filters ----
 
 pub async fn retention_filters_list(cfg: &Config, app_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => RumRetentionFiltersAPI::with_client_and_config(dd_cfg, c),
-        None => RumRetentionFiltersAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(RumRetentionFiltersAPI, cfg);
     let resp = api
         .list_retention_filters(app_id.to_string())
         .await
@@ -246,11 +194,7 @@ pub async fn retention_filters_list(cfg: &Config, app_id: &str) -> Result<()> {
 }
 
 pub async fn retention_filters_get(cfg: &Config, app_id: &str, filter_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => RumRetentionFiltersAPI::with_client_and_config(dd_cfg, c),
-        None => RumRetentionFiltersAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(RumRetentionFiltersAPI, cfg);
     let resp = api
         .get_retention_filter(app_id.to_string(), filter_id.to_string())
         .await
@@ -259,11 +203,7 @@ pub async fn retention_filters_get(cfg: &Config, app_id: &str, filter_id: &str) 
 }
 
 pub async fn retention_filters_create(cfg: &Config, app_id: &str, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => RumRetentionFiltersAPI::with_client_and_config(dd_cfg, c),
-        None => RumRetentionFiltersAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(RumRetentionFiltersAPI, cfg);
     let body: RumRetentionFilterCreateRequest = crate::util::read_json_file(file)?;
     let resp = api
         .create_retention_filter(app_id.to_string(), body)
@@ -278,11 +218,7 @@ pub async fn retention_filters_update(
     filter_id: &str,
     file: &str,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => RumRetentionFiltersAPI::with_client_and_config(dd_cfg, c),
-        None => RumRetentionFiltersAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(RumRetentionFiltersAPI, cfg);
     let body: RumRetentionFilterUpdateRequest = crate::util::read_json_file(file)?;
     let resp = api
         .update_retention_filter(app_id.to_string(), filter_id.to_string(), body)
@@ -292,11 +228,7 @@ pub async fn retention_filters_update(
 }
 
 pub async fn retention_filters_delete(cfg: &Config, app_id: &str, filter_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => RumRetentionFiltersAPI::with_client_and_config(dd_cfg, c),
-        None => RumRetentionFiltersAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(RumRetentionFiltersAPI, cfg);
     api.delete_retention_filter(app_id.to_string(), filter_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete RUM retention filter: {e:?}"))?;
@@ -307,11 +239,7 @@ pub async fn retention_filters_delete(cfg: &Config, app_id: &str, filter_id: &st
 // ---- RUM Sessions ----
 
 pub async fn sessions_list(cfg: &Config, from: String, to: String, limit: i32) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => RUMAPI::with_client_and_config(dd_cfg, c),
-        None => RUMAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(RUMAPI, cfg);
 
     let from_str = chrono::DateTime::from_timestamp_millis(util::parse_time_to_unix_millis(&from)?)
         .unwrap()
@@ -340,11 +268,7 @@ pub async fn sessions_list(cfg: &Config, from: String, to: String, limit: i32) -
 // ---- RUM Playlists ----
 
 pub async fn playlists_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => RumReplayPlaylistsAPI::with_client_and_config(dd_cfg, c),
-        None => RumReplayPlaylistsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(RumReplayPlaylistsAPI, cfg);
     let resp = api
         .list_rum_replay_playlists(ListRumReplayPlaylistsOptionalParams::default())
         .await
@@ -353,11 +277,7 @@ pub async fn playlists_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn playlists_get(cfg: &Config, playlist_id: i32) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => RumReplayPlaylistsAPI::with_client_and_config(dd_cfg, c),
-        None => RumReplayPlaylistsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(RumReplayPlaylistsAPI, cfg);
     let resp = api
         .get_rum_replay_playlist(playlist_id)
         .await
@@ -368,11 +288,7 @@ pub async fn playlists_get(cfg: &Config, playlist_id: i32) -> Result<()> {
 // ---- RUM Heatmaps ----
 
 pub async fn heatmaps_query(cfg: &Config, view_name: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => RumReplayHeatmapsAPI::with_client_and_config(dd_cfg, c),
-        None => RumReplayHeatmapsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(RumReplayHeatmapsAPI, cfg);
     let resp = api
         .list_replay_heatmap_snapshots(
             view_name.to_string(),

--- a/src/commands/scorecards.rs
+++ b/src/commands/scorecards.rs
@@ -6,17 +6,12 @@ use datadog_api_client::datadogV2::api_scorecards::{
 };
 use datadog_api_client::datadogV2::model::{CreateCampaignRequest, UpdateCampaignRequest};
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
 fn make_api(cfg: &Config) -> ScorecardsAPI {
-    let dd_cfg = client::make_dd_config(cfg);
-    match client::make_bearer_client(cfg) {
-        Some(c) => ScorecardsAPI::with_client_and_config(dd_cfg, c),
-        None => ScorecardsAPI::with_config(dd_cfg),
-    }
+    crate::make_api!(ScorecardsAPI, cfg)
 }
 
 pub async fn rules_list(cfg: &Config) -> Result<()> {

--- a/src/commands/seats.rs
+++ b/src/commands/seats.rs
@@ -2,17 +2,12 @@ use anyhow::Result;
 use datadog_api_client::datadogV2::api_seats::{GetSeatsUsersOptionalParams, SeatsAPI};
 use datadog_api_client::datadogV2::model::{AssignSeatsUserRequest, UnassignSeatsUserRequest};
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
 fn make_api(cfg: &Config) -> SeatsAPI {
-    let dd_cfg = client::make_dd_config(cfg);
-    match client::make_bearer_client(cfg) {
-        Some(c) => SeatsAPI::with_client_and_config(dd_cfg, c),
-        None => SeatsAPI::with_config(dd_cfg),
-    }
+    crate::make_api!(SeatsAPI, cfg)
 }
 
 pub async fn users_list(cfg: &Config, product: &str, limit: i32) -> Result<()> {

--- a/src/commands/security.rs
+++ b/src/commands/security.rs
@@ -167,11 +167,7 @@ pub async fn findings_analyze(
 }
 
 pub async fn rules_list(cfg: &Config, filter: Option<String>, sort: Option<String>) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SecurityMonitoringAPI::with_client_and_config(dd_cfg, c),
-        None => SecurityMonitoringAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SecurityMonitoringAPI, cfg);
     let mut params = ListSecurityMonitoringRulesOptionalParams::default();
     if let Some(s) = sort {
         params = params.sort(parse_rule_sort(&s));
@@ -207,11 +203,7 @@ fn parse_rule_sort(s: &str) -> SecurityMonitoringRuleSort {
 }
 
 pub async fn rules_get(cfg: &Config, rule_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SecurityMonitoringAPI::with_client_and_config(dd_cfg, c),
-        None => SecurityMonitoringAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SecurityMonitoringAPI, cfg);
     let resp = api
         .get_security_monitoring_rule(rule_id.to_string())
         .await
@@ -226,11 +218,7 @@ pub async fn signals_search(
     to: String,
     limit: i32,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SecurityMonitoringAPI::with_client_and_config(dd_cfg, c),
-        None => SecurityMonitoringAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SecurityMonitoringAPI, cfg);
 
     let from_dt =
         chrono::DateTime::from_timestamp_millis(util::parse_time_to_unix_millis(&from)?).unwrap();
@@ -256,11 +244,7 @@ pub async fn signals_search(
 }
 
 pub async fn signals_investigation_queries(cfg: &Config, signal_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SecurityMonitoringAPI::with_client_and_config(dd_cfg, c),
-        None => SecurityMonitoringAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SecurityMonitoringAPI, cfg);
     let resp = api
         .get_investigation_log_queries_matching_signal(signal_id.to_string())
         .await
@@ -273,11 +257,7 @@ pub async fn signals_investigation_queries(cfg: &Config, signal_id: &str) -> Res
 }
 
 pub async fn signals_suggested_actions(cfg: &Config, signal_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SecurityMonitoringAPI::with_client_and_config(dd_cfg, c),
-        None => SecurityMonitoringAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SecurityMonitoringAPI, cfg);
     let resp = api
         .get_suggested_actions_matching_signal(signal_id.to_string())
         .await
@@ -288,11 +268,7 @@ pub async fn signals_suggested_actions(cfg: &Config, signal_id: &str) -> Result<
 }
 
 pub async fn findings_search(cfg: &Config, query: Option<String>, limit: i64) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SecurityMonitoringAPI::with_client_and_config(dd_cfg, c),
-        None => SecurityMonitoringAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SecurityMonitoringAPI, cfg);
     let mut params = ListFindingsOptionalParams::default().page_limit(limit);
     if let Some(q) = query {
         params = params.filter_tags(q);
@@ -307,11 +283,7 @@ pub async fn findings_search(cfg: &Config, query: Option<String>, limit: i64) ->
 // ---- Bulk Export ----
 
 pub async fn rules_bulk_export(cfg: &Config, rule_ids: Vec<String>) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SecurityMonitoringAPI::with_client_and_config(dd_cfg, c),
-        None => SecurityMonitoringAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SecurityMonitoringAPI, cfg);
     let attrs = SecurityMonitoringRuleBulkExportAttributes::new(rule_ids);
     let data = SecurityMonitoringRuleBulkExportData::new(
         attrs,
@@ -331,11 +303,7 @@ pub async fn rules_bulk_export(cfg: &Config, rule_ids: Vec<String>) -> Result<()
 // ---- Content Packs ----
 
 pub async fn content_packs_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SecurityMonitoringAPI::with_client_and_config(dd_cfg, c),
-        None => SecurityMonitoringAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SecurityMonitoringAPI, cfg);
     let resp = api
         .get_content_packs_states()
         .await
@@ -344,11 +312,7 @@ pub async fn content_packs_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn content_packs_activate(cfg: &Config, pack_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SecurityMonitoringAPI::with_client_and_config(dd_cfg, c),
-        None => SecurityMonitoringAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SecurityMonitoringAPI, cfg);
     api.activate_content_pack(pack_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to activate content pack: {e:?}"))?;
@@ -357,11 +321,7 @@ pub async fn content_packs_activate(cfg: &Config, pack_id: &str) -> Result<()> {
 }
 
 pub async fn content_packs_deactivate(cfg: &Config, pack_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SecurityMonitoringAPI::with_client_and_config(dd_cfg, c),
-        None => SecurityMonitoringAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SecurityMonitoringAPI, cfg);
     api.deactivate_content_pack(pack_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to deactivate content pack: {e:?}"))?;
@@ -372,11 +332,7 @@ pub async fn content_packs_deactivate(cfg: &Config, pack_id: &str) -> Result<()>
 // ---- Risk Scores ----
 
 pub async fn risk_scores_list(cfg: &Config, query: Option<String>) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => EntityRiskScoresAPI::with_client_and_config(dd_cfg, c),
-        None => EntityRiskScoresAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(EntityRiskScoresAPI, cfg);
     let mut params = ListEntityRiskScoresOptionalParams::default();
     if let Some(q) = query {
         params = params.filter_query(q);
@@ -408,11 +364,7 @@ fn parse_suppression_sort(s: &str) -> SecurityMonitoringSuppressionSort {
 }
 
 pub async fn suppressions_list(cfg: &Config, sort: Option<String>) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SecurityMonitoringAPI::with_client_and_config(dd_cfg, c),
-        None => SecurityMonitoringAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SecurityMonitoringAPI, cfg);
     let mut params = ListSecurityMonitoringSuppressionsOptionalParams::default();
     if let Some(s) = sort {
         params = params.sort(parse_suppression_sort(&s));
@@ -425,11 +377,7 @@ pub async fn suppressions_list(cfg: &Config, sort: Option<String>) -> Result<()>
 }
 
 pub async fn suppressions_get(cfg: &Config, suppression_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SecurityMonitoringAPI::with_client_and_config(dd_cfg, c),
-        None => SecurityMonitoringAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SecurityMonitoringAPI, cfg);
     let resp = api
         .get_security_monitoring_suppression(suppression_id.to_string())
         .await
@@ -439,11 +387,7 @@ pub async fn suppressions_get(cfg: &Config, suppression_id: &str) -> Result<()> 
 
 pub async fn suppressions_create(cfg: &Config, file: &str) -> Result<()> {
     let body: SecurityMonitoringSuppressionCreateRequest = util::read_json_file(file)?;
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SecurityMonitoringAPI::with_client_and_config(dd_cfg, c),
-        None => SecurityMonitoringAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SecurityMonitoringAPI, cfg);
     let resp = api
         .create_security_monitoring_suppression(body)
         .await
@@ -453,11 +397,7 @@ pub async fn suppressions_create(cfg: &Config, file: &str) -> Result<()> {
 
 pub async fn suppressions_update(cfg: &Config, suppression_id: &str, file: &str) -> Result<()> {
     let body: SecurityMonitoringSuppressionUpdateRequest = util::read_json_file(file)?;
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SecurityMonitoringAPI::with_client_and_config(dd_cfg, c),
-        None => SecurityMonitoringAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SecurityMonitoringAPI, cfg);
     let resp = api
         .update_security_monitoring_suppression(suppression_id.to_string(), body)
         .await
@@ -466,11 +406,7 @@ pub async fn suppressions_update(cfg: &Config, suppression_id: &str, file: &str)
 }
 
 pub async fn suppressions_delete(cfg: &Config, suppression_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SecurityMonitoringAPI::with_client_and_config(dd_cfg, c),
-        None => SecurityMonitoringAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SecurityMonitoringAPI, cfg);
     api.delete_security_monitoring_suppression(suppression_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete suppression: {e:?}"))?;
@@ -480,11 +416,7 @@ pub async fn suppressions_delete(cfg: &Config, suppression_id: &str) -> Result<(
 
 pub async fn suppressions_validate(cfg: &Config, file: &str) -> Result<()> {
     let body: SecurityMonitoringSuppressionCreateRequest = util::read_json_file(file)?;
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SecurityMonitoringAPI::with_client_and_config(dd_cfg, c),
-        None => SecurityMonitoringAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SecurityMonitoringAPI, cfg);
     api.validate_security_monitoring_suppression(body)
         .await
         .map_err(|e| anyhow::anyhow!("failed to validate suppression: {e:?}"))?;

--- a/src/commands/service_catalog.rs
+++ b/src/commands/service_catalog.rs
@@ -3,16 +3,11 @@ use datadog_api_client::datadogV2::api_service_definition::{
     GetServiceDefinitionOptionalParams, ListServiceDefinitionsOptionalParams, ServiceDefinitionAPI,
 };
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 
 pub async fn list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceDefinitionAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceDefinitionAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(ServiceDefinitionAPI, cfg);
     let resp = api
         .list_service_definitions(ListServiceDefinitionsOptionalParams::default())
         .await
@@ -21,11 +16,7 @@ pub async fn list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn get(cfg: &Config, service_name: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceDefinitionAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceDefinitionAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(ServiceDefinitionAPI, cfg);
     let resp = api
         .get_service_definition(
             service_name.to_string(),

--- a/src/commands/slos.rs
+++ b/src/commands/slos.rs
@@ -5,7 +5,6 @@ use datadog_api_client::datadogV1::api_service_level_objectives::{
 };
 use datadog_api_client::datadogV1::model::{ServiceLevelObjective, ServiceLevelObjectiveRequest};
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
@@ -18,11 +17,7 @@ pub async fn list(
     limit: Option<i64>,
     offset: Option<i64>,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceLevelObjectivesAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceLevelObjectivesAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(ServiceLevelObjectivesAPI, cfg);
     let mut params = ListSLOsOptionalParams::default();
     if let Some(query) = query {
         params = params.query(query);
@@ -47,11 +42,7 @@ pub async fn list(
 }
 
 pub async fn get(cfg: &Config, id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceLevelObjectivesAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceLevelObjectivesAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(ServiceLevelObjectivesAPI, cfg);
     let resp = api
         .get_slo(id.to_string(), GetSLOOptionalParams::default())
         .await
@@ -61,11 +52,7 @@ pub async fn get(cfg: &Config, id: &str) -> Result<()> {
 
 pub async fn create(cfg: &Config, file: &str) -> Result<()> {
     let body: ServiceLevelObjectiveRequest = util::read_json_file(file)?;
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceLevelObjectivesAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceLevelObjectivesAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(ServiceLevelObjectivesAPI, cfg);
     let resp = api
         .create_slo(body)
         .await
@@ -75,11 +62,7 @@ pub async fn create(cfg: &Config, file: &str) -> Result<()> {
 
 pub async fn update(cfg: &Config, id: &str, file: &str) -> Result<()> {
     let body: ServiceLevelObjective = util::read_json_file(file)?;
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceLevelObjectivesAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceLevelObjectivesAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(ServiceLevelObjectivesAPI, cfg);
     let resp = api
         .update_slo(id.to_string(), body)
         .await
@@ -88,11 +71,7 @@ pub async fn update(cfg: &Config, id: &str, file: &str) -> Result<()> {
 }
 
 pub async fn delete(cfg: &Config, id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceLevelObjectivesAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceLevelObjectivesAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(ServiceLevelObjectivesAPI, cfg);
     let resp = api
         .delete_slo(id.to_string(), DeleteSLOOptionalParams::default())
         .await
@@ -105,11 +84,7 @@ pub async fn status(cfg: &Config, id: &str, from_ts: i64, to_ts: i64) -> Result<
         GetSloStatusOptionalParams, ServiceLevelObjectivesAPI as SloV2API,
     };
 
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SloV2API::with_client_and_config(dd_cfg, c),
-        None => SloV2API::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SloV2API, cfg);
     let resp = api
         .get_slo_status(
             id.to_string(),

--- a/src/commands/software_catalog.rs
+++ b/src/commands/software_catalog.rs
@@ -5,7 +5,6 @@ use datadog_api_client::datadogV2::api_software_catalog::{
 };
 use datadog_api_client::datadogV2::model::{UpsertCatalogEntityRequest, UpsertCatalogKindRequest};
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
@@ -17,11 +16,7 @@ pub async fn entities_list(
     filter_owner: Option<String>,
     filter_ref: Option<String>,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SoftwareCatalogAPI::with_client_and_config(dd_cfg, c),
-        None => SoftwareCatalogAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SoftwareCatalogAPI, cfg);
     let mut params = ListCatalogEntityOptionalParams::default();
     if let Some(v) = &filter_kind {
         params = params.filter_kind(v.clone());
@@ -62,11 +57,7 @@ pub async fn entities_list(
 }
 
 pub async fn entities_upsert(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SoftwareCatalogAPI::with_client_and_config(dd_cfg, c),
-        None => SoftwareCatalogAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SoftwareCatalogAPI, cfg);
     let body = util::read_json_file::<UpsertCatalogEntityRequest>(file)?;
     let resp = api
         .upsert_catalog_entity(body)
@@ -76,11 +67,7 @@ pub async fn entities_upsert(cfg: &Config, file: &str) -> Result<()> {
 }
 
 pub async fn entities_delete(cfg: &Config, entity_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SoftwareCatalogAPI::with_client_and_config(dd_cfg, c),
-        None => SoftwareCatalogAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SoftwareCatalogAPI, cfg);
     api.delete_catalog_entity(entity_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete catalog entity: {e:?}"))?;
@@ -89,11 +76,7 @@ pub async fn entities_delete(cfg: &Config, entity_id: &str) -> Result<()> {
 }
 
 pub async fn kinds_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SoftwareCatalogAPI::with_client_and_config(dd_cfg, c),
-        None => SoftwareCatalogAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SoftwareCatalogAPI, cfg);
     let resp = api
         .list_catalog_kind(ListCatalogKindOptionalParams::default())
         .await
@@ -102,11 +85,7 @@ pub async fn kinds_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn kinds_upsert(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SoftwareCatalogAPI::with_client_and_config(dd_cfg, c),
-        None => SoftwareCatalogAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SoftwareCatalogAPI, cfg);
     let body = util::read_json_file::<UpsertCatalogKindRequest>(file)?;
     let resp = api
         .upsert_catalog_kind(body)
@@ -116,11 +95,7 @@ pub async fn kinds_upsert(cfg: &Config, file: &str) -> Result<()> {
 }
 
 pub async fn kinds_delete(cfg: &Config, kind_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SoftwareCatalogAPI::with_client_and_config(dd_cfg, c),
-        None => SoftwareCatalogAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SoftwareCatalogAPI, cfg);
     api.delete_catalog_kind(kind_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete catalog kind: {e:?}"))?;
@@ -129,11 +104,7 @@ pub async fn kinds_delete(cfg: &Config, kind_id: &str) -> Result<()> {
 }
 
 pub async fn relations_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SoftwareCatalogAPI::with_client_and_config(dd_cfg, c),
-        None => SoftwareCatalogAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SoftwareCatalogAPI, cfg);
     let resp = api
         .list_catalog_relation(ListCatalogRelationOptionalParams::default())
         .await
@@ -142,11 +113,7 @@ pub async fn relations_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn entities_preview(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SoftwareCatalogAPI::with_client_and_config(dd_cfg, c),
-        None => SoftwareCatalogAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SoftwareCatalogAPI, cfg);
     let resp = api
         .preview_catalog_entities()
         .await

--- a/src/commands/static_analysis.rs
+++ b/src/commands/static_analysis.rs
@@ -3,7 +3,6 @@ use datadog_api_client::datadogV2::api_static_analysis::{
     ListCustomRuleRevisionsOptionalParams, StaticAnalysisAPI,
 };
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
@@ -13,11 +12,7 @@ use crate::util;
 // ---------------------------------------------------------------------------
 
 pub async fn custom_rulesets_get(cfg: &Config, id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => StaticAnalysisAPI::with_client_and_config(dd_cfg, c),
-        None => StaticAnalysisAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(StaticAnalysisAPI, cfg);
     let resp = api
         .get_custom_ruleset(id.to_string())
         .await
@@ -26,11 +21,7 @@ pub async fn custom_rulesets_get(cfg: &Config, id: &str) -> Result<()> {
 }
 
 pub async fn custom_rulesets_update(cfg: &Config, ruleset_name: &str, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => StaticAnalysisAPI::with_client_and_config(dd_cfg, c),
-        None => StaticAnalysisAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(StaticAnalysisAPI, cfg);
     let body = util::read_json_file(file)?;
     let resp = api
         .update_custom_ruleset(ruleset_name.to_string(), body)
@@ -40,11 +31,7 @@ pub async fn custom_rulesets_update(cfg: &Config, ruleset_name: &str, file: &str
 }
 
 pub async fn custom_rulesets_delete(cfg: &Config, ruleset_name: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => StaticAnalysisAPI::with_client_and_config(dd_cfg, c),
-        None => StaticAnalysisAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(StaticAnalysisAPI, cfg);
     api.delete_custom_ruleset(ruleset_name.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete custom ruleset: {e:?}"))?;
@@ -57,11 +44,7 @@ pub async fn custom_rulesets_delete(cfg: &Config, ruleset_name: &str) -> Result<
 // ---------------------------------------------------------------------------
 
 pub async fn custom_rules_get(cfg: &Config, ruleset_name: &str, rule_name: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => StaticAnalysisAPI::with_client_and_config(dd_cfg, c),
-        None => StaticAnalysisAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(StaticAnalysisAPI, cfg);
     let resp = api
         .get_custom_rule(ruleset_name.to_string(), rule_name.to_string())
         .await
@@ -70,11 +53,7 @@ pub async fn custom_rules_get(cfg: &Config, ruleset_name: &str, rule_name: &str)
 }
 
 pub async fn custom_rules_create(cfg: &Config, ruleset_name: &str, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => StaticAnalysisAPI::with_client_and_config(dd_cfg, c),
-        None => StaticAnalysisAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(StaticAnalysisAPI, cfg);
     let body = util::read_json_file(file)?;
     let resp = api
         .create_custom_rule(ruleset_name.to_string(), body)
@@ -84,11 +63,7 @@ pub async fn custom_rules_create(cfg: &Config, ruleset_name: &str, file: &str) -
 }
 
 pub async fn custom_rules_delete(cfg: &Config, ruleset_name: &str, rule_name: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => StaticAnalysisAPI::with_client_and_config(dd_cfg, c),
-        None => StaticAnalysisAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(StaticAnalysisAPI, cfg);
     api.delete_custom_rule(ruleset_name.to_string(), rule_name.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete custom rule: {e:?}"))?;
@@ -101,11 +76,7 @@ pub async fn custom_rule_revisions_list(
     ruleset_name: &str,
     rule_name: &str,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => StaticAnalysisAPI::with_client_and_config(dd_cfg, c),
-        None => StaticAnalysisAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(StaticAnalysisAPI, cfg);
     let resp = api
         .list_custom_rule_revisions(
             ruleset_name.to_string(),
@@ -123,11 +94,7 @@ pub async fn custom_rule_revision_get(
     rule_name: &str,
     revision_id: &str,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => StaticAnalysisAPI::with_client_and_config(dd_cfg, c),
-        None => StaticAnalysisAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(StaticAnalysisAPI, cfg);
     let resp = api
         .get_custom_rule_revision(
             ruleset_name.to_string(),

--- a/src/commands/status_pages.rs
+++ b/src/commands/status_pages.rs
@@ -1,4 +1,3 @@
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
@@ -23,11 +22,7 @@ use datadog_api_client::datadogV2::model::{
 // ---------------------------------------------------------------------------
 
 fn make_api(cfg: &Config) -> StatusPagesAPI {
-    let dd_cfg = client::make_dd_config(cfg);
-    match client::make_bearer_client(cfg) {
-        Some(c) => StatusPagesAPI::with_client_and_config(dd_cfg, c),
-        None => StatusPagesAPI::with_config(dd_cfg),
-    }
+    crate::make_api!(StatusPagesAPI, cfg)
 }
 
 pub async fn pages_list(cfg: &Config) -> Result<()> {

--- a/src/commands/synthetics.rs
+++ b/src/commands/synthetics.rs
@@ -11,7 +11,6 @@ use datadog_api_client::datadogV2::model::{
     DeletedSuitesRequestDeleteRequest, SuiteCreateEditRequest,
 };
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 
@@ -210,11 +209,7 @@ pub async fn tests_run(
 }
 
 pub async fn tests_list(cfg: &Config, page_size: i64, page_number: i64) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SyntheticsAPI::with_client_and_config(dd_cfg, c),
-        None => SyntheticsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SyntheticsAPI, cfg);
     let resp = api
         .list_tests(
             ListTestsOptionalParams::default()
@@ -227,11 +222,7 @@ pub async fn tests_list(cfg: &Config, page_size: i64, page_number: i64) -> Resul
 }
 
 pub async fn tests_get(cfg: &Config, public_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SyntheticsAPI::with_client_and_config(dd_cfg, c),
-        None => SyntheticsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SyntheticsAPI, cfg);
     let resp = api
         .get_test(public_id.to_string())
         .await
@@ -248,11 +239,7 @@ pub async fn tests_search(
     start: i64,
     sort: Option<String>,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SyntheticsAPI::with_client_and_config(dd_cfg, c),
-        None => SyntheticsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SyntheticsAPI, cfg);
 
     let mut params = SearchTestsOptionalParams::default();
     if let Some(t) = text {
@@ -282,11 +269,7 @@ pub async fn tests_search(
 }
 
 pub async fn locations_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SyntheticsAPI::with_client_and_config(dd_cfg, c),
-        None => SyntheticsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SyntheticsAPI, cfg);
     let resp = api
         .list_locations()
         .await
@@ -297,11 +280,7 @@ pub async fn locations_list(cfg: &Config) -> Result<()> {
 // ---- Suites (V2 API) ----
 
 pub async fn suites_list(cfg: &Config, query: Option<String>) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SyntheticsV2API::with_client_and_config(dd_cfg, c),
-        None => SyntheticsV2API::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SyntheticsV2API, cfg);
     let mut params = SearchSuitesOptionalParams::default();
     if let Some(q) = query {
         params = params.query(q);
@@ -314,11 +293,7 @@ pub async fn suites_list(cfg: &Config, query: Option<String>) -> Result<()> {
 }
 
 pub async fn suites_get(cfg: &Config, suite_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SyntheticsV2API::with_client_and_config(dd_cfg, c),
-        None => SyntheticsV2API::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SyntheticsV2API, cfg);
     let resp = api
         .get_synthetics_suite(suite_id.to_string())
         .await
@@ -327,11 +302,7 @@ pub async fn suites_get(cfg: &Config, suite_id: &str) -> Result<()> {
 }
 
 pub async fn suites_create(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SyntheticsV2API::with_client_and_config(dd_cfg, c),
-        None => SyntheticsV2API::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SyntheticsV2API, cfg);
     let body: SuiteCreateEditRequest = crate::util::read_json_file(file)?;
     let resp = api
         .create_synthetics_suite(body)
@@ -341,11 +312,7 @@ pub async fn suites_create(cfg: &Config, file: &str) -> Result<()> {
 }
 
 pub async fn suites_update(cfg: &Config, suite_id: &str, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SyntheticsV2API::with_client_and_config(dd_cfg, c),
-        None => SyntheticsV2API::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SyntheticsV2API, cfg);
     let body: SuiteCreateEditRequest = crate::util::read_json_file(file)?;
     let resp = api
         .edit_synthetics_suite(suite_id.to_string(), body)
@@ -355,11 +322,7 @@ pub async fn suites_update(cfg: &Config, suite_id: &str, file: &str) -> Result<(
 }
 
 pub async fn suites_delete(cfg: &Config, suite_ids: Vec<String>) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SyntheticsV2API::with_client_and_config(dd_cfg, c),
-        None => SyntheticsV2API::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SyntheticsV2API, cfg);
     let attrs = DeletedSuitesRequestDeleteAttributes::new(suite_ids);
     let data = DeletedSuitesRequestDelete::new(attrs);
     let body = DeletedSuitesRequestDeleteRequest::new(data);
@@ -373,11 +336,7 @@ pub async fn suites_delete(cfg: &Config, suite_ids: Vec<String>) -> Result<()> {
 // ---- Tests (V2 API) ----
 
 pub async fn tests_get_fast_result(cfg: &Config, result_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SyntheticsV2API::with_client_and_config(dd_cfg, c),
-        None => SyntheticsV2API::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SyntheticsV2API, cfg);
     let resp = api
         .get_synthetics_fast_test_result(result_id.to_string())
         .await
@@ -391,11 +350,7 @@ pub async fn tests_get_version(
     version: i64,
     include_change_metadata: bool,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SyntheticsV2API::with_client_and_config(dd_cfg, c),
-        None => SyntheticsV2API::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SyntheticsV2API, cfg);
     let mut params = GetSyntheticsTestVersionOptionalParams::default();
     if include_change_metadata {
         params = params.include_change_metadata(true);
@@ -413,11 +368,7 @@ pub async fn tests_list_versions(
     limit: Option<i64>,
     last_version_number: Option<i64>,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SyntheticsV2API::with_client_and_config(dd_cfg, c),
-        None => SyntheticsV2API::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SyntheticsV2API, cfg);
     let mut params = ListSyntheticsTestVersionsOptionalParams::default();
     if let Some(l) = limit {
         params = params.limit(l);
@@ -435,11 +386,7 @@ pub async fn tests_list_versions(
 // ---- Multistep (V2 API) ----
 
 pub async fn multistep_get_subtests(cfg: &Config, public_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SyntheticsV2API::with_client_and_config(dd_cfg, c),
-        None => SyntheticsV2API::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SyntheticsV2API, cfg);
     let resp = api
         .get_api_multistep_subtests(public_id.to_string())
         .await
@@ -448,11 +395,7 @@ pub async fn multistep_get_subtests(cfg: &Config, public_id: &str) -> Result<()>
 }
 
 pub async fn multistep_get_subtest_parents(cfg: &Config, public_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => SyntheticsV2API::with_client_and_config(dd_cfg, c),
-        None => SyntheticsV2API::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(SyntheticsV2API, cfg);
     let resp = api
         .get_api_multistep_subtest_parents(public_id.to_string())
         .await

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -5,16 +5,11 @@ use datadog_api_client::datadogV1::api_tags::{
 };
 use datadog_api_client::datadogV1::model::HostTags;
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 
 pub async fn list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => TagsAPI::with_client_and_config(dd_cfg, c),
-        None => TagsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(TagsAPI, cfg);
     let resp = api
         .list_host_tags(ListHostTagsOptionalParams::default())
         .await
@@ -23,11 +18,7 @@ pub async fn list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn get(cfg: &Config, hostname: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => TagsAPI::with_client_and_config(dd_cfg, c),
-        None => TagsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(TagsAPI, cfg);
     let resp = api
         .get_host_tags(hostname.to_string(), GetHostTagsOptionalParams::default())
         .await
@@ -36,11 +27,7 @@ pub async fn get(cfg: &Config, hostname: &str) -> Result<()> {
 }
 
 pub async fn add(cfg: &Config, hostname: &str, tags: Vec<String>) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => TagsAPI::with_client_and_config(dd_cfg, c),
-        None => TagsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(TagsAPI, cfg);
     let body = HostTags::new().tags(tags);
     let resp = api
         .create_host_tags(
@@ -54,11 +41,7 @@ pub async fn add(cfg: &Config, hostname: &str, tags: Vec<String>) -> Result<()> 
 }
 
 pub async fn update(cfg: &Config, hostname: &str, tags: Vec<String>) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => TagsAPI::with_client_and_config(dd_cfg, c),
-        None => TagsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(TagsAPI, cfg);
     let body = HostTags::new().tags(tags);
     let resp = api
         .update_host_tags(
@@ -72,11 +55,7 @@ pub async fn update(cfg: &Config, hostname: &str, tags: Vec<String>) -> Result<(
 }
 
 pub async fn delete(cfg: &Config, hostname: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => TagsAPI::with_client_and_config(dd_cfg, c),
-        None => TagsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(TagsAPI, cfg);
     api.delete_host_tags(
         hostname.to_string(),
         DeleteHostTagsOptionalParams::default(),

--- a/src/commands/test_optimization.rs
+++ b/src/commands/test_optimization.rs
@@ -3,18 +3,13 @@ use datadog_api_client::datadogV2::api_test_optimization::{
     SearchFlakyTestsOptionalParams, TestOptimizationAPI,
 };
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 
 // ---- Service Settings ----
 
 pub async fn settings_get(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => TestOptimizationAPI::with_client_and_config(dd_cfg, c),
-        None => TestOptimizationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(TestOptimizationAPI, cfg);
     let body = crate::util::read_json_file(file)?;
     let resp = api
         .get_test_optimization_service_settings(body)
@@ -24,11 +19,7 @@ pub async fn settings_get(cfg: &Config, file: &str) -> Result<()> {
 }
 
 pub async fn settings_update(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => TestOptimizationAPI::with_client_and_config(dd_cfg, c),
-        None => TestOptimizationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(TestOptimizationAPI, cfg);
     let body = crate::util::read_json_file(file)?;
     let resp = api
         .update_test_optimization_service_settings(body)
@@ -40,11 +31,7 @@ pub async fn settings_update(cfg: &Config, file: &str) -> Result<()> {
 }
 
 pub async fn settings_delete(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => TestOptimizationAPI::with_client_and_config(dd_cfg, c),
-        None => TestOptimizationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(TestOptimizationAPI, cfg);
     let body = crate::util::read_json_file(file)?;
     api.delete_test_optimization_service_settings(body)
         .await
@@ -58,11 +45,7 @@ pub async fn settings_delete(cfg: &Config, file: &str) -> Result<()> {
 // ---- Flaky Tests ----
 
 pub async fn flaky_tests_search(cfg: &Config, file: Option<String>) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => TestOptimizationAPI::with_client_and_config(dd_cfg, c),
-        None => TestOptimizationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(TestOptimizationAPI, cfg);
     let params = if let Some(f) = file {
         let body = crate::util::read_json_file(&f)?;
         SearchFlakyTestsOptionalParams::default().body(body)
@@ -88,11 +71,7 @@ pub async fn flaky_tests_search(cfg: &Config, file: Option<String>) -> Result<()
 }
 
 pub async fn flaky_tests_update(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => TestOptimizationAPI::with_client_and_config(dd_cfg, c),
-        None => TestOptimizationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(TestOptimizationAPI, cfg);
     let body = crate::util::read_json_file(file)?;
     let resp = api
         .update_flaky_tests(body)
@@ -104,11 +83,7 @@ pub async fn flaky_tests_update(cfg: &Config, file: &str) -> Result<()> {
 // ---- Flaky Tests Management Policies ----
 
 pub async fn flaky_tests_management_policies_get(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => TestOptimizationAPI::with_client_and_config(dd_cfg, c),
-        None => TestOptimizationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(TestOptimizationAPI, cfg);
     let body = crate::util::read_json_file(file)?;
     let resp = api
         .get_flaky_tests_management_policies(body)
@@ -118,11 +93,7 @@ pub async fn flaky_tests_management_policies_get(cfg: &Config, file: &str) -> Re
 }
 
 pub async fn flaky_tests_management_policies_update(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => TestOptimizationAPI::with_client_and_config(dd_cfg, c),
-        None => TestOptimizationAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(TestOptimizationAPI, cfg);
     let body = crate::util::read_json_file(file)?;
     let resp = api
         .update_flaky_tests_management_policies(body)

--- a/src/commands/traces.rs
+++ b/src/commands/traces.rs
@@ -166,12 +166,7 @@ pub async fn search(
 ) -> Result<()> {
     validate_sort(&sort)?;
 
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = if let Some(bearer_client) = client::make_bearer_client(cfg) {
-        SpansAPI::with_client_and_config(dd_cfg, bearer_client)
-    } else {
-        SpansAPI::with_config(dd_cfg)
-    };
+    let api = crate::make_api!(SpansAPI, cfg);
 
     let from_ms = util::parse_time_to_unix_millis(&from)?;
     let to_ms = util::parse_time_to_unix_millis(&to)?;
@@ -236,12 +231,7 @@ pub async fn aggregate(
 ) -> Result<()> {
     let (agg_fn, metric) = parse_compute(&compute)?;
 
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = if let Some(bearer_client) = client::make_bearer_client(cfg) {
-        SpansAPI::with_client_and_config(dd_cfg, bearer_client)
-    } else {
-        SpansAPI::with_config(dd_cfg)
-    };
+    let api = crate::make_api!(SpansAPI, cfg);
 
     let from_ms = util::parse_time_to_unix_millis(&from)?;
     let to_ms = util::parse_time_to_unix_millis(&to)?;

--- a/src/commands/usage.rs
+++ b/src/commands/usage.rs
@@ -4,17 +4,12 @@ use datadog_api_client::datadogV1::api_usage_metering::{
 };
 use datadog_api_client::datadogV1::model::HourlyUsageAttributionUsageType;
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
 pub async fn summary(cfg: &Config, start: String, end: Option<String>) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => UsageMeteringAPI::with_client_and_config(dd_cfg, c),
-        None => UsageMeteringAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(UsageMeteringAPI, cfg);
 
     let start_dt =
         chrono::DateTime::from_timestamp_millis(util::parse_time_to_unix_millis(&start)?).unwrap();
@@ -34,11 +29,7 @@ pub async fn summary(cfg: &Config, start: String, end: Option<String>) -> Result
 }
 
 pub async fn hourly(cfg: &Config, start: String, end: Option<String>) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => UsageMeteringAPI::with_client_and_config(dd_cfg, c),
-        None => UsageMeteringAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(UsageMeteringAPI, cfg);
 
     let start_dt =
         chrono::DateTime::from_timestamp_millis(util::parse_time_to_unix_millis(&start)?).unwrap();

--- a/src/commands/users.rs
+++ b/src/commands/users.rs
@@ -5,17 +5,12 @@ use datadog_api_client::datadogV2::api_service_accounts::{
 };
 use datadog_api_client::datadogV2::api_users::{ListUsersOptionalParams, UsersAPI};
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
 pub async fn list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => UsersAPI::with_client_and_config(dd_cfg, c),
-        None => UsersAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(UsersAPI, cfg);
     let resp = api
         .list_users(ListUsersOptionalParams::default())
         .await
@@ -24,11 +19,7 @@ pub async fn list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn get(cfg: &Config, id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => UsersAPI::with_client_and_config(dd_cfg, c),
-        None => UsersAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(UsersAPI, cfg);
     let resp = api
         .get_user(id.to_string())
         .await
@@ -37,11 +28,7 @@ pub async fn get(cfg: &Config, id: &str) -> Result<()> {
 }
 
 pub async fn roles_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => RolesAPI::with_client_and_config(dd_cfg, c),
-        None => RolesAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(RolesAPI, cfg);
     let resp = api
         .list_roles(ListRolesOptionalParams::default())
         .await
@@ -50,11 +37,7 @@ pub async fn roles_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn service_accounts_create(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceAccountsAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceAccountsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(ServiceAccountsAPI, cfg);
     let body = util::read_json_file(file)?;
     let resp = api
         .create_service_account(body)
@@ -68,11 +51,7 @@ pub async fn service_account_app_keys_create(
     service_account_id: &str,
     file: &str,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceAccountsAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceAccountsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(ServiceAccountsAPI, cfg);
     let body = util::read_json_file(file)?;
     let resp = api
         .create_service_account_application_key(service_account_id.to_string(), body)
@@ -82,11 +61,7 @@ pub async fn service_account_app_keys_create(
 }
 
 pub async fn service_account_app_keys_list(cfg: &Config, service_account_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceAccountsAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceAccountsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(ServiceAccountsAPI, cfg);
     let resp = api
         .list_service_account_application_keys(
             service_account_id.to_string(),
@@ -102,11 +77,7 @@ pub async fn service_account_app_keys_get(
     service_account_id: &str,
     app_key_id: &str,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceAccountsAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceAccountsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(ServiceAccountsAPI, cfg);
     let resp = api
         .get_service_account_application_key(service_account_id.to_string(), app_key_id.to_string())
         .await
@@ -120,11 +91,7 @@ pub async fn service_account_app_keys_update(
     app_key_id: &str,
     file: &str,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceAccountsAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceAccountsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(ServiceAccountsAPI, cfg);
     let body = util::read_json_file(file)?;
     let resp = api
         .update_service_account_application_key(
@@ -142,11 +109,7 @@ pub async fn service_account_app_keys_delete(
     service_account_id: &str,
     app_key_id: &str,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = match client::make_bearer_client(cfg) {
-        Some(c) => ServiceAccountsAPI::with_client_and_config(dd_cfg, c),
-        None => ServiceAccountsAPI::with_config(dd_cfg),
-    };
+    let api = crate::make_api!(ServiceAccountsAPI, cfg);
     api.delete_service_account_application_key(
         service_account_id.to_string(),
         app_key_id.to_string(),

--- a/src/commands/widgets.rs
+++ b/src/commands/widgets.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use datadog_api_client::datadogV2::api_widgets::{SearchWidgetsOptionalParams, WidgetsAPI};
 use datadog_api_client::datadogV2::model::WidgetExperienceType;
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
@@ -20,11 +19,7 @@ fn parse_experience_type(s: &str) -> Result<WidgetExperienceType> {
 }
 
 fn make_api(cfg: &Config) -> WidgetsAPI {
-    let dd_cfg = client::make_dd_config(cfg);
-    match client::make_bearer_client(cfg) {
-        Some(c) => WidgetsAPI::with_client_and_config(dd_cfg, c),
-        None => WidgetsAPI::with_config(dd_cfg),
-    }
+    crate::make_api!(WidgetsAPI, cfg)
 }
 
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
## Summary
- Extracts the repeated 4-line API client initialization pattern (`make_dd_config` + `match make_bearer_client { Some => with_client_and_config, None => with_config }`) into a single `make_api!(API, cfg)` macro.
- Touches ~297 call sites across `src/commands/`. Pure mechanical refactor, no behavior change - existing test suite is the regression gate.

## Changes
- New `make_api!` macro in `src/client.rs` (exported at the crate root via `#[macro_export]`). Binds `$cfg` to a local first to avoid double-evaluation, then calls the existing `make_dd_config` / `make_bearer_client` helpers.
- Two unit tests for the macro itself in `src/client.rs`, covering both the bearer-token-present and bearer-token-absent branches using `MonitorsAPI`.
- 289 call sites converted via the clean 4-line `match` pattern (both the "helper fn" form with no trailing semicolon and the "inline `let api = match ...`" form).
- 8 additional call sites in `src/commands/monitors.rs` (6) and `src/commands/traces.rs` (2) that used the semantically identical `if let Some(..) = ... { with_client_and_config } else { with_config }` form were also converted.
- Total: 297/297 matching sites converted. No sites skipped.
- `use crate::client;` imports removed from 51 files where the macro is now the only reason `client` was imported. Files that still use `client::raw_*` helpers keep the import.

## Testing
- `cargo fmt --check` - clean
- `cargo clippy --bin pup -- -D warnings` - clean
- `cargo test --bin pup` - 860/860 pass (includes 27 in `client::tests`, 2 of which are new macro tests)

Note: `cargo clippy --all-targets -- -D warnings` reports pre-existing `await_holding_lock` errors in `src/test_commands.rs` that exist on `main` before this branch and are unrelated to this refactor.

---
Generated with [Claude Code](https://claude.com/claude-code)