### PR TITLE
docs(notebooks): correct help text — OAuth2 is supported

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1889,8 +1889,8 @@ enum Commands {
     ///   pup notebooks delete 12345
     ///
     /// AUTHENTICATION:
-    ///   Requires API key authentication (DD_API_KEY + DD_APP_KEY).
-    ///   OAuth2 is not supported for this endpoint.
+    ///   Requires OAuth2 (via 'pup auth login') with notebooks_read/notebooks_write
+    ///   scopes, or API key authentication (DD_API_KEY + DD_APP_KEY).
     #[command(verbatim_doc_comment)]
     Notebooks {
         #[command(subcommand)]


### PR DESCRIPTION
## Summary
Fix the AUTHENTICATION block in `pup notebooks --help`, which incorrectly claimed OAuth2 is not supported. OAuth2 with `notebooks_read` / `notebooks_write` scopes works fine — `src/commands/acp.rs` already describes this accurately.

## Changes
- `src/main.rs:1891-1893` — replace the misleading AUTHENTICATION block with phrasing that mirrors the pattern used by other OAuth2 + API-key commands in the same file (e.g. api-keys, containers) and matches the scope reference in `src/commands/acp.rs:6`.

## Testing
- `cargo fmt --check` — clean
- `cargo clippy -- -D warnings` — clean
- `cargo test notebooks` — 2 passed (`client::tests::test_no_fallback_for_notebooks`, `test_commands::test_notebooks_list`)
- No new tests added: this is a pure help-string change and there is no existing help-text test pattern to mirror.

## Related Issues
Closes #406

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)