### PR TITLE
feat(security): add Terraform export and convert commands

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -230,6 +230,10 @@ static UNSTABLE_OPS: &[&str] = &[
     // Indicators of Compromise (2)
     "v2.list_indicators_of_compromise",
     "v2.get_indicator_of_compromise",
+    // Security Monitoring Terraform export (3)
+    "v2.bulk_export_security_monitoring_terraform_resources",
+    "v2.export_security_monitoring_terraform_resource",
+    "v2.convert_security_monitoring_terraform_resource",
     // Code Coverage (2)
     "v2.get_code_coverage_branch_summary",
     "v2.get_code_coverage_commit_summary",
@@ -1033,7 +1037,7 @@ mod tests {
 
     #[test]
     fn test_unstable_ops_count() {
-        assert_eq!(UNSTABLE_OPS.len(), 163);
+        assert_eq!(UNSTABLE_OPS.len(), 166);
     }
 
     #[test]

--- a/src/commands/security.rs
+++ b/src/commands/security.rs
@@ -22,10 +22,12 @@ use datadog_api_client::datadogV2::model::{
     ApplicationSecurityWafExclusionFilterUpdateRequest, RestrictionPolicyUpdateRequest,
     SecurityMonitoringRuleBulkExportAttributes, SecurityMonitoringRuleBulkExportData,
     SecurityMonitoringRuleBulkExportDataType, SecurityMonitoringRuleBulkExportPayload,
-    SecurityMonitoringRuleSort, SecurityMonitoringSignalListRequest,
-    SecurityMonitoringSignalListRequestFilter, SecurityMonitoringSignalListRequestPage,
-    SecurityMonitoringSignalsSort, SecurityMonitoringSuppressionCreateRequest,
-    SecurityMonitoringSuppressionSort, SecurityMonitoringSuppressionUpdateRequest,
+    SecurityMonitoringRuleConvertPayload, SecurityMonitoringRuleSort,
+    SecurityMonitoringSignalListRequest, SecurityMonitoringSignalListRequestFilter,
+    SecurityMonitoringSignalListRequestPage, SecurityMonitoringSignalsSort,
+    SecurityMonitoringSuppressionCreateRequest, SecurityMonitoringSuppressionSort,
+    SecurityMonitoringSuppressionUpdateRequest, SecurityMonitoringTerraformBulkExportRequest,
+    SecurityMonitoringTerraformConvertRequest, SecurityMonitoringTerraformResourceType,
 };
 
 const SCHEMA_URL: &str = "https://docs.datadoghq.com/security/guide/findings-schema.md";
@@ -296,6 +298,71 @@ pub async fn rules_bulk_export(cfg: &Config, rule_ids: Vec<String>) -> Result<()
     let output = String::from_utf8_lossy(&resp);
     println!("{output}");
     Ok(())
+}
+
+// ---- Terraform export ----
+
+fn parse_terraform_resource_type(s: &str) -> Result<SecurityMonitoringTerraformResourceType> {
+    Ok(match s {
+        "suppressions" => SecurityMonitoringTerraformResourceType::SUPPRESSIONS,
+        "critical_assets" => SecurityMonitoringTerraformResourceType::CRITICAL_ASSETS,
+        _ => {
+            anyhow::bail!("invalid resource-type '{s}' — use one of: suppressions, critical_assets")
+        }
+    })
+}
+
+pub async fn rules_to_terraform(cfg: &Config, file: &str) -> Result<()> {
+    let body: SecurityMonitoringRuleConvertPayload = util::read_json_file(file)?;
+    let api = crate::make_api!(SecurityMonitoringAPI, cfg);
+    let resp = api
+        .convert_security_monitoring_rule_from_json_to_terraform(body)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to convert rule to Terraform: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn terraform_export(cfg: &Config, resource_type: &str, resource_id: &str) -> Result<()> {
+    let rt = parse_terraform_resource_type(resource_type)?;
+    let api = crate::make_api!(SecurityMonitoringAPI, cfg);
+    let resp = api
+        .export_security_monitoring_terraform_resource(rt, resource_id.to_string())
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to export Terraform resource: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn terraform_bulk_export(
+    cfg: &Config,
+    resource_type: &str,
+    file: &str,
+    output_file: &str,
+) -> Result<()> {
+    let rt = parse_terraform_resource_type(resource_type)?;
+    let body: SecurityMonitoringTerraformBulkExportRequest = util::read_json_file(file)?;
+    let api = crate::make_api!(SecurityMonitoringAPI, cfg);
+    let bytes = api
+        .bulk_export_security_monitoring_terraform_resources(rt, body)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to bulk export Terraform resources: {e:?}"))?;
+    std::fs::write(output_file, &bytes)
+        .map_err(|e| anyhow::anyhow!("failed to write to '{output_file}': {e}"))?;
+    eprintln!(
+        "Wrote {} bytes (zip archive) to '{output_file}'.",
+        bytes.len()
+    );
+    Ok(())
+}
+
+pub async fn terraform_convert(cfg: &Config, resource_type: &str, file: &str) -> Result<()> {
+    let rt = parse_terraform_resource_type(resource_type)?;
+    let body: SecurityMonitoringTerraformConvertRequest = util::read_json_file(file)?;
+    let api = crate::make_api!(SecurityMonitoringAPI, cfg);
+    let resp = api
+        .convert_security_monitoring_terraform_resource(rt, body)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to convert Terraform resource: {e:?}"))?;
+    formatter::output(cfg, &resp)
 }
 
 // ---- Content Packs ----
@@ -768,6 +835,159 @@ mod tests {
             .await;
         let result = super::iocs_get(&cfg, "missing").await;
         assert!(result.is_err(), "expected error for 404 response");
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_security_rules_to_terraform() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let tmp = write_temp_json("pup_test_rule_to_tf.json", r#"{"rule":{}}"#);
+        let _mock = mock_any(
+            &mut server,
+            "POST",
+            r#"{"rule_id":"abc","resource":"resource \"x\" \"y\" {}"}"#,
+        )
+        .await;
+        let result = super::rules_to_terraform(&cfg, tmp.to_str().unwrap()).await;
+        assert!(
+            result.is_ok(),
+            "rules_to_terraform failed: {:?}",
+            result.err()
+        );
+        let _ = std::fs::remove_file(tmp);
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_security_terraform_export() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = mock_any(&mut server, "GET", r#"{}"#).await;
+        let result = super::terraform_export(&cfg, "suppressions", "abc-123").await;
+        assert!(
+            result.is_ok(),
+            "terraform_export failed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_security_terraform_export_bad_resource_type() {
+        let _lock = lock_env().await;
+        let cfg = test_config("http://unused.local");
+        let result = super::terraform_export(&cfg, "bogus", "abc-123").await;
+        assert!(result.is_err(), "expected resource-type parse error");
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("invalid resource-type"));
+    }
+
+    #[tokio::test]
+    async fn test_security_terraform_bulk_export() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let body_tmp = write_temp_json(
+            "pup_test_tf_bulk.json",
+            r#"{"data":{"type":"bulk_export_resources","attributes":{"resource_ids":["abc"]}}}"#,
+        );
+        let zip_bytes: &[u8] = b"PK\x03\x04fake-zip-bytes";
+        let _mock = server
+            .mock("POST", mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/zip")
+            .with_body(zip_bytes)
+            .create_async()
+            .await;
+        let out = std::env::temp_dir().join("pup_test_tf_bulk_out.zip");
+        let out_str = out.to_str().unwrap();
+        let result = super::terraform_bulk_export(
+            &cfg,
+            "critical_assets",
+            body_tmp.to_str().unwrap(),
+            out_str,
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "terraform_bulk_export failed: {:?}",
+            result.err()
+        );
+        let written = std::fs::read(&out).expect("expected output file to exist");
+        assert_eq!(written, zip_bytes);
+        let _ = std::fs::remove_file(&out);
+        let _ = std::fs::remove_file(body_tmp);
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_security_terraform_bulk_export_bad_type() {
+        let _lock = lock_env().await;
+        let cfg = test_config("http://unused.local");
+        let result = super::terraform_bulk_export(
+            &cfg,
+            "bogus",
+            "/nonexistent/path.json",
+            "/nonexistent/out.zip",
+        )
+        .await;
+        assert!(result.is_err(), "expected resource-type parse error");
+    }
+
+    #[tokio::test]
+    async fn test_security_terraform_convert() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let tmp = write_temp_json(
+            "pup_test_tf_convert.json",
+            r#"{"data":{"id":"abc","type":"convert_resource","attributes":{"resource_json":{}}}}"#,
+        );
+        let _mock = mock_any(&mut server, "POST", r#"{}"#).await;
+        let result = super::terraform_convert(&cfg, "suppressions", tmp.to_str().unwrap()).await;
+        assert!(
+            result.is_ok(),
+            "terraform_convert failed: {:?}",
+            result.err()
+        );
+        let _ = std::fs::remove_file(tmp);
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_security_terraform_convert_403() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let tmp = write_temp_json(
+            "pup_test_tf_convert_403.json",
+            r#"{"data":{"id":"abc","type":"convert_resource","attributes":{"resource_json":{}}}}"#,
+        );
+        let _mock = server
+            .mock("POST", mockito::Matcher::Any)
+            .with_status(403)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors":["Forbidden"]}"#)
+            .create_async()
+            .await;
+        let result = super::terraform_convert(&cfg, "suppressions", tmp.to_str().unwrap()).await;
+        assert!(result.is_err(), "expected 403 error");
+        let _ = std::fs::remove_file(tmp);
         cleanup_env();
         std::env::remove_var("DD_TOKEN_STORAGE");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4396,6 +4396,42 @@ enum SecurityActions {
         #[command(subcommand)]
         action: RestrictionPolicyActions,
     },
+    /// Export and convert security monitoring resources as Terraform
+    Terraform {
+        #[command(subcommand)]
+        action: SecurityTerraformActions,
+    },
+}
+
+#[derive(Subcommand)]
+enum SecurityTerraformActions {
+    /// Export a single resource as Terraform
+    Export {
+        /// Resource type (suppressions, critical_assets)
+        resource_type: String,
+        /// Resource ID to export
+        resource_id: String,
+    },
+    /// Bulk export resources as a Terraform zip archive
+    #[command(name = "bulk-export")]
+    BulkExport {
+        /// Resource type (suppressions, critical_assets)
+        resource_type: String,
+        #[arg(long, help = "JSON file with the bulk export payload (required)")]
+        file: String,
+        #[arg(
+            long = "output-file",
+            help = "Path to write the zip archive to (required)"
+        )]
+        output_file: String,
+    },
+    /// Convert a JSON resource definition into Terraform
+    Convert {
+        /// Resource type (suppressions, critical_assets)
+        resource_type: String,
+        #[arg(long, help = "JSON file with the conversion payload (required)")]
+        file: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -4473,6 +4509,12 @@ enum SecurityRuleActions {
     BulkExport {
         /// Rule IDs to export
         rule_ids: Vec<String>,
+    },
+    /// Convert a JSON rule definition into a Terraform resource
+    #[command(name = "to-terraform")]
+    ToTerraform {
+        #[arg(long, help = "JSON file with the rule conversion payload (required)")]
+        file: String,
     },
 }
 
@@ -10704,6 +10746,9 @@ async fn main_inner() -> anyhow::Result<()> {
                     SecurityRuleActions::BulkExport { rule_ids } => {
                         commands::security::rules_bulk_export(&cfg, rule_ids).await?;
                     }
+                    SecurityRuleActions::ToTerraform { file } => {
+                        commands::security::rules_to_terraform(&cfg, &file).await?;
+                    }
                 },
                 SecurityActions::Signals { action } => match action {
                     SecuritySignalActions::List {
@@ -10862,6 +10907,34 @@ async fn main_inner() -> anyhow::Result<()> {
                     }
                     RestrictionPolicyActions::Delete { resource_id } => {
                         commands::security::restriction_policy_delete(&cfg, &resource_id).await?;
+                    }
+                },
+                SecurityActions::Terraform { action } => match action {
+                    SecurityTerraformActions::Export {
+                        resource_type,
+                        resource_id,
+                    } => {
+                        commands::security::terraform_export(&cfg, &resource_type, &resource_id)
+                            .await?;
+                    }
+                    SecurityTerraformActions::BulkExport {
+                        resource_type,
+                        file,
+                        output_file,
+                    } => {
+                        commands::security::terraform_bulk_export(
+                            &cfg,
+                            &resource_type,
+                            &file,
+                            &output_file,
+                        )
+                        .await?;
+                    }
+                    SecurityTerraformActions::Convert {
+                        resource_type,
+                        file,
+                    } => {
+                        commands::security::terraform_convert(&cfg, &resource_type, &file).await?;
                     }
                 },
             }


### PR DESCRIPTION
## Summary
Expose the v2 Security Monitoring Terraform endpoints from datadog-api-client 0.30.0:

```
pup security rules to-terraform --file rule.json
pup security terraform export <type> <id>
pup security terraform bulk-export <type> --file body.json --output-file out.zip
pup security terraform convert <type> --file body.json
```

Resource types accepted by the `terraform` subgroup: `suppressions`, `critical_assets`.

## Stability
| Endpoint | Stable? |
| --- | --- |
| \`convert_security_monitoring_rule_from_json_to_terraform\` | ✅ stable |
| \`bulk_export_security_monitoring_terraform_resources\` | ⚠️ unstable |
| \`export_security_monitoring_terraform_resource\` | ⚠️ unstable |
| \`convert_security_monitoring_terraform_resource\` | ⚠️ unstable |

The 3 unstable endpoints are registered in \`UNSTABLE_OPS\` so the client enables them automatically.

## Notes on \`bulk-export\`
The endpoint streams an \`application/zip\` archive. Rather than mangling binary data through stdout, this command requires \`--output-file\` and writes the zip bytes verbatim to disk via \`std::fs::write\`. (The pre-existing \`pup security rules bulk-export\` outputs the zip via \`String::from_utf8_lossy\` to stdout, which corrupts binary data — that's a pre-existing issue, not addressed here.)

## Changes
- \`src/client.rs\`: register 3 new unstable ops in \`UNSTABLE_OPS\`; bump count test 163 → 166
- \`src/commands/security.rs\`: add \`rules_to_terraform\`, \`terraform_export\`, \`terraform_bulk_export\`, \`terraform_convert\`, plus a \`parse_terraform_resource_type\` helper with friendly error
- \`src/main.rs\`: add \`SecurityRuleActions::ToTerraform\`, \`SecurityActions::Terraform\` with \`Export\` / \`BulkExport\` / \`Convert\` subactions, and corresponding match arms

## Testing
- 7 new unit tests: rule-to-Terraform happy path, \`terraform_export\` happy path + invalid resource-type, \`terraform_bulk_export\` happy path (verifies zip bytes are written to disk verbatim) + bad type, \`terraform_convert\` happy path + 403
- \`cargo test -- --test-threads=1\`: 958/958 pass
- \`cargo clippy --all-targets -- -D warnings\`: clean
- \`cargo fmt --check\`: clean
- Verified help: \`pup security terraform --help --no-agent\` and \`pup security rules to-terraform --help --no-agent\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)