### PR TITLE
test(keys): add unit tests for api_keys, app_keys, authn_mappings

### DIFF
--- a/src/commands/api_keys.rs
+++ b/src/commands/api_keys.rs
@@ -54,33 +54,151 @@ mod tests {
 
     use crate::test_support::*;
 
+    // -----------------------------------------------------------------------
+    // list()
+    // -----------------------------------------------------------------------
+
     #[tokio::test]
-    async fn test_api_keys_list() {
+    async fn test_api_keys_list_success() {
         let _lock = lock_env().await;
         let mut s = mockito::Server::new_async().await;
         let cfg = test_config(&s.url());
         mock_all(&mut s, r#"{"data": []}"#).await;
-        let _ = super::list(&cfg).await;
+        let result = super::list(&cfg).await;
+        assert!(result.is_ok(), "list should succeed: {:?}", result.err());
         cleanup_env();
     }
 
     #[tokio::test]
-    async fn test_api_keys_get() {
+    async fn test_api_keys_list_error_403() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(403)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors":["Forbidden"]}"#)
+            .create_async()
+            .await;
+        let result = super::list(&cfg).await;
+        assert!(result.is_err(), "expected error on 403");
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("failed to list API keys"),
+            "error should mention failed listing: {err_msg}"
+        );
+        cleanup_env();
+    }
+
+    // -----------------------------------------------------------------------
+    // get()
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_api_keys_get_success() {
         let _lock = lock_env().await;
         let mut s = mockito::Server::new_async().await;
         let cfg = test_config(&s.url());
         mock_all(&mut s, r#"{"data": {}}"#).await;
-        let _ = super::get(&cfg, "k1").await;
+        let result = super::get(&cfg, "key-id-123").await;
+        assert!(result.is_ok(), "get should succeed: {:?}", result.err());
         cleanup_env();
     }
 
     #[tokio::test]
-    async fn test_api_keys_delete() {
+    async fn test_api_keys_get_error_404() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(404)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors":["Not Found"]}"#)
+            .create_async()
+            .await;
+        let result = super::get(&cfg, "missing").await;
+        assert!(result.is_err(), "expected error on 404");
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("failed to get API key"),
+            "error should mention failed get: {err_msg}"
+        );
+        cleanup_env();
+    }
+
+    // -----------------------------------------------------------------------
+    // create()
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_api_keys_create_success() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        mock_all(&mut s, r#"{"data": {"id":"k1","type":"api_keys"}}"#).await;
+        let result = super::create(&cfg, "my-new-key").await;
+        assert!(result.is_ok(), "create should succeed: {:?}", result.err());
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_api_keys_create_error_400() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = server
+            .mock("POST", mockito::Matcher::Any)
+            .with_status(400)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors":["Invalid name"]}"#)
+            .create_async()
+            .await;
+        let result = super::create(&cfg, "").await;
+        assert!(result.is_err(), "expected error on 400");
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("failed to create API key"),
+            "error should mention failed create: {err_msg}"
+        );
+        cleanup_env();
+    }
+
+    // -----------------------------------------------------------------------
+    // delete()
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_api_keys_delete_success() {
         let _lock = lock_env().await;
         let mut s = mockito::Server::new_async().await;
         let cfg = test_config(&s.url());
         mock_all(&mut s, r#"{}"#).await;
-        let _ = super::delete(&cfg, "k1").await;
+        let result = super::delete(&cfg, "k1").await;
+        assert!(result.is_ok(), "delete should succeed: {:?}", result.err());
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_api_keys_delete_error_404() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = server
+            .mock("DELETE", mockito::Matcher::Any)
+            .with_status(404)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors":["Not Found"]}"#)
+            .create_async()
+            .await;
+        let result = super::delete(&cfg, "nope").await;
+        assert!(result.is_err(), "expected error on 404");
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("failed to delete API key"),
+            "error should mention failed delete: {err_msg}"
+        );
         cleanup_env();
     }
 }

