### PR TITLE
refactor(util): extract shared parse_compute_raw helper

### DIFF
--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -83,56 +83,6 @@ pub fn split_compute_args(input: &str) -> Vec<String> {
     result
 }
 
-fn parse_compute_raw(input: &str) -> Result<(String, Option<String>)> {
-    let input = input.trim();
-    if input.is_empty() {
-        bail!("--compute is required");
-    }
-
-    if input == "count" {
-        return Ok(("count".into(), None));
-    }
-
-    if let Some(paren) = input.find('(') {
-        let func = &input[..paren];
-        let rest = input[paren + 1..].trim_end_matches(')').trim();
-
-        if func == "percentile" {
-            let parts: Vec<&str> = rest.splitn(2, ',').collect();
-            if parts.len() != 2 {
-                bail!("percentile requires field and value: percentile(@duration, 99)");
-            }
-            let metric = parts[0].trim().to_string();
-            let pct: u32 = parts[1]
-                .trim()
-                .parse()
-                .map_err(|_| anyhow::anyhow!("invalid percentile value: {}", parts[1].trim()))?;
-            let agg_name = match pct {
-                75 => "pc75",
-                90 => "pc90",
-                95 => "pc95",
-                98 => "pc98",
-                99 => "pc99",
-                _ => bail!("unsupported percentile: {pct} (supported: 75, 90, 95, 98, 99)"),
-            };
-            return Ok((agg_name.into(), Some(metric)));
-        }
-
-        let metric = rest.to_string();
-        let agg_name = match func {
-            "avg" | "sum" | "min" | "max" | "median" | "cardinality" => func.to_string(),
-            "count" => bail!("count does not accept a field argument; use just 'count'"),
-            _ => bail!("unknown aggregation function: {func}"),
-        };
-        return Ok((agg_name, Some(metric)));
-    }
-
-    bail!(
-        "invalid --compute format: {input:?}\n\
-         Expected: count, avg(@duration), sum(@duration), percentile(@duration, 99), etc."
-    )
-}
-
 const VALID_SORT_AGGREGATIONS: &[&str] = &[
     "count",
     "cardinality",
@@ -187,7 +137,7 @@ fn build_aggregate_body(
     let compute_arr: Vec<serde_json::Value> = computes
         .iter()
         .map(|c| {
-            let (aggregation, metric) = parse_compute_raw(c)?;
+            let (aggregation, metric) = util::parse_compute_raw(c)?;
             let mut obj = serde_json::json!({ "aggregation": aggregation });
             if let Some(m) = metric {
                 obj["metric"] = serde_json::Value::String(m);
@@ -450,107 +400,6 @@ mod tests {
     use crate::test_support::*;
 
     use super::*;
-
-    #[test]
-    fn test_parse_compute_count() {
-        let (aggregation, metric) = parse_compute_raw("count").unwrap();
-        assert_eq!(aggregation, "count");
-        assert!(metric.is_none());
-    }
-
-    #[test]
-    fn test_parse_compute_avg() {
-        let (aggregation, metric) = parse_compute_raw("avg(@duration)").unwrap();
-        assert_eq!(aggregation, "avg");
-        assert_eq!(metric.unwrap(), "@duration");
-    }
-
-    #[test]
-    fn test_parse_compute_sum() {
-        let (aggregation, metric) = parse_compute_raw("sum(@duration)").unwrap();
-        assert_eq!(aggregation, "sum");
-        assert_eq!(metric.unwrap(), "@duration");
-    }
-
-    #[test]
-    fn test_parse_compute_min() {
-        let (aggregation, metric) = parse_compute_raw("min(@duration)").unwrap();
-        assert_eq!(aggregation, "min");
-        assert_eq!(metric.unwrap(), "@duration");
-    }
-
-    #[test]
-    fn test_parse_compute_max() {
-        let (aggregation, metric) = parse_compute_raw("max(@duration)").unwrap();
-        assert_eq!(aggregation, "max");
-        assert_eq!(metric.unwrap(), "@duration");
-    }
-
-    #[test]
-    fn test_parse_compute_median() {
-        let (aggregation, metric) = parse_compute_raw("median(@duration)").unwrap();
-        assert_eq!(aggregation, "median");
-        assert_eq!(metric.unwrap(), "@duration");
-    }
-
-    #[test]
-    fn test_parse_compute_cardinality() {
-        let (aggregation, metric) = parse_compute_raw("cardinality(@usr.id)").unwrap();
-        assert_eq!(aggregation, "cardinality");
-        assert_eq!(metric.unwrap(), "@usr.id");
-    }
-
-    #[test]
-    fn test_parse_compute_percentile_99() {
-        let (aggregation, metric) = parse_compute_raw("percentile(@duration, 99)").unwrap();
-        assert_eq!(aggregation, "pc99");
-        assert_eq!(metric.unwrap(), "@duration");
-    }
-
-    #[test]
-    fn test_parse_compute_percentile_95() {
-        let (aggregation, metric) = parse_compute_raw("percentile(@duration, 95)").unwrap();
-        assert_eq!(aggregation, "pc95");
-        assert_eq!(metric.unwrap(), "@duration");
-    }
-
-    #[test]
-    fn test_parse_compute_percentile_90() {
-        let (aggregation, metric) = parse_compute_raw("percentile(@duration, 90)").unwrap();
-        assert_eq!(aggregation, "pc90");
-        assert_eq!(metric.unwrap(), "@duration");
-    }
-
-    #[test]
-    fn test_parse_compute_empty() {
-        assert!(parse_compute_raw("").is_err());
-    }
-
-    #[test]
-    fn test_parse_compute_invalid() {
-        assert!(parse_compute_raw("invalid").is_err());
-    }
-
-    #[test]
-    fn test_parse_compute_unknown_function() {
-        assert!(parse_compute_raw("foo(@bar)").is_err());
-    }
-
-    #[test]
-    fn test_parse_compute_unsupported_percentile() {
-        assert!(parse_compute_raw("percentile(@duration, 42)").is_err());
-    }
-
-    #[test]
-    fn test_parse_compute_percentile_missing_value() {
-        assert!(parse_compute_raw("percentile(@duration)").is_err());
-    }
-
-    #[test]
-    fn test_parse_compute_rejects_invalid_count_metric() {
-        let err = parse_compute_raw("count(@duration)").unwrap_err();
-        assert!(err.to_string().contains("does not accept a field"));
-    }
 
     #[test]
     fn test_normalize_storage_tier_alias() {

--- a/src/commands/traces.rs
+++ b/src/commands/traces.rs
@@ -80,64 +80,9 @@ fn validate_sort(sort: &str) -> Result<()> {
     }
 }
 
-/// Parse a compute string like "count", "avg(@duration)", "percentile(@duration, 99)"
-/// into a (function_name, Option<metric>) pair as raw strings.
-fn parse_compute_raw(input: &str) -> Result<(String, Option<String>)> {
-    let input = input.trim();
-    if input.is_empty() {
-        bail!("--compute is required");
-    }
-
-    // Simple aggregations without a metric
-    if input == "count" {
-        return Ok(("count".into(), None));
-    }
-
-    // func(@field) pattern
-    if let Some(paren) = input.find('(') {
-        let func = &input[..paren];
-        let rest = input[paren + 1..].trim_end_matches(')').trim();
-
-        // Handle percentile(@field, N)
-        if func == "percentile" {
-            let parts: Vec<&str> = rest.splitn(2, ',').collect();
-            if parts.len() != 2 {
-                bail!("percentile requires field and value: percentile(@duration, 99)");
-            }
-            let metric = parts[0].trim().to_string();
-            let pct: u32 = parts[1]
-                .trim()
-                .parse()
-                .map_err(|_| anyhow::anyhow!("invalid percentile value: {}", parts[1].trim()))?;
-            let agg_name = match pct {
-                75 => "pc75",
-                90 => "pc90",
-                95 => "pc95",
-                98 => "pc98",
-                99 => "pc99",
-                _ => bail!("unsupported percentile: {pct} (supported: 75, 90, 95, 98, 99)"),
-            };
-            return Ok((agg_name.into(), Some(metric)));
-        }
-
-        let metric = rest.to_string();
-        let agg_name = match func {
-            "avg" | "sum" | "min" | "max" | "median" | "cardinality" => func.to_string(),
-            "count" => bail!("count does not accept a field argument; use just 'count'"),
-            _ => bail!("unknown aggregation function: {func}"),
-        };
-        return Ok((agg_name, Some(metric)));
-    }
-
-    bail!(
-        "invalid --compute format: {input:?}\n\
-         Expected: count, avg(@duration), sum(@duration), percentile(@duration, 99), etc."
-    )
-}
-
 /// Parse a compute string into (SpansAggregationFunction, Option<metric>).
 fn parse_compute(input: &str) -> Result<(SpansAggregationFunction, Option<String>)> {
-    let (func, metric) = parse_compute_raw(input)?;
+    let (func, metric) = util::parse_compute_raw(input)?;
     let agg = match func.as_str() {
         "count" => SpansAggregationFunction::COUNT,
         "avg" => SpansAggregationFunction::AVG,

--- a/src/util.rs
+++ b/src/util.rs
@@ -141,6 +141,61 @@ pub fn parse_uuid(id: &str, label: &str) -> anyhow::Result<uuid::Uuid> {
     uuid::Uuid::parse_str(id).map_err(|e| anyhow::anyhow!("invalid {label} UUID '{id}': {e}"))
 }
 
+/// Parse a compute string like "count", "avg(@duration)", "percentile(@duration, 99)"
+/// into a (function_name, Option<metric>) pair as raw strings.
+pub(crate) fn parse_compute_raw(input: &str) -> Result<(String, Option<String>)> {
+    let input = input.trim();
+    if input.is_empty() {
+        bail!("--compute is required");
+    }
+
+    // Simple aggregations without a metric
+    if input == "count" {
+        return Ok(("count".into(), None));
+    }
+
+    // func(@field) pattern
+    if let Some(paren) = input.find('(') {
+        let func = &input[..paren];
+        let rest = input[paren + 1..].trim_end_matches(')').trim();
+
+        // Handle percentile(@field, N)
+        if func == "percentile" {
+            let parts: Vec<&str> = rest.splitn(2, ',').collect();
+            if parts.len() != 2 {
+                bail!("percentile requires field and value: percentile(@duration, 99)");
+            }
+            let metric = parts[0].trim().to_string();
+            let pct: u32 = parts[1]
+                .trim()
+                .parse()
+                .map_err(|_| anyhow::anyhow!("invalid percentile value: {}", parts[1].trim()))?;
+            let agg_name = match pct {
+                75 => "pc75",
+                90 => "pc90",
+                95 => "pc95",
+                98 => "pc98",
+                99 => "pc99",
+                _ => bail!("unsupported percentile: {pct} (supported: 75, 90, 95, 98, 99)"),
+            };
+            return Ok((agg_name.into(), Some(metric)));
+        }
+
+        let metric = rest.to_string();
+        let agg_name = match func {
+            "avg" | "sum" | "min" | "max" | "median" | "cardinality" => func.to_string(),
+            "count" => bail!("count does not accept a field argument; use just 'count'"),
+            _ => bail!("unknown aggregation function: {func}"),
+        };
+        return Ok((agg_name, Some(metric)));
+    }
+
+    bail!(
+        "invalid --compute format: {input:?}\n\
+         Expected: count, avg(@duration), sum(@duration), percentile(@duration, 99), etc."
+    )
+}
+
 /// Percent-encode a string for safe use in URL paths and query values.
 ///
 /// Unreserved characters (RFC 3986 §2.3) — `A-Z a-z 0-9 - _ . ~` — are
@@ -417,5 +472,106 @@ mod tests {
     #[test]
     fn test_duration_now() {
         assert_eq!(parse_duration_to_millis("now").unwrap(), 0);
+    }
+
+    #[test]
+    fn test_parse_compute_count() {
+        let (aggregation, metric) = parse_compute_raw("count").unwrap();
+        assert_eq!(aggregation, "count");
+        assert!(metric.is_none());
+    }
+
+    #[test]
+    fn test_parse_compute_avg() {
+        let (aggregation, metric) = parse_compute_raw("avg(@duration)").unwrap();
+        assert_eq!(aggregation, "avg");
+        assert_eq!(metric.unwrap(), "@duration");
+    }
+
+    #[test]
+    fn test_parse_compute_sum() {
+        let (aggregation, metric) = parse_compute_raw("sum(@duration)").unwrap();
+        assert_eq!(aggregation, "sum");
+        assert_eq!(metric.unwrap(), "@duration");
+    }
+
+    #[test]
+    fn test_parse_compute_min() {
+        let (aggregation, metric) = parse_compute_raw("min(@duration)").unwrap();
+        assert_eq!(aggregation, "min");
+        assert_eq!(metric.unwrap(), "@duration");
+    }
+
+    #[test]
+    fn test_parse_compute_max() {
+        let (aggregation, metric) = parse_compute_raw("max(@duration)").unwrap();
+        assert_eq!(aggregation, "max");
+        assert_eq!(metric.unwrap(), "@duration");
+    }
+
+    #[test]
+    fn test_parse_compute_median() {
+        let (aggregation, metric) = parse_compute_raw("median(@duration)").unwrap();
+        assert_eq!(aggregation, "median");
+        assert_eq!(metric.unwrap(), "@duration");
+    }
+
+    #[test]
+    fn test_parse_compute_cardinality() {
+        let (aggregation, metric) = parse_compute_raw("cardinality(@usr.id)").unwrap();
+        assert_eq!(aggregation, "cardinality");
+        assert_eq!(metric.unwrap(), "@usr.id");
+    }
+
+    #[test]
+    fn test_parse_compute_percentile_99() {
+        let (aggregation, metric) = parse_compute_raw("percentile(@duration, 99)").unwrap();
+        assert_eq!(aggregation, "pc99");
+        assert_eq!(metric.unwrap(), "@duration");
+    }
+
+    #[test]
+    fn test_parse_compute_percentile_95() {
+        let (aggregation, metric) = parse_compute_raw("percentile(@duration, 95)").unwrap();
+        assert_eq!(aggregation, "pc95");
+        assert_eq!(metric.unwrap(), "@duration");
+    }
+
+    #[test]
+    fn test_parse_compute_percentile_90() {
+        let (aggregation, metric) = parse_compute_raw("percentile(@duration, 90)").unwrap();
+        assert_eq!(aggregation, "pc90");
+        assert_eq!(metric.unwrap(), "@duration");
+    }
+
+    #[test]
+    fn test_parse_compute_empty() {
+        assert!(parse_compute_raw("").is_err());
+    }
+
+    #[test]
+    fn test_parse_compute_invalid() {
+        assert!(parse_compute_raw("invalid").is_err());
+    }
+
+    #[test]
+    fn test_parse_compute_unknown_function() {
+        assert!(parse_compute_raw("foo(@bar)").is_err());
+    }
+
+    #[test]
+    fn test_parse_compute_unsupported_percentile() {
+        assert!(parse_compute_raw("percentile(@duration, 42)").is_err());
+    }
+
+    #[test]
+    fn test_parse_compute_percentile_missing_value() {
+        assert!(parse_compute_raw("percentile(@duration)").is_err());
+    }
+
+    #[test]
+    fn test_parse_compute_rejects_invalid_count_metric() {
+        let err = parse_compute_raw("count(@duration)").unwrap_err();
+        assert!(err.to_string().contains("does not accept a field"));
     }
 }


### PR DESCRIPTION
## Summary
Consolidate the duplicated `parse_compute_raw` parser into `src/util.rs` so `commands/logs.rs` and `commands/traces.rs` share one implementation. The two copies were byte-for-byte equivalent apart from comments.

## Changes
- Add `pub(crate) fn parse_compute_raw` to `src/util.rs` (src/util.rs:146)
- Move the 16 direct positive/negative parser tests from `commands/logs.rs` to `src/util.rs` (src/util.rs:477)
- Replace the local definition in `src/commands/logs.rs` with a call to `util::parse_compute_raw` (src/commands/logs.rs:140)
- Replace the local definition in `src/commands/traces.rs` with a call to `util::parse_compute_raw` (src/commands/traces.rs:85)
- Leave the `parse_compute` wrapper and its `SpansAggregationFunction`-mapping tests in `commands/traces.rs` untouched

## Testing
- `cargo fmt --check` clean
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test` — 874 passed, 0 failed
- Verified `util::tests::test_parse_compute_*` (16) and `commands::traces::tests::test_parse_compute_*` (16) all run and pass

## Related Issues
None — internal cleanup per REVIEW.md §1 (Code Reuse).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)