### PR TITLE
fix(dbm): accept OAuth2 bearer tokens in samples search

### DIFF
--- a/src/commands/dbm.rs
+++ b/src/commands/dbm.rs
@@ -48,7 +48,7 @@ pub async fn samples_search(
     limit: i32,
     sort: String,
 ) -> Result<()> {
-    cfg.validate_api_and_app_keys()?;
+    cfg.validate_auth()?;
 
     let from_ms = util::parse_time_to_unix_millis(&from)?;
     let to_ms = util::parse_time_to_unix_millis(&to)?;
@@ -180,6 +180,79 @@ mod tests {
             result.is_ok(),
             "dbm samples search failed: {:?}",
             result.err()
+        );
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_dbm_samples_search_accepts_oauth_bearer_token() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let mut cfg = test_config(&server.url());
+        // Simulate OAuth-only auth: bearer token configured, no API/APP keys.
+        cfg.api_key = None;
+        cfg.app_key = None;
+        cfg.access_token = Some("oauth-bearer-token".into());
+        std::env::remove_var("DD_API_KEY");
+        std::env::remove_var("DD_APP_KEY");
+
+        let _mock = server
+            .mock("POST", "/api/v1/logs-analytics/list")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "type".into(),
+                "databasequery".into(),
+            ))
+            .match_header("Authorization", "Bearer oauth-bearer-token")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data":[]}"#)
+            .create_async()
+            .await;
+
+        let result = super::samples_search(
+            &cfg,
+            "service:db".into(),
+            "1h".into(),
+            "now".into(),
+            10,
+            "asc".into(),
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "dbm samples search with OAuth bearer failed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_dbm_samples_search_rejects_when_no_auth_configured() {
+        let _lock = lock_env().await;
+        let server = mockito::Server::new_async().await;
+        let mut cfg = test_config(&server.url());
+        cfg.api_key = None;
+        cfg.app_key = None;
+        cfg.access_token = None;
+        std::env::remove_var("DD_API_KEY");
+        std::env::remove_var("DD_APP_KEY");
+
+        let result = super::samples_search(
+            &cfg,
+            "service:db".into(),
+            "1h".into(),
+            "now".into(),
+            10,
+            "asc".into(),
+        )
+        .await;
+
+        assert!(result.is_err(), "expected auth error when no credentials");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("authentication"),
+            "expected auth error message, got: {err}"
         );
         cleanup_env();
     }


### PR DESCRIPTION
## What does this PR do?

Allows `pup dbm samples search` to authenticate with an OAuth2 bearer token (`pup auth login`) in addition to `DD_API_KEY` + `DD_APP_KEY`.

The single behavioral change is in `src/commands/dbm.rs`: replace the upfront `cfg.validate_api_and_app_keys()?;` gate with `cfg.validate_auth()?;`. The underlying `client::raw_post` / `apply_auth` already prefer a bearer token when present and fall back to API+APP keys otherwise, so no client-side changes are needed.

## Motivation

Closes #433.

`pup dbm samples search` rejected OAuth2 bearer tokens even though:

- The endpoint it calls (`/api/v1/logs-analytics/list`) is the same one used by `logs` commands, which already accept OAuth2.
- `pup dbm --help` advertises OAuth as a supported auth method, so users following the help guidance hit a hard error after `pup auth login`.

The behavior was a leftover from the command's initial template — `validate_api_and_app_keys` is documented in `src/config.rs` as being for endpoints that genuinely don't accept OAuth, which doesn't apply here.

## Additional Notes

- Existing happy-path test (`test_dbm_samples_search_uses_documented_payload`) still covers the API+APP key path.
- Two new tests added:
  - `test_dbm_samples_search_accepts_oauth_bearer_token` — asserts OAuth-only auth is accepted and the `Authorization: Bearer …` header is forwarded.
  - `test_dbm_samples_search_rejects_when_no_auth_configured` — asserts a clear error when neither auth method is configured.
- Diff is intentionally minimal and scoped to `src/commands/dbm.rs`.

## Checklist

- [x] The code change follows the project conventions (see [CONTRIBUTING.md](../docs/CONTRIBUTING.md))
- [x] Tests have been added/updated (if applicable)
- [ ] Documentation has been updated (if applicable) — no doc changes needed; `pup dbm --help` already advertised OAuth
- [x] All CI checks pass — pending
- [x] Code coverage is maintained or improved

## Related Issues

Closes #433