--- a/src/commands/app_keys.rs
+++ b/src/commands/app_keys.rs
@@ -189,65 +189,380 @@ pub async fn delete(cfg: &Config, key_id: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
 
+    use super::*;
     use crate::test_support::*;
 
+    // -----------------------------------------------------------------------
+    // parse_sort()
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_sort_name_ascending() {
+        let sort = parse_sort("name").unwrap();
+        assert_eq!(sort, ApplicationKeysSort::NAME_ASCENDING);
+    }
+
+    #[test]
+    fn test_parse_sort_name_descending() {
+        let sort = parse_sort("-name").unwrap();
+        assert_eq!(sort, ApplicationKeysSort::NAME_DESCENDING);
+    }
+
+    #[test]
+    fn test_parse_sort_created_at_ascending() {
+        let sort = parse_sort("created_at").unwrap();
+        assert_eq!(sort, ApplicationKeysSort::CREATED_AT_ASCENDING);
+    }
+
+    #[test]
+    fn test_parse_sort_created_at_descending() {
+        let sort = parse_sort("-created_at").unwrap();
+        assert_eq!(sort, ApplicationKeysSort::CREATED_AT_DESCENDING);
+    }
+
+    #[test]
+    fn test_parse_sort_last4_ascending() {
+        let sort = parse_sort("last4").unwrap();
+        assert_eq!(sort, ApplicationKeysSort::LAST4_ASCENDING);
+    }
+
+    #[test]
+    fn test_parse_sort_last4_descending() {
+        let sort = parse_sort("-last4").unwrap();
+        assert_eq!(sort, ApplicationKeysSort::LAST4_DESCENDING);
+    }
+
+    #[test]
+    fn test_parse_sort_invalid_rejects_unknown_value() {
+        let result = parse_sort("created");
+        assert!(result.is_err(), "bare 'created' should be rejected");
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("invalid --sort value"),
+            "error should mention invalid sort: {err_msg}"
+        );
+    }
+
+    #[test]
+    fn test_parse_sort_invalid_lists_accepted_values() {
+        let err_msg = parse_sort("bogus").unwrap_err().to_string();
+        // Error message should list the accepted values so users can self-correct.
+        assert!(err_msg.contains("name"), "error should list name");
+        assert!(
+            err_msg.contains("created_at"),
+            "error should list created_at"
+        );
+        assert!(err_msg.contains("last4"), "error should list last4");
+    }
+
+    #[test]
+    fn test_parse_sort_empty_is_invalid() {
+        // Empty string is not a valid sort token — callers short-circuit before
+        // invoking parse_sort, but the parser itself must reject it.
+        assert!(parse_sort("").is_err());
+    }
+
+    #[test]
+    fn test_parse_sort_case_sensitive() {
+        // The API enum is case-sensitive; uppercase variants must not be silently accepted.
+        assert!(parse_sort("NAME").is_err());
+        assert!(parse_sort("Created_At").is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // list()
+    // -----------------------------------------------------------------------
+
     #[tokio::test]
-    async fn test_app_keys_list() {
+    async fn test_app_keys_list_success() {
         let _lock = lock_env().await;
         let mut s = mockito::Server::new_async().await;
         let cfg = test_config(&s.url());
         mock_all(&mut s, r#"{"data": []}"#).await;
-        let _ = super::list(&cfg, 10, 0, "", "").await;
+        let result = super::list(&cfg, 10, 0, "", "").await;
+        assert!(result.is_ok(), "list should succeed: {:?}", result.err());
         cleanup_env();
     }
 
     #[tokio::test]
-    async fn test_app_keys_list_all() {
+    async fn test_app_keys_list_with_filter_and_sort() {
         let _lock = lock_env().await;
         let mut s = mockito::Server::new_async().await;
         let cfg = test_config(&s.url());
         mock_all(&mut s, r#"{"data": []}"#).await;
-        let _ = super::list_all(&cfg, 10, 0, "", "").await;
+        let result = super::list(&cfg, 25, 1, "prod", "-created_at").await;
+        assert!(
+            result.is_ok(),
+            "list with filter/sort should succeed: {:?}",
+            result.err()
+        );
         cleanup_env();
     }
 
     #[tokio::test]
-    async fn test_app_keys_get() {
+    async fn test_app_keys_list_invalid_sort_rejected_before_network() {
+        let _lock = lock_env().await;
+        // No mocks registered — if the function tried to make an HTTP call it
+        // would hang or error with a connection-refused. Asserting is_err()
+        // with the correct error message confirms validation runs first.
+        let server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let result = super::list(&cfg, 10, 0, "", "not-a-sort").await;
+        assert!(result.is_err(), "invalid sort should be rejected");
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("invalid --sort value"));
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_app_keys_list_error_403() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(403)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors":["Forbidden"]}"#)
+            .create_async()
+            .await;
+        let result = super::list(&cfg, 10, 0, "", "").await;
+        assert!(result.is_err(), "expected error on 403");
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("failed to list application keys"));
+        cleanup_env();
+    }
+
+    // -----------------------------------------------------------------------
+    // list_all()
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_app_keys_list_all_success() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        mock_all(&mut s, r#"{"data": []}"#).await;
+        let result = super::list_all(&cfg, 10, 0, "", "").await;
+        assert!(
+            result.is_ok(),
+            "list_all should succeed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_app_keys_list_all_invalid_sort_rejected() {
+        let _lock = lock_env().await;
+        let server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let result = super::list_all(&cfg, 10, 0, "", "garbage").await;
+        assert!(result.is_err(), "invalid sort should be rejected");
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_app_keys_list_all_error_500() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(500)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors":["Internal"]}"#)
+            .create_async()
+            .await;
+        let result = super::list_all(&cfg, 10, 0, "", "").await;
+        assert!(result.is_err(), "expected error on 500");
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("failed to list all application keys"));
+        cleanup_env();
+    }
+
+    // -----------------------------------------------------------------------
+    // get()
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_app_keys_get_success() {
         let _lock = lock_env().await;
         let mut s = mockito::Server::new_async().await;
         let cfg = test_config(&s.url());
         mock_all(&mut s, r#"{"data": {}}"#).await;
-        let _ = super::get(&cfg, "k1").await;
+        let result = super::get(&cfg, "key-id").await;
+        assert!(result.is_ok(), "get should succeed: {:?}", result.err());
         cleanup_env();
     }
 
     #[tokio::test]
-    async fn test_app_keys_create() {
+    async fn test_app_keys_get_error_404() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(404)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors":["Not Found"]}"#)
+            .create_async()
+            .await;
+        let result = super::get(&cfg, "missing-key").await;
+        assert!(result.is_err(), "expected error on 404");
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("failed to get application key"));
+        cleanup_env();
+    }
+
+    // -----------------------------------------------------------------------
+    // create()
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_app_keys_create_success_no_scopes() {
         let _lock = lock_env().await;
         let mut s = mockito::Server::new_async().await;
         let cfg = test_config(&s.url());
         mock_all(&mut s, r#"{"data": {}}"#).await;
-        let _ = super::create(&cfg, "test-key", "").await;
+        let result = super::create(&cfg, "test-key", "").await;
+        assert!(
+            result.is_ok(),
+            "create without scopes should succeed: {:?}",
+            result.err()
+        );
         cleanup_env();
     }
 
     #[tokio::test]
-    async fn test_app_keys_update() {
+    async fn test_app_keys_create_success_with_scopes() {
         let _lock = lock_env().await;
         let mut s = mockito::Server::new_async().await;
         let cfg = test_config(&s.url());
         mock_all(&mut s, r#"{"data": {}}"#).await;
-        let _ = super::update(&cfg, "k1", "new-name", "").await;
+        // Comma-separated scopes, with surrounding whitespace that should be trimmed.
+        let result = super::create(&cfg, "test-key", "events_read, metrics_read ,logs_read").await;
+        assert!(
+            result.is_ok(),
+            "create with scopes should succeed: {:?}",
+            result.err()
+        );
         cleanup_env();
     }
 
     #[tokio::test]
-    async fn test_app_keys_delete() {
+    async fn test_app_keys_create_error_400() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = server
+            .mock("POST", mockito::Matcher::Any)
+            .with_status(400)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors":["Invalid scope"]}"#)
+            .create_async()
+            .await;
+        let result = super::create(&cfg, "test-key", "bogus_scope").await;
+        assert!(result.is_err(), "expected error on 400");
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("failed to create application key"));
+        cleanup_env();
+    }
+
+    // -----------------------------------------------------------------------
+    // update()
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_app_keys_update_success_name_only() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        mock_all(&mut s, r#"{"data": {}}"#).await;
+        let result = super::update(&cfg, "k1", "renamed", "").await;
+        assert!(result.is_ok(), "update should succeed: {:?}", result.err());
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_app_keys_update_success_scopes_only() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        mock_all(&mut s, r#"{"data": {}}"#).await;
+        let result = super::update(&cfg, "k1", "", "events_read,metrics_read").await;
+        assert!(
+            result.is_ok(),
+            "update with scopes should succeed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_app_keys_update_error_404() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = server
+            .mock("PATCH", mockito::Matcher::Any)
+            .with_status(404)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors":["Not Found"]}"#)
+            .create_async()
+            .await;
+        let result = super::update(&cfg, "missing", "name", "").await;
+        assert!(result.is_err(), "expected error on 404");
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("failed to update application key"));
+        cleanup_env();
+    }
+
+    // -----------------------------------------------------------------------
+    // delete()
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_app_keys_delete_success() {
         let _lock = lock_env().await;
         let mut s = mockito::Server::new_async().await;
         let cfg = test_config(&s.url());
         mock_all(&mut s, r#"{}"#).await;
-        let _ = super::delete(&cfg, "k1").await;
+        let result = super::delete(&cfg, "k1").await;
+        assert!(result.is_ok(), "delete should succeed: {:?}", result.err());
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_app_keys_delete_error_404() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = server
+            .mock("DELETE", mockito::Matcher::Any)
+            .with_status(404)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors":["Not Found"]}"#)
+            .create_async()
+            .await;
+        let result = super::delete(&cfg, "missing").await;
+        assert!(result.is_err(), "expected error on 404");
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("failed to delete application key"));
         cleanup_env();
     }
 }

--- a/src/commands/authn_mappings.rs
+++ b/src/commands/authn_mappings.rs
@@ -66,8 +66,46 @@ mod tests {
 
     use crate::test_support::*;
 
+    /// Sample create-request body matching the AuthNMappingCreateRequest schema.
+    /// Used by create-path tests to exercise the JSON parser in `util::read_json_file`.
+    const SAMPLE_CREATE_JSON: &str = r#"{
+      "data": {
+        "type": "authn_mappings",
+        "attributes": {
+          "attribute_key": "member-of",
+          "attribute_value": "engineering"
+        },
+        "relationships": {
+          "role": {
+            "data": { "type": "roles", "id": "11111111-1111-1111-1111-111111111111" }
+          }
+        }
+      }
+    }"#;
+
+    /// Sample update-request body matching the AuthNMappingUpdateRequest schema.
+    const SAMPLE_UPDATE_JSON: &str = r#"{
+      "data": {
+        "type": "authn_mappings",
+        "id": "abc-123",
+        "attributes": {
+          "attribute_key": "member-of",
+          "attribute_value": "security"
+        },
+        "relationships": {
+          "role": {
+            "data": { "type": "roles", "id": "22222222-2222-2222-2222-222222222222" }
+          }
+        }
+      }
+    }"#;
+
+    // -----------------------------------------------------------------------
+    // list()
+    // -----------------------------------------------------------------------
+
     #[tokio::test]
-    async fn test_authn_mappings_list() {
+    async fn test_authn_mappings_list_success() {
         let _lock = lock_env().await;
         std::env::set_var("DD_TOKEN_STORAGE", "file");
         let mut server = mockito::Server::new_async().await;
@@ -98,12 +136,20 @@ mod tests {
             .await;
         let result = super::list(&cfg).await;
         assert!(result.is_err(), "expected error for 403 response");
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("failed to list AuthN mappings"));
         cleanup_env();
         std::env::remove_var("DD_TOKEN_STORAGE");
     }
 
+    // -----------------------------------------------------------------------
+    // get()
+    // -----------------------------------------------------------------------
+
     #[tokio::test]
-    async fn test_authn_mappings_get() {
+    async fn test_authn_mappings_get_success() {
         let _lock = lock_env().await;
         std::env::set_var("DD_TOKEN_STORAGE", "file");
         let mut server = mockito::Server::new_async().await;
@@ -120,6 +166,242 @@ mod tests {
             "authn mappings get failed: {:?}",
             result.err()
         );
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_authn_mappings_get_error_404() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(404)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors":["Not Found"]}"#)
+            .create_async()
+            .await;
+        let result = super::get(&cfg, "missing").await;
+        assert!(result.is_err(), "expected error on 404");
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("failed to get AuthN mapping"));
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    // -----------------------------------------------------------------------
+    // create()
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_authn_mappings_create_success() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = mock_any(
+            &mut server,
+            "POST",
+            r#"{"data":{"type":"authn_mappings","id":"new-1","attributes":{}}}"#,
+        )
+        .await;
+
+        let path = write_temp_json("pup_authn_create_ok.json", SAMPLE_CREATE_JSON);
+        let result = super::create(&cfg, path.to_str().unwrap()).await;
+        assert!(
+            result.is_ok(),
+            "authn mappings create failed: {:?}",
+            result.err()
+        );
+
+        let _ = std::fs::remove_file(&path);
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_authn_mappings_create_missing_file() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        // Nonexistent path — file read must fail before any HTTP call.
+        let result = super::create(&cfg, "/tmp/__pup_authn_missing_fixture__.json").await;
+        assert!(result.is_err(), "expected error for missing file");
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("failed to read file"),
+            "error should mention file read failure: {err_msg}"
+        );
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_authn_mappings_create_invalid_json() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        // Well-formed JSON that doesn't match the expected schema.
+        let path = write_temp_json("pup_authn_create_bad.json", r#"{"nope":true}"#);
+        let result = super::create(&cfg, path.to_str().unwrap()).await;
+        assert!(result.is_err(), "expected error for invalid schema");
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("failed to parse JSON"));
+
+        let _ = std::fs::remove_file(&path);
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_authn_mappings_create_api_error() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = server
+            .mock("POST", mockito::Matcher::Any)
+            .with_status(409)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors":["Conflict"]}"#)
+            .create_async()
+            .await;
+
+        let path = write_temp_json("pup_authn_create_conflict.json", SAMPLE_CREATE_JSON);
+        let result = super::create(&cfg, path.to_str().unwrap()).await;
+        assert!(result.is_err(), "expected error on 409");
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("failed to create AuthN mapping"));
+
+        let _ = std::fs::remove_file(&path);
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    // -----------------------------------------------------------------------
+    // update()
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_authn_mappings_update_success() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = mock_any(
+            &mut server,
+            "PATCH",
+            r#"{"data":{"type":"authn_mappings","id":"abc-123","attributes":{}}}"#,
+        )
+        .await;
+
+        let path = write_temp_json("pup_authn_update_ok.json", SAMPLE_UPDATE_JSON);
+        let result = super::update(&cfg, "abc-123", path.to_str().unwrap()).await;
+        assert!(
+            result.is_ok(),
+            "authn mappings update failed: {:?}",
+            result.err()
+        );
+
+        let _ = std::fs::remove_file(&path);
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_authn_mappings_update_missing_file() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let result = super::update(&cfg, "abc-123", "/tmp/__pup_authn_update_missing__.json").await;
+        assert!(result.is_err(), "expected error for missing file");
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("failed to read file"));
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_authn_mappings_update_api_error() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = server
+            .mock("PATCH", mockito::Matcher::Any)
+            .with_status(404)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors":["Not Found"]}"#)
+            .create_async()
+            .await;
+
+        let path = write_temp_json("pup_authn_update_404.json", SAMPLE_UPDATE_JSON);
+        let result = super::update(&cfg, "missing", path.to_str().unwrap()).await;
+        assert!(result.is_err(), "expected error on 404");
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("failed to update AuthN mapping"));
+
+        let _ = std::fs::remove_file(&path);
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    // -----------------------------------------------------------------------
+    // delete()
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_authn_mappings_delete_success() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = mock_any(&mut server, "DELETE", "").await;
+        let result = super::delete(&cfg, "abc-123").await;
+        assert!(
+            result.is_ok(),
+            "authn mappings delete failed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_authn_mappings_delete_error_404() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = server
+            .mock("DELETE", mockito::Matcher::Any)
+            .with_status(404)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors":["Not Found"]}"#)
+            .create_async()
+            .await;
+        let result = super::delete(&cfg, "missing").await;
+        assert!(result.is_err(), "expected error on 404");
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("failed to delete AuthN mapping"));
         cleanup_env();
         std::env::remove_var("DD_TOKEN_STORAGE");
     }


### PR DESCRIPTION
## Summary

Expand unit-test coverage of three credential-adjacent command modules that previously exercised their API entry points without asserting behavior. Every public function now has at least one positive test (happy path against a mockito server) and at least one negative test (HTTP error response or input-validation failure), per [REVIEW.md §2](docs/REVIEW.md).

Tests-only PR — no production code changes. No visibility widening needed; `parse_sort` in `app_keys` is already reachable from the in-module `tests` submodule via `use super::*;`.

## Per-module coverage added

### `src/commands/api_keys.rs` (5 tests → 8 tests, +5 net, all pairs)
- `list`: positive (`Ok` asserted) + 403 error (verifies `failed to list API keys` wrapper)
- `get`: positive + 404 error
- `create`: positive (new coverage — previous suite had no create test) + 400 error
- `delete`: positive (`Ok` asserted) + 404 error

### `src/commands/app_keys.rs` (6 tests → 27 tests, +21 net)
- `parse_sort` (private helper, 10 tests): positive test for each of the 6 accepted values (`name`, `-name`, `created_at`, `-created_at`, `last4`, `-last4`); negative tests for unknown value, empty string, and case-sensitivity; an assertion that the error message lists the accepted values.
- `list`: positive, positive with filter + sort, invalid-sort rejected before network, 403 error
- `list_all`: positive, invalid-sort rejected, 500 error
- `get`: positive + 404 error
- `create`: positive without scopes, positive with comma-separated scopes (whitespace-trimmed), 400 error
- `update`: positive name-only, positive scopes-only, 404 error
- `delete`: positive + 404 error

### `src/commands/authn_mappings.rs` (3 tests → 13 tests, +10 net)
- `list`: positive (existing) + 403 error (existing, strengthened with error-message assertion)
- `get`: positive (existing) + 404 error
- `create`: positive (with temp JSON fixture matching schema), missing-file negative (verifies `failed to read file` from `util::read_json_file`), schema-mismatched JSON negative (verifies `failed to parse JSON`), API 409 negative
- `update`: positive, missing-file negative, 404 error
- `delete`: positive + 404 error

## Skipped functions / rationale

None. All public functions in these three modules are testable hermetically with `mockito` via the existing `PUP_MOCK_SERVER` redirect mechanism and `src/test_support.rs` helpers. No function required network access, keychain access, or filesystem state beyond `std::env::temp_dir()`.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 910 passed, 0 failed (was 874 before)
- [x] Per-module runs:
  - `cargo test --bin pup commands::api_keys` — 8 passed
  - `cargo test --bin pup commands::app_keys` — 27 passed
  - `cargo test --bin pup commands::authn_mappings` — 13 passed
- [x] No credentials printed or asserted on — only the static `test-api-key` / `test-app-key` placeholders already established in `src/test_support.rs`.

---
Co-Authored-By: Claude <noreply@anthropic.com>