### PR TITLE
feat(on-call): add pages get subcommand

### DIFF
--- a/src/commands/on_call.rs
+++ b/src/commands/on_call.rs
@@ -20,6 +20,7 @@ use datadog_api_client::datadogV2::model::{
     UserTeamUpdateRequest, UserTeamUserType,
 };
 
+use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
@@ -425,6 +426,18 @@ pub async fn pages_create(cfg: &Config, file: &str) -> Result<()> {
     formatter::output(cfg, &resp)
 }
 
+/// Fetches a single on-call page by ID.
+///
+/// Uses `client::raw_get` because `datadog-api-client` does not yet
+/// expose a `get_on_call_page` binding.
+pub async fn pages_get(cfg: &Config, page_id: &str) -> Result<()> {
+    let path = format!("/api/v2/on-call/pages/{}", util::percent_encode(page_id));
+    let resp = client::raw_get(cfg, &path, &[])
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to get page: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
 #[cfg(test)]
 mod tests {
     use crate::test_support::*;
@@ -767,6 +780,57 @@ mod tests {
             .await;
         let result = super::notification_rules_list(&cfg, "u1").await;
         assert!(result.is_err(), "expected error on 500 response");
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_on_call_pages_get() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        s.mock("GET", "/api/v2/on-call/pages/12345")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data": {"id": "12345", "type": "pages"}}"#)
+            .create_async()
+            .await;
+        let result = super::pages_get(&cfg, "12345").await;
+        assert!(result.is_ok(), "pages_get failed: {:?}", result.err());
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_on_call_pages_get_not_found() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        s.mock("GET", "/api/v2/on-call/pages/missing")
+            .with_status(404)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors": ["page not found"]}"#)
+            .create_async()
+            .await;
+        let result = super::pages_get(&cfg, "missing").await;
+        assert!(result.is_err(), "expected error on 404 response");
+        cleanup_env();
+    }
+
+    // Uses an ID with reserved URL characters ('/' and '?') so the mock's
+    // path-exact matcher only succeeds if `util::percent_encode` is actually
+    // applied. A refactor that drops the encoder would fail this test.
+    #[tokio::test]
+    async fn test_on_call_pages_get_percent_encodes_id() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        s.mock("GET", "/api/v2/on-call/pages/abc%2Fdef%3Fx")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data": {"id": "abc/def?x", "type": "pages"}}"#)
+            .create_async()
+            .await;
+        let result = super::pages_get(&cfg, "abc/def?x").await;
+        assert!(result.is_ok(), "pages_get failed: {:?}", result.err());
         cleanup_env();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5761,6 +5761,8 @@ enum OnCallPagesActions {
         #[arg(long, help = "Path to JSON file")]
         file: String,
     },
+    /// Get an on-call page by ID
+    Get { page_id: String },
 }
 
 #[derive(Subcommand)]
@@ -11417,6 +11419,9 @@ async fn main_inner() -> anyhow::Result<()> {
                 OnCallActions::Pages { action } => match action {
                     OnCallPagesActions::Create { file } => {
                         commands::on_call::pages_create(&cfg, &file).await?;
+                    }
+                    OnCallPagesActions::Get { page_id } => {
+                        commands::on_call::pages_get(&cfg, &page_id).await?;
                     }
                 },
             }


### PR DESCRIPTION
## Summary

Adds `pup on-call pages get <page_id>` so you can look up an on-call page by ID from the CLI. Today `pup on-call pages` only exposes `create`, which means triaging a page URL from the terminal requires either falling back to the web UI or hand-crafting a `pup api` call.

## Change

New function in `src/commands/on_call.rs`:

```rust
pub async fn pages_get(cfg: &Config, page_id: &str) -> Result<()>
```

Calls `GET /api/v2/on-call/pages/{page_id}` via `client::raw_get` — the typed `datadog-api-client` crate does not yet expose a `get_on_call_page` binding, so this follows the established `raw_get` fallback pattern used elsewhere in the codebase. The full JSON:API response is passed through to `formatter::output`, consistent with how `teams_get` handles its response.

`page_id` is percent-encoded via `util::percent_encode` before being interpolated into the path, matching the existing pattern in `src/commands/cost_ccm.rs` for user-supplied IDs in URLs.

New CLI surface registered as a `Get { page_id: String }` variant on the existing `OnCallPagesActions` enum, with a dispatch arm mirroring `Create`.

## Tests

Two new `mockito`-backed tests in `src/test_commands.rs`:

- `test_pages_get_success` — 200 response with a minimal JSON:API envelope; asserts `pages_get` returns `Ok`.
- `test_pages_get_not_found` — 404 response; asserts `pages_get` returns `Err`.

Both use the existing `mock_get` helper.

## Test plan

- [x] `cargo test` (all existing tests pass + 2 new)
- [x] `cargo fmt --check`
- [x] `cargo clippy --no-deps -- -D warnings`
- [ ] Reviewer: after merge, `pup on-call pages get <real-page-id>` should return the page as JSON.

## Notes

- Does not wrap `acknowledge`/`escalate`/`resolve` — those bindings exist in the typed client and can be added as siblings in a separate PR. Out of scope here.
- Does not add `pages list` — that's part of a broader "add list commands for on-call resources" effort. Out of scope here.