### PR TITLE
feat(on-call): accept team handle as alternative to UUID

### DIFF
--- a/src/commands/on_call.rs
+++ b/src/commands/on_call.rs
@@ -19,20 +19,13 @@ use datadog_api_client::datadogV2::model::{
     UserTeamRelationships, UserTeamRequest, UserTeamRole, UserTeamType, UserTeamUpdate,
     UserTeamUpdateRequest, UserTeamUserType,
 };
-use regex::Regex;
 
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
-/// Returns true if `s` is a canonical UUID (8-4-4-4-12 lowercase/uppercase hex).
 fn is_uuid(s: &str) -> bool {
-    // Keep the regex simple and exact; accept upper- or lower-case hex.
-    let re = Regex::new(
-        r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
-    )
-    .unwrap();
-    re.is_match(s)
+    uuid::Uuid::parse_str(s).is_ok()
 }
 
 /// Resolve a team identifier that may be either a UUID or a team handle.
@@ -74,11 +67,8 @@ pub(crate) async fn resolve_team_id(cfg: &Config, input: &str) -> Result<String>
     match exact.len() {
         1 => Ok(exact[0].id.clone()),
         0 if total == 0 => Err(anyhow::anyhow!("no team with handle '{input}'")),
-        0 => Err(anyhow::anyhow!(
+        _ => Err(anyhow::anyhow!(
             "no exact handle match for '{input}' ({total} candidates matched substring)"
-        )),
-        n => Err(anyhow::anyhow!(
-            "no exact handle match for '{input}' ({n} candidates matched substring)"
         )),
     }
 }
@@ -105,10 +95,11 @@ pub async fn teams_get(cfg: &Config, team_id: &str) -> Result<()> {
 pub async fn teams_delete(cfg: &Config, team_id: &str) -> Result<()> {
     let resolved = resolve_team_id(cfg, team_id).await?;
     let api = crate::make_api!(TeamsAPI, cfg);
-    api.delete_team(resolved.clone())
+    let msg = format!("Team '{resolved}' deleted successfully.");
+    api.delete_team(resolved)
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete team: {e:?}"))?;
-    println!("Team '{resolved}' deleted successfully.");
+    println!("{msg}");
     Ok(())
 }
 
@@ -204,10 +195,11 @@ pub async fn memberships_update(
 pub async fn memberships_remove(cfg: &Config, team_id: &str, user_id: &str) -> Result<()> {
     let resolved = resolve_team_id(cfg, team_id).await?;
     let api = crate::make_api!(TeamsAPI, cfg);
-    api.delete_team_membership(resolved.clone(), user_id.to_string())
+    let msg = format!("Membership for user {user_id} removed from team {resolved}.");
+    api.delete_team_membership(resolved, user_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to remove membership: {e:?}"))?;
-    println!("Membership for user {user_id} removed from team {resolved}.");
+    println!("{msg}");
     Ok(())
 }
 

--- a/src/commands/on_call.rs
+++ b/src/commands/on_call.rs
@@ -19,10 +19,69 @@ use datadog_api_client::datadogV2::model::{
     UserTeamRelationships, UserTeamRequest, UserTeamRole, UserTeamType, UserTeamUpdate,
     UserTeamUpdateRequest, UserTeamUserType,
 };
+use regex::Regex;
 
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
+
+/// Returns true if `s` is a canonical UUID (8-4-4-4-12 lowercase/uppercase hex).
+fn is_uuid(s: &str) -> bool {
+    // Keep the regex simple and exact; accept upper- or lower-case hex.
+    let re = Regex::new(
+        r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+    )
+    .unwrap();
+    re.is_match(s)
+}
+
+/// Resolve a team identifier that may be either a UUID or a team handle.
+///
+/// If `input` parses as a UUID it is returned as-is (fast path, no API call).
+/// Otherwise, `ListTeams` is called with `filter[keyword]=<input>` and a single
+/// page of size 100. The returned teams are filtered locally for exact
+/// `attributes.handle == input` match; exactly one match returns `Ok(id)`.
+///
+/// Errors out (no silent inference):
+///   - no team matches the keyword at all,
+///   - substring matches exist but none has an exact handle,
+///   - more than one team has an exact handle (defensive; API-side invariant).
+///
+/// Note: the 100-result ceiling is deliberate; we do not loop-paginate.
+/// Handle collisions past page 1 will surface as "no exact match" rather than
+/// hiding a real team; callers can still pass the UUID directly.
+pub(crate) async fn resolve_team_id(cfg: &Config, input: &str) -> Result<String> {
+    if is_uuid(input) {
+        return Ok(input.to_string());
+    }
+
+    let api = crate::make_api!(TeamsAPI, cfg);
+    let params = ListTeamsOptionalParams::default()
+        .filter_keyword(input.to_string())
+        .page_size(100);
+    let resp = api
+        .list_teams(params)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to resolve team handle '{input}': {e:?}"))?;
+
+    let teams = resp.data.unwrap_or_default();
+    let total = teams.len();
+    let exact: Vec<&datadog_api_client::datadogV2::model::Team> = teams
+        .iter()
+        .filter(|t| t.attributes.handle == input)
+        .collect();
+
+    match exact.len() {
+        1 => Ok(exact[0].id.clone()),
+        0 if total == 0 => Err(anyhow::anyhow!("no team with handle '{input}'")),
+        0 => Err(anyhow::anyhow!(
+            "no exact handle match for '{input}' ({total} candidates matched substring)"
+        )),
+        n => Err(anyhow::anyhow!(
+            "no exact handle match for '{input}' ({n} candidates matched substring)"
+        )),
+    }
+}
 
 pub async fn teams_list(cfg: &Config) -> Result<()> {
     let api = crate::make_api!(TeamsAPI, cfg);
@@ -34,20 +93,22 @@ pub async fn teams_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn teams_get(cfg: &Config, team_id: &str) -> Result<()> {
+    let resolved = resolve_team_id(cfg, team_id).await?;
     let api = crate::make_api!(TeamsAPI, cfg);
     let resp = api
-        .get_team(team_id.to_string())
+        .get_team(resolved)
         .await
         .map_err(|e| anyhow::anyhow!("failed to get team: {e:?}"))?;
     formatter::output(cfg, &resp)
 }
 
 pub async fn teams_delete(cfg: &Config, team_id: &str) -> Result<()> {
+    let resolved = resolve_team_id(cfg, team_id).await?;
     let api = crate::make_api!(TeamsAPI, cfg);
-    api.delete_team(team_id.to_string())
+    api.delete_team(resolved.clone())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete team: {e:?}"))?;
-    println!("Team '{team_id}' deleted successfully.");
+    println!("Team '{resolved}' deleted successfully.");
     Ok(())
 }
 
@@ -64,22 +125,24 @@ pub async fn teams_create(cfg: &Config, name: &str, handle: &str) -> Result<()> 
 }
 
 pub async fn teams_update(cfg: &Config, team_id: &str, name: &str, handle: &str) -> Result<()> {
+    let resolved = resolve_team_id(cfg, team_id).await?;
     let api = crate::make_api!(TeamsAPI, cfg);
     let attrs = TeamUpdateAttributes::new(handle.to_string(), name.to_string());
     let data = TeamUpdate::new(attrs, TeamType::TEAM);
     let body = TeamUpdateRequest::new(data);
     let resp = api
-        .update_team(team_id.to_string(), body)
+        .update_team(resolved, body)
         .await
         .map_err(|e| anyhow::anyhow!("failed to update team: {e:?}"))?;
     formatter::output(cfg, &resp)
 }
 
 pub async fn memberships_list(cfg: &Config, team_id: &str, page_size: i64) -> Result<()> {
+    let resolved = resolve_team_id(cfg, team_id).await?;
     let api = crate::make_api!(TeamsAPI, cfg);
     let params = GetTeamMembershipsOptionalParams::default().page_size(page_size);
     let resp = api
-        .get_team_memberships(team_id.to_string(), params)
+        .get_team_memberships(resolved, params)
         .await
         .map_err(|e| anyhow::anyhow!("failed to list memberships: {e:?}"))?;
     formatter::output(cfg, &resp)
@@ -91,6 +154,7 @@ pub async fn memberships_add(
     user_id: &str,
     role: Option<String>,
 ) -> Result<()> {
+    let resolved = resolve_team_id(cfg, team_id).await?;
     let api = crate::make_api!(TeamsAPI, cfg);
     let mut attrs = UserTeamAttributes::new();
     if let Some(r) = role {
@@ -109,7 +173,7 @@ pub async fn memberships_add(
         .relationships(relationships);
     let body = UserTeamRequest::new(data);
     let resp = api
-        .create_team_membership(team_id.to_string(), body)
+        .create_team_membership(resolved, body)
         .await
         .map_err(|e| anyhow::anyhow!("failed to add membership: {e:?}"))?;
     formatter::output(cfg, &resp)
@@ -121,6 +185,7 @@ pub async fn memberships_update(
     user_id: &str,
     role: &str,
 ) -> Result<()> {
+    let resolved = resolve_team_id(cfg, team_id).await?;
     let api = crate::make_api!(TeamsAPI, cfg);
     let team_role = match role.to_lowercase().as_str() {
         "admin" => UserTeamRole::ADMIN,
@@ -130,18 +195,19 @@ pub async fn memberships_update(
     let data = UserTeamUpdate::new(UserTeamType::TEAM_MEMBERSHIPS).attributes(attrs);
     let body = UserTeamUpdateRequest::new(data);
     let resp = api
-        .update_team_membership(team_id.to_string(), user_id.to_string(), body)
+        .update_team_membership(resolved, user_id.to_string(), body)
         .await
         .map_err(|e| anyhow::anyhow!("failed to update membership: {e:?}"))?;
     formatter::output(cfg, &resp)
 }
 
 pub async fn memberships_remove(cfg: &Config, team_id: &str, user_id: &str) -> Result<()> {
+    let resolved = resolve_team_id(cfg, team_id).await?;
     let api = crate::make_api!(TeamsAPI, cfg);
-    api.delete_team_membership(team_id.to_string(), user_id.to_string())
+    api.delete_team_membership(resolved.clone(), user_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to remove membership: {e:?}"))?;
-    println!("Membership for user {user_id} removed from team {team_id}.");
+    println!("Membership for user {user_id} removed from team {resolved}.");
     Ok(())
 }
 
@@ -365,4 +431,36 @@ pub async fn pages_create(cfg: &Config, file: &str) -> Result<()> {
         .await
         .map_err(|e| anyhow::anyhow!("failed to create page: {e:?}"))?;
     formatter::output(cfg, &resp)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_uuid_accepts_canonical() {
+        assert!(is_uuid("00000000-0000-0000-0000-000000000000"));
+        assert!(is_uuid("abcdef01-2345-6789-abcd-ef0123456789"));
+        // Uppercase hex is also valid.
+        assert!(is_uuid("ABCDEF01-2345-6789-ABCD-EF0123456789"));
+    }
+
+    #[test]
+    fn test_is_uuid_rejects_handle() {
+        assert!(!is_uuid("example-team"));
+        assert!(!is_uuid("team-handle-with-dashes"));
+        assert!(!is_uuid(""));
+    }
+
+    #[test]
+    fn test_is_uuid_rejects_wrong_length() {
+        // Too short (last segment is 11 hex chars).
+        assert!(!is_uuid("00000000-0000-0000-0000-00000000000"));
+        // Too long (last segment is 13 hex chars).
+        assert!(!is_uuid("00000000-0000-0000-0000-0000000000000"));
+        // Non-hex character ('g').
+        assert!(!is_uuid("g0000000-0000-0000-0000-000000000000"));
+        // Missing dashes.
+        assert!(!is_uuid("000000000000000000000000000000000000"));
+    }
 }

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -1847,7 +1847,75 @@ async fn test_on_call_teams_get() {
     let mut s = mockito::Server::new_async().await;
     let cfg = test_config(&s.url());
     mock_all(&mut s, r#"{"data": {}}"#).await;
-    let _ = crate::commands::on_call::teams_get(&cfg, "t1").await;
+    // Canonical UUID input takes the fast path in `resolve_team_id`, so
+    // only the `get_team` endpoint needs a mock response.
+    let _ = crate::commands::on_call::teams_get(&cfg, "00000000-0000-0000-0000-000000000000").await;
+    cleanup_env();
+}
+#[tokio::test]
+async fn test_on_call_teams_get_by_handle() {
+    let _lock = lock_env();
+    let mut s = mockito::Server::new_async().await;
+    let cfg = test_config(&s.url());
+    // `resolve_team_id` first calls ListTeams (GET /api/v2/team) with a
+    // keyword filter; we return one team whose handle exactly matches.
+    let list_body = r#"{
+        "data": [
+            {
+                "id": "00000000-0000-0000-0000-000000000000",
+                "type": "team",
+                "attributes": {
+                    "name": "Example Team",
+                    "handle": "example-team",
+                    "description": null,
+                    "avatar": null,
+                    "banner": null,
+                    "visible_modules": null,
+                    "hidden_modules": null,
+                    "created_at": null,
+                    "modified_at": null,
+                    "summary": null,
+                    "link_count": 0,
+                    "user_count": 0,
+                    "team_links": null
+                }
+            }
+        ]
+    }"#;
+    let get_body = r#"{
+        "data": {
+            "id": "00000000-0000-0000-0000-000000000000",
+            "type": "team",
+            "attributes": {
+                "name": "Example Team",
+                "handle": "example-team"
+            }
+        }
+    }"#;
+    // `mockito` picks the first matching mock; `Matcher::Any` on the path
+    // means both GETs resolve here. We register two GET mocks; each mock
+    // is consumed once by default, so ListTeams hits the first, GetTeam
+    // the second.
+    s.mock("GET", mockito::Matcher::Any)
+        .match_query(mockito::Matcher::Any)
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(list_body)
+        .create_async()
+        .await;
+    s.mock("GET", mockito::Matcher::Any)
+        .match_query(mockito::Matcher::Any)
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(get_body)
+        .create_async()
+        .await;
+    let result = crate::commands::on_call::teams_get(&cfg, "example-team").await;
+    assert!(
+        result.is_ok(),
+        "teams_get by handle failed: {:?}",
+        result.err()
+    );
     cleanup_env();
 }
 #[tokio::test]

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -1857,8 +1857,7 @@ async fn test_on_call_teams_get_by_handle() {
     let _lock = lock_env();
     let mut s = mockito::Server::new_async().await;
     let cfg = test_config(&s.url());
-    // `resolve_team_id` first calls ListTeams (GET /api/v2/team) with a
-    // keyword filter; we return one team whose handle exactly matches.
+    // ListTeams keyword-filter response with one exactly-matching handle.
     let list_body = r#"{
         "data": [
             {


### PR DESCRIPTION
## Summary

`pup on-call teams get <id>` and sibling commands today require a team UUID and 404 on handles:

```
$ pup on-call teams get example-team
Error: failed to get team: ResponseError(ResponseContent { status: 404,
  content: "{\"errors\":[\"example-team is not a valid uuid not found\"]}", ... })
```

The handle is the natural identifier users see in Slack, the UI, service catalog, and ownership metadata. This PR accepts either form.

## Change

One new helper in `src/commands/on_call.rs`:

```rust
pub(crate) async fn resolve_team_id(cfg: &Config, input: &str) -> Result<String>
```

If `input` parses as a UUID (via `uuid::Uuid::parse_str`), return it as-is (fast path, no API call). Otherwise, `ListTeams` with `filter[keyword]=<input>`, page size 100, single page, then local exact match on `attributes.handle`.

Routed through the resolver: `teams_get`, `teams_delete`, `teams_update`, `memberships_list`, `memberships_add`, `memberships_update`, `memberships_remove`.

Errors explicitly (no silent inference):

- no team matches the keyword overall → `no team with handle 'X'`
- substring hits exist but none exact → `no exact handle match for 'X' (N candidates matched substring)`

The 100-result page cap is deliberate: a handle fragment matching more than 100 teams is too short to be useful; surfacing it as an error beats loop-paginating and hiding failures. Callers can still pass the UUID directly if they have one.

## Tests

- `test_is_uuid_accepts_canonical`, `test_is_uuid_rejects_handle`, `test_is_uuid_rejects_wrong_length` — unit tests on the UUID check.
- `test_on_call_teams_get_by_handle` — mock-server test exercising `teams_get` through the handle resolver.
- Existing `test_on_call_teams_get` updated to use a canonical-UUID input (exercises the fast path).

All 862 tests pass. `cargo fmt --check` and `cargo clippy --no-deps -- -D warnings` clean.

## Notes

- Follows the `src/commands/on_call.rs` structure already established by #334 (cloud_cost_management) and #388 (on_call_* scopes).
- Depends on the `on_call_read` scope added in #388.
- Intentionally does not generalize the resolver to other entity types (schedules, escalation policies, users) — single-entity scope. If a pattern emerges with a second consumer, a later PR can lift it into `util.rs` as a generic resolver.

## Test plan

- [x] `cargo test` (862 pass)
- [x] `cargo fmt --check`
- [x] `cargo clippy --no-deps -- -D warnings`
- [ ] Reviewer: after merge, confirm `pup on-call teams get <real-handle>` returns the team and the sibling commands (`teams delete/update`, `memberships list/add/update/remove`) accept handles.