### PR TITLE
Update datadog-api-client to 0.30.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,8 +820,8 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "datadog-api-client"
-version = "0.29.0"
-source = "git+https://github.com/DataDog/datadog-api-client-rust?rev=d70b186e29175ba7e160fe77091cd8571950c553#d70b186e29175ba7e160fe77091cd8571950c553"
+version = "0.30.0"
+source = "git+https://github.com/DataDog/datadog-api-client-rust?rev=aa0c8416e3af27038cf6a17e74ff1bf11d6bc1a6#aa0c8416e3af27038cf6a17e74ff1bf11d6bc1a6"
 dependencies = [
  "async-stream",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,9 +121,9 @@ ssh-key = { version = "0.6", features = ["p256", "std"], optional = true }
 futures = { version = "0.3", optional = true }
 tokio-util = { version = "0.7", features = ["compat", "io"], optional = true }
 
-# Datadog API client — includes fleet tracers/clusters/instrumented-pods (d70b186e)
+# Datadog API client — pinned to 0.30.0 release tag
 # Use default-features = false; feature sets are activated per-target via features above
-datadog-api-client = { git = "https://github.com/DataDog/datadog-api-client-rust", rev = "d70b186e29175ba7e160fe77091cd8571950c553", optional = true, default-features = false }
+datadog-api-client = { git = "https://github.com/DataDog/datadog-api-client-rust", rev = "aa0c8416e3af27038cf6a17e74ff1bf11d6bc1a6", optional = true, default-features = false }
 
 # HTTP middleware (version-matched to DD client; compiles on all targets)
 reqwest-middleware = "0.5"


### PR DESCRIPTION
## What does this PR do?

Updates datadog-api-client to 0.30.0.
