### PR TITLE
feat(organizations): add org group policies, overrides, and configs

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -148,7 +148,7 @@ macro_rules! make_api {
 // Unstable operations table — used by make_dd_config
 // ---------------------------------------------------------------------------
 
-/// All 93 unstable operations (snake_case for the Rust DD client).
+/// All unstable operations (snake_case for the Rust DD client).
 static UNSTABLE_OPS: &[&str] = &[
     // Incidents (26)
     "v2.list_incidents",

--- a/src/client.rs
+++ b/src/client.rs
@@ -238,6 +238,18 @@ static UNSTABLE_OPS: &[&str] = &[
     "v2.get_hamr_org_connection",
     // Entity Risk Scores (1)
     "v2.list_entity_risk_scores",
+    // Org Group Policies (11)
+    "v2.list_org_group_policies",
+    "v2.get_org_group_policy",
+    "v2.create_org_group_policy",
+    "v2.update_org_group_policy",
+    "v2.delete_org_group_policy",
+    "v2.list_org_group_policy_overrides",
+    "v2.get_org_group_policy_override",
+    "v2.create_org_group_policy_override",
+    "v2.update_org_group_policy_override",
+    "v2.delete_org_group_policy_override",
+    "v2.list_org_group_policy_configs",
     // Security Findings (1)
     "v2.list_findings",
     // SLO Status (1)
@@ -1015,7 +1027,7 @@ mod tests {
 
     #[test]
     fn test_unstable_ops_count() {
-        assert_eq!(UNSTABLE_OPS.len(), 147);
+        assert_eq!(UNSTABLE_OPS.len(), 158);
     }
 
     #[test]

--- a/src/commands/organizations.rs
+++ b/src/commands/organizations.rs
@@ -1,8 +1,17 @@
 use anyhow::Result;
 use datadog_api_client::datadogV1::api_organizations::OrganizationsAPI;
+use datadog_api_client::datadogV2::api_org_groups::{
+    ListOrgGroupPoliciesOptionalParams, ListOrgGroupPolicyOverridesOptionalParams, OrgGroupsAPI,
+};
+use datadog_api_client::datadogV2::model::{
+    OrgGroupPolicyCreateRequest, OrgGroupPolicyOverrideCreateRequest,
+    OrgGroupPolicyOverrideSortOption, OrgGroupPolicyOverrideUpdateRequest,
+    OrgGroupPolicySortOption, OrgGroupPolicyUpdateRequest,
+};
 
 use crate::config::Config;
 use crate::formatter;
+use crate::util;
 
 pub async fn list(cfg: &Config) -> Result<()> {
     let api = crate::make_api!(OrganizationsAPI, cfg);
@@ -22,10 +31,195 @@ pub async fn get(cfg: &Config) -> Result<()> {
     formatter::output(cfg, &resp)
 }
 
+fn parse_uuid(label: &str, value: &str) -> Result<uuid::Uuid> {
+    uuid::Uuid::parse_str(value).map_err(|e| anyhow::anyhow!("invalid {label} '{value}': {e}"))
+}
+
+fn parse_policy_sort(s: &str) -> Result<OrgGroupPolicySortOption> {
+    Ok(match s {
+        "id" => OrgGroupPolicySortOption::ID,
+        "-id" => OrgGroupPolicySortOption::MINUS_ID,
+        "name" => OrgGroupPolicySortOption::NAME,
+        "-name" => OrgGroupPolicySortOption::MINUS_NAME,
+        _ => anyhow::bail!("invalid sort '{s}' — use one of: id, -id, name, -name"),
+    })
+}
+
+fn parse_override_sort(s: &str) -> Result<OrgGroupPolicyOverrideSortOption> {
+    Ok(match s {
+        "id" => OrgGroupPolicyOverrideSortOption::ID,
+        "-id" => OrgGroupPolicyOverrideSortOption::MINUS_ID,
+        "org_uuid" => OrgGroupPolicyOverrideSortOption::ORG_UUID,
+        "-org_uuid" => OrgGroupPolicyOverrideSortOption::MINUS_ORG_UUID,
+        _ => anyhow::bail!("invalid sort '{s}' — use one of: id, -id, org_uuid, -org_uuid"),
+    })
+}
+
+// ---- Policies ----
+
+pub async fn policies_list(
+    cfg: &Config,
+    group_id: &str,
+    name: Option<String>,
+    page_number: Option<i64>,
+    page_size: Option<i64>,
+    sort: Option<String>,
+) -> Result<()> {
+    let group_uuid = parse_uuid("group-id", group_id)?;
+    let mut params = ListOrgGroupPoliciesOptionalParams::default();
+    if let Some(n) = name {
+        params.filter_policy_name = Some(n);
+    }
+    if let Some(n) = page_number {
+        params.page_number = Some(n);
+    }
+    if let Some(n) = page_size {
+        params.page_size = Some(n);
+    }
+    if let Some(s) = sort {
+        params.sort = Some(parse_policy_sort(&s)?);
+    }
+    let api = crate::make_api!(OrgGroupsAPI, cfg);
+    let resp = api
+        .list_org_group_policies(group_uuid, params)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to list org group policies: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn policies_get(cfg: &Config, policy_id: &str) -> Result<()> {
+    let id = parse_uuid("policy-id", policy_id)?;
+    let api = crate::make_api!(OrgGroupsAPI, cfg);
+    let resp = api
+        .get_org_group_policy(id)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to get org group policy: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn policies_create(cfg: &Config, file: &str) -> Result<()> {
+    let body: OrgGroupPolicyCreateRequest = util::read_json_file(file)?;
+    let api = crate::make_api!(OrgGroupsAPI, cfg);
+    let resp = api
+        .create_org_group_policy(body)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to create org group policy: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn policies_update(cfg: &Config, policy_id: &str, file: &str) -> Result<()> {
+    let id = parse_uuid("policy-id", policy_id)?;
+    let body: OrgGroupPolicyUpdateRequest = util::read_json_file(file)?;
+    let api = crate::make_api!(OrgGroupsAPI, cfg);
+    let resp = api
+        .update_org_group_policy(id, body)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to update org group policy: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn policies_delete(cfg: &Config, policy_id: &str) -> Result<()> {
+    let id = parse_uuid("policy-id", policy_id)?;
+    let api = crate::make_api!(OrgGroupsAPI, cfg);
+    api.delete_org_group_policy(id)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to delete org group policy: {e:?}"))?;
+    eprintln!("Org group policy '{policy_id}' deleted.");
+    Ok(())
+}
+
+// ---- Policy Overrides ----
+
+pub async fn policy_overrides_list(
+    cfg: &Config,
+    group_id: &str,
+    policy_id: Option<String>,
+    page_number: Option<i64>,
+    page_size: Option<i64>,
+    sort: Option<String>,
+) -> Result<()> {
+    let group_uuid = parse_uuid("group-id", group_id)?;
+    let mut params = ListOrgGroupPolicyOverridesOptionalParams::default();
+    if let Some(pid) = policy_id {
+        params.filter_policy_id = Some(parse_uuid("policy-id", &pid)?);
+    }
+    if let Some(n) = page_number {
+        params.page_number = Some(n);
+    }
+    if let Some(n) = page_size {
+        params.page_size = Some(n);
+    }
+    if let Some(s) = sort {
+        params.sort = Some(parse_override_sort(&s)?);
+    }
+    let api = crate::make_api!(OrgGroupsAPI, cfg);
+    let resp = api
+        .list_org_group_policy_overrides(group_uuid, params)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to list org group policy overrides: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn policy_overrides_get(cfg: &Config, override_id: &str) -> Result<()> {
+    let id = parse_uuid("override-id", override_id)?;
+    let api = crate::make_api!(OrgGroupsAPI, cfg);
+    let resp = api
+        .get_org_group_policy_override(id)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to get org group policy override: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn policy_overrides_create(cfg: &Config, file: &str) -> Result<()> {
+    let body: OrgGroupPolicyOverrideCreateRequest = util::read_json_file(file)?;
+    let api = crate::make_api!(OrgGroupsAPI, cfg);
+    let resp = api
+        .create_org_group_policy_override(body)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to create org group policy override: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn policy_overrides_update(cfg: &Config, override_id: &str, file: &str) -> Result<()> {
+    let id = parse_uuid("override-id", override_id)?;
+    let body: OrgGroupPolicyOverrideUpdateRequest = util::read_json_file(file)?;
+    let api = crate::make_api!(OrgGroupsAPI, cfg);
+    let resp = api
+        .update_org_group_policy_override(id, body)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to update org group policy override: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn policy_overrides_delete(cfg: &Config, override_id: &str) -> Result<()> {
+    let id = parse_uuid("override-id", override_id)?;
+    let api = crate::make_api!(OrgGroupsAPI, cfg);
+    api.delete_org_group_policy_override(id)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to delete org group policy override: {e:?}"))?;
+    eprintln!("Org group policy override '{override_id}' deleted.");
+    Ok(())
+}
+
+// ---- Policy Configs ----
+
+pub async fn policy_configs_list(cfg: &Config) -> Result<()> {
+    let api = crate::make_api!(OrgGroupsAPI, cfg);
+    let resp = api
+        .list_org_group_policy_configs()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to list org group policy configs: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
 #[cfg(test)]
 mod tests {
 
     use crate::test_support::*;
+
+    const GROUP_UUID: &str = "11111111-1111-1111-1111-111111111111";
+    const POLICY_UUID: &str = "22222222-2222-2222-2222-222222222222";
+    const OVERRIDE_UUID: &str = "33333333-3333-3333-3333-333333333333";
 
     #[tokio::test]
     async fn test_organizations_list() {
@@ -35,5 +229,349 @@ mod tests {
         mock_all(&mut s, r#"{"orgs": []}"#).await;
         let _ = super::list(&cfg).await;
         cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_policies_list() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = mock_any(&mut server, "GET", r#"{"data":[]}"#).await;
+        let result = super::policies_list(&cfg, GROUP_UUID, None, None, None, None).await;
+        assert!(result.is_ok(), "policies_list failed: {:?}", result.err());
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_policies_list_with_params() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = mock_any(&mut server, "GET", r#"{"data":[]}"#).await;
+        let result = super::policies_list(
+            &cfg,
+            GROUP_UUID,
+            Some("admin".into()),
+            Some(1),
+            Some(50),
+            Some("-name".into()),
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "policies_list with params failed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_policies_list_bad_group_id() {
+        let _lock = lock_env().await;
+        let cfg = test_config("http://unused.local");
+        let result = super::policies_list(&cfg, "not-a-uuid", None, None, None, None).await;
+        assert!(result.is_err(), "expected UUID parse error");
+        assert!(result.unwrap_err().to_string().contains("invalid group-id"));
+    }
+
+    #[tokio::test]
+    async fn test_policies_list_bad_sort() {
+        let _lock = lock_env().await;
+        let cfg = test_config("http://unused.local");
+        let result =
+            super::policies_list(&cfg, GROUP_UUID, None, None, None, Some("bogus".into())).await;
+        assert!(result.is_err(), "expected sort parse error");
+    }
+
+    #[tokio::test]
+    async fn test_policies_get() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let body = format!(
+            r#"{{"data":{{"id":"{POLICY_UUID}","type":"org_group_policies","attributes":{{"enforcement_tier":"DEFAULT","modified_at":"2024-01-01T00:00:00Z","policy_name":"test","policy_type":"org_config"}}}}}}"#
+        );
+        let _mock = mock_any(&mut server, "GET", &body).await;
+        let result = super::policies_get(&cfg, POLICY_UUID).await;
+        assert!(result.is_ok(), "policies_get failed: {:?}", result.err());
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_policies_get_404() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(404)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors":["not found"]}"#)
+            .create_async()
+            .await;
+        let result = super::policies_get(&cfg, POLICY_UUID).await;
+        assert!(result.is_err(), "expected 404 error");
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_policies_create() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let tmp = write_temp_json(
+            "pup_test_policies_create.json",
+            &format!(
+                r#"{{"data":{{"type":"org_group_policies","attributes":{{"content":{{}},"policy_name":"test"}},"relationships":{{"org_group":{{"data":{{"id":"{GROUP_UUID}","type":"org_groups"}}}}}}}}}}"#
+            ),
+        );
+        let body = format!(
+            r#"{{"data":{{"id":"{POLICY_UUID}","type":"org_group_policies","attributes":{{"enforcement_tier":"DEFAULT","modified_at":"2024-01-01T00:00:00Z","policy_name":"test","policy_type":"org_config"}}}}}}"#
+        );
+        let _mock = mock_any(&mut server, "POST", &body).await;
+        let result = super::policies_create(&cfg, tmp.to_str().unwrap()).await;
+        assert!(result.is_ok(), "policies_create failed: {:?}", result.err());
+        let _ = std::fs::remove_file(tmp);
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_policies_update() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let tmp = write_temp_json(
+            "pup_test_policies_update.json",
+            &format!(
+                r#"{{"data":{{"id":"{POLICY_UUID}","type":"org_group_policies","attributes":{{}}}}}}"#
+            ),
+        );
+        let body = format!(
+            r#"{{"data":{{"id":"{POLICY_UUID}","type":"org_group_policies","attributes":{{"enforcement_tier":"DEFAULT","modified_at":"2024-01-01T00:00:00Z","policy_name":"test","policy_type":"org_config"}}}}}}"#
+        );
+        let _mock = mock_any(&mut server, "PATCH", &body).await;
+        let result = super::policies_update(&cfg, POLICY_UUID, tmp.to_str().unwrap()).await;
+        assert!(result.is_ok(), "policies_update failed: {:?}", result.err());
+        let _ = std::fs::remove_file(tmp);
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_policies_delete() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = server
+            .mock("DELETE", mockito::Matcher::Any)
+            .with_status(204)
+            .create_async()
+            .await;
+        let result = super::policies_delete(&cfg, POLICY_UUID).await;
+        assert!(result.is_ok(), "policies_delete failed: {:?}", result.err());
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_policy_overrides_list() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = mock_any(&mut server, "GET", r#"{"data":[]}"#).await;
+        let result = super::policy_overrides_list(&cfg, GROUP_UUID, None, None, None, None).await;
+        assert!(
+            result.is_ok(),
+            "policy_overrides_list failed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_policy_overrides_list_filter_policy() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = mock_any(&mut server, "GET", r#"{"data":[]}"#).await;
+        let result = super::policy_overrides_list(
+            &cfg,
+            GROUP_UUID,
+            Some(POLICY_UUID.into()),
+            Some(1),
+            Some(25),
+            Some("org_uuid".into()),
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "policy_overrides_list filter failed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_policy_overrides_list_bad_policy_id() {
+        let _lock = lock_env().await;
+        let cfg = test_config("http://unused.local");
+        let result = super::policy_overrides_list(
+            &cfg,
+            GROUP_UUID,
+            Some("not-a-uuid".into()),
+            None,
+            None,
+            None,
+        )
+        .await;
+        assert!(result.is_err(), "expected UUID parse error");
+    }
+
+    #[tokio::test]
+    async fn test_policy_overrides_get() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let body = format!(
+            r#"{{"data":{{"id":"{OVERRIDE_UUID}","type":"org_group_policy_overrides","attributes":{{"created_at":"2024-01-01T00:00:00Z","modified_at":"2024-01-01T00:00:00Z","org_site":"datadoghq.com","org_uuid":"{OVERRIDE_UUID}"}}}}}}"#
+        );
+        let _mock = mock_any(&mut server, "GET", &body).await;
+        let result = super::policy_overrides_get(&cfg, OVERRIDE_UUID).await;
+        assert!(
+            result.is_ok(),
+            "policy_overrides_get failed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_policy_overrides_create() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let tmp = write_temp_json(
+            "pup_test_overrides_create.json",
+            &format!(
+                r#"{{"data":{{"type":"org_group_policy_overrides","attributes":{{"org_site":"datadoghq.com","org_uuid":"{OVERRIDE_UUID}"}},"relationships":{{"org_group":{{"data":{{"id":"{GROUP_UUID}","type":"org_groups"}}}},"org_group_policy":{{"data":{{"id":"{POLICY_UUID}","type":"org_group_policies"}}}}}}}}}}"#
+            ),
+        );
+        let body = format!(
+            r#"{{"data":{{"id":"{OVERRIDE_UUID}","type":"org_group_policy_overrides","attributes":{{"created_at":"2024-01-01T00:00:00Z","modified_at":"2024-01-01T00:00:00Z","org_site":"datadoghq.com","org_uuid":"{OVERRIDE_UUID}"}}}}}}"#
+        );
+        let _mock = mock_any(&mut server, "POST", &body).await;
+        let result = super::policy_overrides_create(&cfg, tmp.to_str().unwrap()).await;
+        assert!(
+            result.is_ok(),
+            "policy_overrides_create failed: {:?}",
+            result.err()
+        );
+        let _ = std::fs::remove_file(tmp);
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_policy_overrides_update() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let tmp = write_temp_json(
+            "pup_test_overrides_update.json",
+            &format!(
+                r#"{{"data":{{"id":"{OVERRIDE_UUID}","type":"org_group_policy_overrides","attributes":{{"org_site":"datadoghq.com","org_uuid":"{OVERRIDE_UUID}"}}}}}}"#
+            ),
+        );
+        let body = format!(
+            r#"{{"data":{{"id":"{OVERRIDE_UUID}","type":"org_group_policy_overrides","attributes":{{"created_at":"2024-01-01T00:00:00Z","modified_at":"2024-01-01T00:00:00Z","org_site":"datadoghq.com","org_uuid":"{OVERRIDE_UUID}"}}}}}}"#
+        );
+        let _mock = mock_any(&mut server, "PATCH", &body).await;
+        let result =
+            super::policy_overrides_update(&cfg, OVERRIDE_UUID, tmp.to_str().unwrap()).await;
+        assert!(
+            result.is_ok(),
+            "policy_overrides_update failed: {:?}",
+            result.err()
+        );
+        let _ = std::fs::remove_file(tmp);
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_policy_overrides_delete() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = server
+            .mock("DELETE", mockito::Matcher::Any)
+            .with_status(204)
+            .create_async()
+            .await;
+        let result = super::policy_overrides_delete(&cfg, OVERRIDE_UUID).await;
+        assert!(
+            result.is_ok(),
+            "policy_overrides_delete failed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_policy_configs_list() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = mock_any(&mut server, "GET", r#"{"data":[]}"#).await;
+        let result = super::policy_configs_list(&cfg).await;
+        assert!(
+            result.is_ok(),
+            "policy_configs_list failed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_policy_configs_list_403() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(403)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors":["Forbidden"]}"#)
+            .create_async()
+            .await;
+        let result = super::policy_configs_list(&cfg).await;
+        assert!(result.is_err(), "expected 403 error");
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4749,6 +4749,117 @@ enum OrgActions {
     List,
     /// Get organization details
     Get,
+    /// Manage organization group policies
+    Policies {
+        #[command(subcommand)]
+        action: OrgPoliciesActions,
+    },
+    /// Manage organization group policy overrides
+    #[command(name = "policy-overrides")]
+    PolicyOverrides {
+        #[command(subcommand)]
+        action: OrgPolicyOverridesActions,
+    },
+    /// List available org group policy config definitions
+    #[command(name = "policy-configs")]
+    PolicyConfigs {
+        #[command(subcommand)]
+        action: OrgPolicyConfigsActions,
+    },
+}
+
+#[derive(Subcommand)]
+enum OrgPoliciesActions {
+    /// List policies for an org group
+    List {
+        /// Org group UUID (required)
+        #[arg(long = "group-id")]
+        group_id: String,
+        /// Filter by policy name
+        #[arg(long)]
+        name: Option<String>,
+        /// Page number
+        #[arg(long = "page-number")]
+        page_number: Option<i64>,
+        /// Page size (max 1000)
+        #[arg(long = "page-size")]
+        page_size: Option<i64>,
+        /// Sort (id, -id, name, -name)
+        #[arg(long)]
+        sort: Option<String>,
+    },
+    /// Get a policy by ID
+    Get {
+        /// Policy UUID
+        policy_id: String,
+    },
+    /// Create a policy
+    Create {
+        #[arg(long, help = "JSON file with request body (required)")]
+        file: String,
+    },
+    /// Update a policy
+    Update {
+        /// Policy UUID
+        policy_id: String,
+        #[arg(long, help = "JSON file with request body (required)")]
+        file: String,
+    },
+    /// Delete a policy
+    Delete {
+        /// Policy UUID
+        policy_id: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum OrgPolicyOverridesActions {
+    /// List policy overrides for an org group
+    List {
+        /// Org group UUID (required)
+        #[arg(long = "group-id")]
+        group_id: String,
+        /// Filter by policy UUID
+        #[arg(long = "policy-id")]
+        policy_id: Option<String>,
+        /// Page number
+        #[arg(long = "page-number")]
+        page_number: Option<i64>,
+        /// Page size (max 1000)
+        #[arg(long = "page-size")]
+        page_size: Option<i64>,
+        /// Sort (id, -id, org_uuid, -org_uuid)
+        #[arg(long)]
+        sort: Option<String>,
+    },
+    /// Get a policy override by ID
+    Get {
+        /// Override UUID
+        override_id: String,
+    },
+    /// Create a policy override
+    Create {
+        #[arg(long, help = "JSON file with request body (required)")]
+        file: String,
+    },
+    /// Update a policy override
+    Update {
+        /// Override UUID
+        override_id: String,
+        #[arg(long, help = "JSON file with request body (required)")]
+        file: String,
+    },
+    /// Delete a policy override
+    Delete {
+        /// Override UUID
+        override_id: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum OrgPolicyConfigsActions {
+    /// List available org group policy config definitions
+    List,
 }
 
 // ---- Cloud ----
@@ -10688,6 +10799,75 @@ async fn main_inner() -> anyhow::Result<()> {
             match action {
                 OrgActions::List => commands::organizations::list(&cfg).await?,
                 OrgActions::Get => commands::organizations::get(&cfg).await?,
+                OrgActions::Policies { action } => match action {
+                    OrgPoliciesActions::List {
+                        group_id,
+                        name,
+                        page_number,
+                        page_size,
+                        sort,
+                    } => {
+                        commands::organizations::policies_list(
+                            &cfg,
+                            &group_id,
+                            name,
+                            page_number,
+                            page_size,
+                            sort,
+                        )
+                        .await?;
+                    }
+                    OrgPoliciesActions::Get { policy_id } => {
+                        commands::organizations::policies_get(&cfg, &policy_id).await?;
+                    }
+                    OrgPoliciesActions::Create { file } => {
+                        commands::organizations::policies_create(&cfg, &file).await?;
+                    }
+                    OrgPoliciesActions::Update { policy_id, file } => {
+                        commands::organizations::policies_update(&cfg, &policy_id, &file).await?;
+                    }
+                    OrgPoliciesActions::Delete { policy_id } => {
+                        commands::organizations::policies_delete(&cfg, &policy_id).await?;
+                    }
+                },
+                OrgActions::PolicyOverrides { action } => match action {
+                    OrgPolicyOverridesActions::List {
+                        group_id,
+                        policy_id,
+                        page_number,
+                        page_size,
+                        sort,
+                    } => {
+                        commands::organizations::policy_overrides_list(
+                            &cfg,
+                            &group_id,
+                            policy_id,
+                            page_number,
+                            page_size,
+                            sort,
+                        )
+                        .await?;
+                    }
+                    OrgPolicyOverridesActions::Get { override_id } => {
+                        commands::organizations::policy_overrides_get(&cfg, &override_id).await?;
+                    }
+                    OrgPolicyOverridesActions::Create { file } => {
+                        commands::organizations::policy_overrides_create(&cfg, &file).await?;
+                    }
+                    OrgPolicyOverridesActions::Update { override_id, file } => {
+                        commands::organizations::policy_overrides_update(&cfg, &override_id, &file)
+                            .await?;
+                    }
+                    OrgPolicyOverridesActions::Delete { override_id } => {
+                        commands::organizations::policy_overrides_delete(&cfg, &override_id)
+                            .await?;
+                    }
+                },
+                OrgActions::PolicyConfigs { action } => match action {
+                    OrgPolicyConfigsActions::List => {
+                        commands::organizations::policy_configs_list(&cfg).await?;
+                    }
+                },
             }
         }
         // --- Change Management ---


### PR DESCRIPTION
## Summary
Expose the v2 org group policy management surface as `pup organizations policies`, `pup organizations policy-overrides`, and `pup organizations policy-configs list`. All 11 endpoints are unstable and are registered in `UNSTABLE_OPS` so the client enables them automatically.

Includes the two new-in-0.30.0 endpoints (`GET /policies/{id}`, `GET /policy-overrides/{id}`) alongside the pre-existing CRUD for a cohesive end-to-end flow. The sibling endpoints for org-group CRUD and memberships are not in this PR; they can follow as a pure parity PR.

## Commands
```
pup organizations policies list --group-id <uuid> [--name <s>] [--page-number N] [--page-size N] [--sort <s>]
pup organizations policies get <policy-id>
pup organizations policies create --file body.json
pup organizations policies update <policy-id> --file body.json
pup organizations policies delete <policy-id>

pup organizations policy-overrides list --group-id <uuid> [--policy-id <uuid>] [--page-number N] [--page-size N] [--sort <s>]
pup organizations policy-overrides get <override-id>
pup organizations policy-overrides create --file body.json
pup organizations policy-overrides update <override-id> --file body.json
pup organizations policy-overrides delete <override-id>

pup organizations policy-configs list
```

## Changes
- `src/client.rs`: register 11 `v2.*_org_group_policy*` and `v2.*_org_group_policy_override*` and `v2.list_org_group_policy_configs` ops in UNSTABLE_OPS; bump count test 147 → 158
- `src/commands/organizations.rs`: add `policies_*`, `policy_overrides_*`, `policy_configs_list`; UUIDs parsed at call site with friendly errors; sort flags mapped to typed enums
- `src/main.rs`: add `OrgActions::Policies` / `PolicyOverrides` / `PolicyConfigs` variants, subcommand enums, and match arms

## Unstable endpoints
All 11 endpoints are marked `x-unstable: true` in the spec (\"This endpoint is in preview and is subject to change\"). Consistent with pup's pattern of exposing unstable ops behind `UNSTABLE_OPS`.

## Testing
- 18 new unit tests: happy-path list/get/create/update/delete for both policies and overrides, policy-configs list + 403, 404 errors, and negative tests for invalid UUIDs and invalid sort inputs
- `cargo test -- --test-threads=1`: 892/892 pass (874 baseline + 18 new)
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean
- Verified help output across all new subcommands

🤖 Generated with [Claude Code](https://claude.com/claude-code)