### PR TITLE
incidents: expose --query on `incidents list` (default state:active)

### DIFF
--- a/src/commands/incidents.rs
+++ b/src/commands/incidents.rs
@@ -29,13 +29,14 @@ fn make_api(cfg: &Config) -> IncidentsAPI {
 // Core incident operations
 // ---------------------------------------------------------------------------
 
-pub async fn list(cfg: &Config, limit: i64) -> Result<()> {
+pub async fn list(cfg: &Config, query: Option<String>, limit: i64) -> Result<()> {
     let api = make_api(cfg);
     let params = SearchIncidentsOptionalParams::default()
         .page_size(limit)
         .sort(IncidentSearchSortOrder::CREATED_DESCENDING);
+    let q = query.unwrap_or_else(|| "state:active".to_string());
     let resp = api
-        .search_incidents("state:active".to_string(), params)
+        .search_incidents(q, params)
         .await
         .map_err(|e| anyhow::anyhow!("failed to list incidents: {:?}", e))?;
     formatter::output(cfg, &resp)?;
@@ -364,7 +365,7 @@ mod tests {
         let mut s = mockito::Server::new_async().await;
         let cfg = test_config(&s.url());
         mock_all(&mut s, r#"{"data": []}"#).await;
-        let _ = super::list(&cfg, 10).await;
+        let _ = super::list(&cfg, None, 10).await;
         cleanup_env();
     }
 

--- a/src/commands/incidents.rs
+++ b/src/commands/incidents.rs
@@ -369,6 +369,67 @@ mod tests {
         cleanup_env();
     }
 
+    /// When a `--query` is supplied, it must be forwarded as the
+    /// `filter[query]` URL parameter on the incidents-search request.
+    #[tokio::test]
+    async fn test_incidents_list_forwards_query() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+
+        // Strict mock: only matches when the request URL contains the
+        // URL-encoded `filter[query]=state:resolved`. Any other query
+        // string falls through and the request fails.
+        let _mock = s
+            .mock("GET", mockito::Matcher::Any)
+            .match_query(mockito::Matcher::UrlEncoded(
+                "filter[query]".into(),
+                "state:resolved".into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data": []}"#)
+            .create_async()
+            .await;
+
+        let result = super::list(&cfg, Some("state:resolved".to_string()), 10).await;
+        assert!(
+            result.is_ok(),
+            "list with --query=state:resolved should forward the query: {:?}",
+            result.err()
+        );
+        cleanup_env();
+    }
+
+    /// When `--query` is omitted, the default `state:active` must still be
+    /// sent on the wire, preserving the previous CLI behavior.
+    #[tokio::test]
+    async fn test_incidents_list_defaults_to_state_active() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+
+        let _mock = s
+            .mock("GET", mockito::Matcher::Any)
+            .match_query(mockito::Matcher::UrlEncoded(
+                "filter[query]".into(),
+                "state:active".into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data": []}"#)
+            .create_async()
+            .await;
+
+        let result = super::list(&cfg, None, 10).await;
+        assert!(
+            result.is_ok(),
+            "list with no --query should default to state:active: {:?}",
+            result.err()
+        );
+        cleanup_env();
+    }
+
     #[tokio::test]
     async fn test_incidents_get() {
         let _lock = lock_env().await;

--- a/src/commands/incidents.rs
+++ b/src/commands/incidents.rs
@@ -370,25 +370,25 @@ mod tests {
     }
 
     /// When a `--query` is supplied, it must be forwarded as the
-    /// `filter[query]` URL parameter on the incidents-search request.
+    /// `query` URL parameter on the incidents-search request.
     #[tokio::test]
     async fn test_incidents_list_forwards_query() {
         let _lock = lock_env().await;
         let mut s = mockito::Server::new_async().await;
         let cfg = test_config(&s.url());
 
-        // Strict mock: only matches when the request URL contains the
-        // URL-encoded `filter[query]=state:resolved`. Any other query
-        // string falls through and the request fails.
+        // Strict mock: only matches when the request URL contains
+        // `query=state:resolved`. Any other query string falls through
+        // and the request fails.
         let _mock = s
             .mock("GET", mockito::Matcher::Any)
             .match_query(mockito::Matcher::UrlEncoded(
-                "filter[query]".into(),
+                "query".into(),
                 "state:resolved".into(),
             ))
             .with_status(200)
             .with_header("content-type", "application/json")
-            .with_body(r#"{"data": []}"#)
+            .with_body(r#"{"data": {}}"#)
             .create_async()
             .await;
 
@@ -412,12 +412,12 @@ mod tests {
         let _mock = s
             .mock("GET", mockito::Matcher::Any)
             .match_query(mockito::Matcher::UrlEncoded(
-                "filter[query]".into(),
+                "query".into(),
                 "state:active".into(),
             ))
             .with_status(200)
             .with_header("content-type", "application/json")
-            .with_body(r#"{"data": []}"#)
+            .with_body(r#"{"data": {}}"#)
             .create_async()
             .await;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1435,8 +1435,14 @@ enum Commands {
     ///   • completed: Post-incident tasks completed (postmortem, etc.)
     ///
     /// EXAMPLES:
-    ///   # List all incidents
+    ///   # List active incidents (default)
     ///   pup incidents list
+    ///
+    ///   # List resolved incidents
+    ///   pup incidents list --query="state:resolved"
+    ///
+    ///   # Filter by severity
+    ///   pup incidents list --query="severity:SEV-2"
     ///
     ///   # Get detailed incident information
     ///   pup incidents get abc-123-def
@@ -3000,6 +3006,11 @@ enum LogMetricActions {
 enum IncidentActions {
     /// List all incidents
     List {
+        #[arg(
+            long,
+            help = "Filter incidents using Datadog incidents search syntax (e.g., 'state:resolved', 'severity:SEV-2', 'state:(active OR stable)'). Defaults to 'state:active'."
+        )]
+        query: Option<String>,
         #[arg(long, default_value_t = 50)]
         limit: i64,
     },
@@ -9990,8 +10001,8 @@ async fn main_inner() -> anyhow::Result<()> {
         Commands::Incidents { action } => {
             cfg.validate_auth()?;
             match action {
-                IncidentActions::List { limit } => {
-                    commands::incidents::list(&cfg, limit).await?;
+                IncidentActions::List { query, limit } => {
+                    commands::incidents::list(&cfg, query, limit).await?;
                 }
                 IncidentActions::Get { incident_id } => {
                     commands::incidents::get(&cfg, &incident_id).await?;


### PR DESCRIPTION
## Motivation

`pup incidents list` currently hardcodes `"state:active"` as the search query (`src/commands/incidents.rs:38`), with no flag to override. The only exposed flag is `--limit`. This silently excludes resolved/stable incidents from the listing — a problem for any workflow that wants to summarize a past time window (e.g., a weekly on-call review, postmortem prep, or compliance audit).

## Change

Add a `--query` flag to `incidents list` that maps directly to the first arg of `search_incidents()` in the Datadog SDK. When omitted, the behavior is unchanged (`state:active` by default), so this is a purely additive change.

```
# Before — only active
pup incidents list

# After — all the existing power of the Datadog incidents search syntax
pup incidents list --query="state:resolved"
pup incidents list --query="severity:SEV-2"
pup incidents list --query="state:(active OR stable)"
pup incidents list --query="services:my-service state:resolved"
pup incidents list --query="responder:alice@example.com"
```

The pattern matches `cases search` (`src/commands/cases.rs:32`), `monitors search`, and `slos list`, all of which already expose an optional `query: Option<String>`.

## Files touched

- `src/commands/incidents.rs` — `list()` takes `query: Option<String>`, defaulting to `"state:active"`. Two new strict tests (`test_incidents_list_forwards_query`, `test_incidents_list_defaults_to_state_active`) assert the value flows through to the actual `query=` URL parameter.
- `src/main.rs` — `IncidentActions::List` gains a `query` field; help text and example block updated.

## Test plan

### Unit tests (locally on `incidents-list-query`)

- [x] `cargo test --bin pup` — **949 passed, 0 failed** (incl. the two new strict tests).
- [x] `cargo clippy --bin pup -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.

The new tests use `mockito::Matcher::UrlEncoded("query", ...)` to assert the URL parameter (the Datadog SDK serializes the search query as `query=...`, see `datadog-api-client-rust/src/datadogV2/api/api_incidents.rs:7052`), so they would catch any regression that drops the parameter or sends the wrong default.

### End-to-end verification against the live Datadog API

Built locally (`cargo build`) and exercised against prod:

| Test | Expected | Actual |
|---|---|---|
| `pup incidents list` (no flag) | only `state:active`, behavior unchanged | ✅ 5/5 active |
| `--query="state:resolved"` | only `resolved` | ✅ 500/500 resolved on a `--limit 500` run |
| `--query="severity:SEV-2"` | only SEV-2 | ✅ 5/5 SEV-2 |
| `--query="responder:user@example.com"` | only incidents that user responded to | ✅ filtered to a 26-incident user-scoped list |
| State purity check (`state:stable` IDs absent from `state:resolved` results) | yes | ✅ |
| Recovery check: a known resolved incident that was hidden by the previous active-only behavior reappeared in `--query="state:resolved"` results | yes | ✅ |

The change works against the live API exactly as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)