### PR TITLE
feat(security): add indicators of compromise list/get commands

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -227,6 +227,9 @@ static UNSTABLE_OPS: &[&str] = &[
     "v2.activate_content_pack",
     "v2.deactivate_content_pack",
     "v2.get_content_packs_states",
+    // Indicators of Compromise (2)
+    "v2.list_indicators_of_compromise",
+    "v2.get_indicator_of_compromise",
     // Code Coverage (2)
     "v2.get_code_coverage_branch_summary",
     "v2.get_code_coverage_commit_summary",
@@ -1015,7 +1018,7 @@ mod tests {
 
     #[test]
     fn test_unstable_ops_count() {
-        assert_eq!(UNSTABLE_OPS.len(), 147);
+        assert_eq!(UNSTABLE_OPS.len(), 149);
     }
 
     #[test]

--- a/src/commands/security.rs
+++ b/src/commands/security.rs
@@ -12,8 +12,8 @@ use datadog_api_client::datadogV2::api_restriction_policies::{
     RestrictionPoliciesAPI, UpdateRestrictionPolicyOptionalParams,
 };
 use datadog_api_client::datadogV2::api_security_monitoring::{
-    ListFindingsOptionalParams, ListSecurityMonitoringRulesOptionalParams,
-    ListSecurityMonitoringSuppressionsOptionalParams,
+    ListFindingsOptionalParams, ListIndicatorsOfCompromiseOptionalParams,
+    ListSecurityMonitoringRulesOptionalParams, ListSecurityMonitoringSuppressionsOptionalParams,
     SearchSecurityMonitoringSignalsOptionalParams, SecurityMonitoringAPI,
 };
 use datadog_api_client::datadogV2::model::{
@@ -327,6 +327,49 @@ pub async fn content_packs_deactivate(cfg: &Config, pack_id: &str) -> Result<()>
     Ok(())
 }
 
+// ---- Indicators of Compromise ----
+
+pub async fn iocs_list(
+    cfg: &Config,
+    query: Option<String>,
+    limit: Option<i32>,
+    offset: Option<i32>,
+    sort_column: Option<String>,
+    sort_order: Option<String>,
+) -> Result<()> {
+    let api = crate::make_api!(SecurityMonitoringAPI, cfg);
+    let mut params = ListIndicatorsOfCompromiseOptionalParams::default();
+    if let Some(q) = query {
+        params.query = Some(q);
+    }
+    if let Some(l) = limit {
+        params.limit = Some(l);
+    }
+    if let Some(o) = offset {
+        params.offset = Some(o);
+    }
+    if let Some(c) = sort_column {
+        params.sort_column = Some(c);
+    }
+    if let Some(o) = sort_order {
+        params.sort_order = Some(o);
+    }
+    let resp = api
+        .list_indicators_of_compromise(params)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to list indicators of compromise: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn iocs_get(cfg: &Config, indicator: &str) -> Result<()> {
+    let api = crate::make_api!(SecurityMonitoringAPI, cfg);
+    let resp = api
+        .get_indicator_of_compromise(indicator.to_string())
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to get indicator of compromise: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
 // ---- Risk Scores ----
 
 pub async fn risk_scores_list(cfg: &Config, query: Option<String>) -> Result<()> {
@@ -638,6 +681,95 @@ mod tests {
         mock_all(&mut s, r#"{"data": []}"#).await;
         let _ = super::content_packs_list(&cfg).await;
         cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_security_iocs_list() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = mock_any(&mut server, "GET", r#"{"data":{},"meta":{}}"#).await;
+        let result = super::iocs_list(&cfg, None, None, None, None, None).await;
+        assert!(result.is_ok(), "iocs list failed: {:?}", result.err());
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_security_iocs_list_with_params() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = mock_any(&mut server, "GET", r#"{"data":{},"meta":{}}"#).await;
+        let result = super::iocs_list(
+            &cfg,
+            Some("indicator_type:ip".to_string()),
+            Some(50),
+            Some(100),
+            Some("score".to_string()),
+            Some("desc".to_string()),
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "iocs list with params failed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_security_iocs_list_error() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(403)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors":["Forbidden"]}"#)
+            .create_async()
+            .await;
+        let result = super::iocs_list(&cfg, None, None, None, None, None).await;
+        assert!(result.is_err(), "expected error for 403 response");
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_security_iocs_get() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = mock_any(&mut server, "GET", r#"{"data":{}}"#).await;
+        let result = super::iocs_get(&cfg, "1.2.3.4").await;
+        assert!(result.is_ok(), "iocs get failed: {:?}", result.err());
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_security_iocs_get_not_found() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(404)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors":["Not found"]}"#)
+            .create_async()
+            .await;
+        let result = super::iocs_get(&cfg, "missing").await;
+        assert!(result.is_err(), "expected error for 404 response");
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4362,6 +4362,11 @@ enum SecurityActions {
         #[command(subcommand)]
         action: SecurityContentPackActions,
     },
+    /// Explore indicators of compromise (IoCs)
+    Iocs {
+        #[command(subcommand)]
+        action: SecurityIocActions,
+    },
     /// Manage ASM WAF custom rules
     #[command(name = "asm-custom-rules")]
     AsmCustomRules {
@@ -4535,6 +4540,33 @@ enum SecurityContentPackActions {
     Activate { pack_id: String },
     /// Deactivate a content pack
     Deactivate { pack_id: String },
+}
+
+#[derive(Subcommand)]
+enum SecurityIocActions {
+    /// List indicators of compromise
+    List {
+        /// Search/filter query (supports field:value syntax)
+        #[arg(long)]
+        query: Option<String>,
+        /// Number of results per page
+        #[arg(long)]
+        limit: Option<i32>,
+        /// Pagination offset
+        #[arg(long)]
+        offset: Option<i32>,
+        /// Sort column (score, first_seen_ts_epoch, last_seen_ts_epoch, indicator, indicator_type, signal_count, log_count, category, as_type)
+        #[arg(long = "sort-column")]
+        sort_column: Option<String>,
+        /// Sort order (asc, desc)
+        #[arg(long = "sort-order")]
+        sort_order: Option<String>,
+    },
+    /// Get a single indicator of compromise
+    Get {
+        /// Indicator value (e.g. IP, domain, hash)
+        indicator: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -10565,6 +10597,28 @@ async fn main_inner() -> anyhow::Result<()> {
                     }
                     SecurityContentPackActions::Deactivate { pack_id } => {
                         commands::security::content_packs_deactivate(&cfg, &pack_id).await?;
+                    }
+                },
+                SecurityActions::Iocs { action } => match action {
+                    SecurityIocActions::List {
+                        query,
+                        limit,
+                        offset,
+                        sort_column,
+                        sort_order,
+                    } => {
+                        commands::security::iocs_list(
+                            &cfg,
+                            query,
+                            limit,
+                            offset,
+                            sort_column,
+                            sort_order,
+                        )
+                        .await?;
+                    }
+                    SecurityIocActions::Get { indicator } => {
+                        commands::security::iocs_get(&cfg, &indicator).await?;
                     }
                 },
                 SecurityActions::RiskScores { action } => match action {


### PR DESCRIPTION
## Summary
Expose the new v2 IoC Explorer endpoints (from datadog-api-client 0.30.0) as `pup security iocs list` and `pup security iocs get`. Both are unstable operations and are registered in `UNSTABLE_OPS` so the client enables them automatically.

## Changes
- `src/client.rs`: register `v2.list_indicators_of_compromise` and `v2.get_indicator_of_compromise` in UNSTABLE_OPS; bump count test 147 → 149
- `src/commands/security.rs`: add `iocs_list` and `iocs_get`
- `src/main.rs`: add `SecurityActions::Iocs` variant, `SecurityIocActions` subcommand enum, and match arm

## Commands
```
pup security iocs list [--query ...] [--limit ...] [--offset ...] [--sort-column ...] [--sort-order ...]
pup security iocs get <indicator>
```

## Testing
- 5 new unit tests in `src/commands/security.rs`: happy-path list, list with all params, list 403 error, get, get 404
- `cargo test -- --test-threads=1`: 879/879 pass (874 baseline + 5 new)
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean
- Verified help output: `pup security iocs --help --no-agent`

## Dependencies
Built on top of #419 (datadog-api-client 0.30.0 bump). Once that merges to main, this branch can be rebased and the noise drops out of the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)