### PR TITLE
chore: prepare for transfer from datadog-labs to datadog org

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,7 +6,7 @@
     "name": "Datadog",
     "email": "support@datadoghq.com"
   },
-  "repository": "https://github.com/datadog-labs/pup",
+  "repository": "https://github.com/datadog/pup",
   "license": "Apache-2.0",
   "keywords": ["datadog", "monitoring", "logs", "apm", "metrics", "security", "infrastructure"]
 }

--- a/.github/chainguard/release.sts.yaml
+++ b/.github/chainguard/release.sts.yaml
@@ -1,12 +1,12 @@
-# Policy for: .github/workflows/release-prepare.yml in datadog-labs/pup
+# Policy for: .github/workflows/release-prepare.yml in datadog/pup
 issuer: https://token.actions.githubusercontent.com
-subject: repo:datadog-labs/pup:ref:refs/heads/main
+subject: repo:datadog/pup:ref:refs/heads/main
 
 claim_pattern:
   event_name: schedule|workflow_dispatch
-  job_workflow_ref: datadog-labs/pup/\.github/workflows/release-prepare\.yml@refs/heads/main
+  job_workflow_ref: datadog/pup/\.github/workflows/release-prepare\.yml@refs/heads/main
   ref: refs/heads/main
-  repository: datadog-labs/pup
+  repository: datadog/pup
 
 permissions:
   contents: write

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
         id: octo-sts
         with:
-          scope: datadog-labs/pup
+          scope: datadog/pup
           policy: release
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,19 +289,19 @@ jobs:
 
           \`\`\`bash
           # macOS (Apple Silicon)
-          curl -L https://github.com/datadog-labs/pup/releases/download/${TAG}/pup_${VERSION}_Darwin_arm64.tar.gz | tar xz
+          curl -L https://github.com/datadog/pup/releases/download/${TAG}/pup_${VERSION}_Darwin_arm64.tar.gz | tar xz
 
           # macOS (Intel)
-          curl -L https://github.com/datadog-labs/pup/releases/download/${TAG}/pup_${VERSION}_Darwin_x86_64.tar.gz | tar xz
+          curl -L https://github.com/datadog/pup/releases/download/${TAG}/pup_${VERSION}_Darwin_x86_64.tar.gz | tar xz
 
           # Linux (x86_64)
-          curl -L https://github.com/datadog-labs/pup/releases/download/${TAG}/pup_${VERSION}_Linux_x86_64.tar.gz | tar xz
+          curl -L https://github.com/datadog/pup/releases/download/${TAG}/pup_${VERSION}_Linux_x86_64.tar.gz | tar xz
 
           # Linux (arm64)
-          curl -L https://github.com/datadog-labs/pup/releases/download/${TAG}/pup_${VERSION}_Linux_arm64.tar.gz | tar xz
+          curl -L https://github.com/datadog/pup/releases/download/${TAG}/pup_${VERSION}_Linux_arm64.tar.gz | tar xz
 
           # Windows (x86_64)
-          curl -L https://github.com/datadog-labs/pup/releases/download/${TAG}/pup_${VERSION}_Windows_x86_64.zip -o pup.zip
+          curl -L https://github.com/datadog/pup/releases/download/${TAG}/pup_${VERSION}_Windows_x86_64.zip -o pup.zip
           tar -xf pup.zip
           \`\`\`
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -115,7 +115,7 @@ changelog:
 
 release:
   github:
-    owner: datadog-labs
+    owner: datadog
     name: pup
   draft: false
   prerelease: auto
@@ -131,19 +131,19 @@ release:
 
     ```bash
     # macOS (Apple Silicon)
-    curl -L https://github.com/datadog-labs/pup/releases/download/{{ .Tag }}/pup_{{ .Version }}_Darwin_arm64.tar.gz | tar xz
+    curl -L https://github.com/datadog/pup/releases/download/{{ .Tag }}/pup_{{ .Version }}_Darwin_arm64.tar.gz | tar xz
 
     # macOS (Intel)
-    curl -L https://github.com/datadog-labs/pup/releases/download/{{ .Tag }}/pup_{{ .Version }}_Darwin_x86_64.tar.gz | tar xz
+    curl -L https://github.com/datadog/pup/releases/download/{{ .Tag }}/pup_{{ .Version }}_Darwin_x86_64.tar.gz | tar xz
 
     # Linux (x86_64)
-    curl -L https://github.com/datadog-labs/pup/releases/download/{{ .Tag }}/pup_{{ .Version }}_Linux_x86_64.tar.gz | tar xz
+    curl -L https://github.com/datadog/pup/releases/download/{{ .Tag }}/pup_{{ .Version }}_Linux_x86_64.tar.gz | tar xz
 
     # Linux (arm64)
-    curl -L https://github.com/datadog-labs/pup/releases/download/{{ .Tag }}/pup_{{ .Version }}_Linux_arm64.tar.gz | tar xz
+    curl -L https://github.com/datadog/pup/releases/download/{{ .Tag }}/pup_{{ .Version }}_Linux_arm64.tar.gz | tar xz
 
     # Windows (x86_64)
-    curl -L https://github.com/datadog-labs/pup/releases/download/{{ .Tag }}/pup_{{ .Version }}_Windows_x86_64.zip -o pup.zip
+    curl -L https://github.com/datadog/pup/releases/download/{{ .Tag }}/pup_{{ .Version }}_Windows_x86_64.zip -o pup.zip
     tar -xf pup.zip
     ```
 
@@ -165,4 +165,4 @@ release:
     ```
 
   footer: |
-    **Full Changelog**: https://github.com/datadog-labs/pup/compare/{{ .PreviousTag }}...{{ .Tag }}
+    **Full Changelog**: https://github.com/datadog/pup/compare/{{ .PreviousTag }}...{{ .Tag }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
 # Changelog
 
-See the [GitHub Releases](https://github.com/datadog-labs/pup/releases) page for
+See the [GitHub Releases](https://github.com/datadog/pup/releases) page for
 the authoritative list of changes per release.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ brew tap datadog-labs/pack
 brew install pup
 
 # Or clone and build from source
-git clone https://github.com/datadog-labs/pup.git && cd pup
+git clone https://github.com/datadog/pup.git && cd pup
 cargo build --release
 cp target/release/pup /usr/local/bin/pup
 
@@ -213,5 +213,5 @@ Apache 2.0 - Copyright 2024-present Datadog, Inc.
 
 ## Support
 
-- Issues: [GitHub Issues](https://github.com/datadog-labs/pup/issues)
+- Issues: [GitHub Issues](https://github.com/datadog/pup/issues)
 - Community: [Datadog Community](https://community.datadoghq.com/)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **NOTICE: This is in Preview mode, we are fine tuning the interactions and bugs that arise. Please file issues or submit PRs. Thank you for your early interest!**
 
-[![CI](https://github.com/datadog-labs/pup/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/datadog-labs/pup/actions/workflows/ci.yml)
+[![CI](https://github.com/datadog/pup/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/datadog/pup/actions/workflows/ci.yml)
 [![Rust](https://img.shields.io/badge/rust-stable-orange?logo=rust)](https://www.rust-lang.org/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
@@ -44,7 +44,7 @@ Pup covers most major Datadog product surfaces. See
 `pup --help` (or `pup agent schema` for machine-readable output) for the live
 list of commands as built.
 
-💡 **Tip:** Use Ctrl/Cmd+F to search for specific APIs. [Request features via GitHub Issues](https://github.com/datadog-labs/pup/issues).
+💡 **Tip:** Use Ctrl/Cmd+F to search for specific APIs. [Request features via GitHub Issues](https://github.com/datadog/pup/issues).
 
 ---
 
@@ -192,14 +192,14 @@ brew install datadog-labs/pack/pup
 ### Build from Source
 
 ```bash
-git clone https://github.com/datadog-labs/pup.git && cd pup
+git clone https://github.com/datadog/pup.git && cd pup
 cargo build --release
 cp target/release/pup /usr/local/bin/pup
 ```
 
 ### Manual Download
 
-Download pre-built binaries from the [latest release](https://github.com/datadog-labs/pup/releases/latest).
+Download pre-built binaries from the [latest release](https://github.com/datadog/pup/releases/latest).
 
 ## Authentication
 
@@ -508,7 +508,7 @@ For Claude Code, skills install to `.claude/skills/` and agents install to `.cla
 Pup is also available as a **Claude Code plugin marketplace**:
 
 ```
-/plugin marketplace add datadog-labs/pup
+/plugin marketplace add datadog/pup
 ```
 
 ## ACP Server

--- a/SKILL.md
+++ b/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   author:
     name: Datadog
     email: support@datadoghq.com
-  repository: https://github.com/datadog-labs/pup
+  repository: https://github.com/datadog/pup
   tags: datadog,cli,monitoring,logs,apm,metrics,security,infrastructure
 ---
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Guidelines for contributing to Pup.
 
 Pup uses the **fork and pull** model: contributors push changes to their
 personal fork and open pull requests to bring those changes into this
-repository. Direct pushes to `datadog-labs/pup` are not permitted.
+repository. Direct pushes to `datadog/pup` are not permitted.
 
 ### 1. Fork and clone
 
@@ -16,7 +16,7 @@ git clone https://github.com/<your-username>/pup.git
 cd pup
 
 # Add upstream remote and disable accidental pushes to it
-git remote add upstream https://github.com/datadog-labs/pup.git
+git remote add upstream https://github.com/datadog/pup.git
 git remote set-url --push upstream no_push
 ```
 
@@ -224,7 +224,7 @@ EOF
 
 ### 4. Push and open a pull request
 
-Push to your fork, then open a PR against `datadog-labs/pup:main`:
+Push to your fork, then open a PR against `datadog/pup:main`:
 
 ```bash
 git push -u origin <type>/<short-description>
@@ -234,7 +234,7 @@ Use `gh` CLI for efficiency:
 
 ```bash
 gh pr create \
-  --repo datadog-labs/pup \
+  --repo datadog/pup \
   --head <your-username>:<branch-name> \
   --title "<type>(<scope>): <clear, concise title>" \
   --body "$(cat <<'EOF'
@@ -278,7 +278,7 @@ EOF
 **Example PR:**
 ```bash
 gh pr create \
-  --repo datadog-labs/pup \
+  --repo datadog/pup \
   --head your-username:feat/oauth2-token-refresh \
   --title "feat(auth): implement OAuth2 token refresh with PKCE" \
   --body "$(cat <<'EOF'

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -510,7 +510,7 @@ When opening a GitHub issue, include:
 
 ### Community Support
 
-- **GitHub Issues:** [github.com/datadog-labs/pup/issues](https://github.com/datadog-labs/pup/issues)
+- **GitHub Issues:** [github.com/datadog/pup/issues](https://github.com/datadog/pup/issues)
 - **Datadog Community:** [community.datadoghq.com](https://community.datadoghq.com/)
 
 ## Common Workarounds

--- a/skills/dd-logs/SKILL.md
+++ b/skills/dd-logs/SKILL.md
@@ -19,7 +19,7 @@ Search, process, and archive logs with cost awareness.
 Datadog Pup (dd-pup/pup) should already be installed:
 
 ```bash
-go install github.com/datadog-labs/pup@latest
+go install github.com/datadog/pup@latest
 ```
 
 ## Quick Start

--- a/skills/dd-monitors/SKILL.md
+++ b/skills/dd-monitors/SKILL.md
@@ -18,7 +18,7 @@ Create, manage, and maintain monitors for alerting.
 ## Prerequisites
 This requires Go or the pup binary in your path. 
 
-`pup` - `go install github.com/datadog-labs/pup@latest`
+`pup` - `go install github.com/datadog/pup@latest`
 Ensure `~/go/bin` is in `$PATH`.
 
 

--- a/skills/dd-pup/SKILL.md
+++ b/skills/dd-pup/SKILL.md
@@ -298,7 +298,7 @@ brew tap datadog-labs/pack
 brew install pup
 
 # Or build from source
-cargo install --git https://github.com/datadog-labs/pup
+cargo install --git https://github.com/datadog/pup
 ```
 
 ### Verify Installation


### PR DESCRIPTION
## Summary
Updates all in-repo references from `datadog-labs/pup` to `datadog/pup` ahead of the GitHub repo transfer.

**Do not merge until the transfer is complete.** The updated `.github/chainguard/release.sts.yaml` policy only validates against the new repo path — merging early would break CI on the current `datadog-labs/pup`.

## Changes
- `.goreleaser.yaml` — owner + release URLs
- `.github/workflows/release.yml` + `release-prepare.yml` — release URLs and dd-octo-sts scope
- `.github/chainguard/release.sts.yaml` — subject, job_workflow_ref, repository
- README.md, CLAUDE.md, SKILL.md, CHANGELOG.md
- `docs/CONTRIBUTING.md`, `docs/TROUBLESHOOTING.md`
- `.claude-plugin/plugin.json`
- `skills/dd-pup/SKILL.md`, `skills/dd-logs/SKILL.md`, `skills/dd-monitors/SKILL.md` — install snippets

## Deliberately not changed
- `brew tap datadog-labs/pack` references — Homebrew tap is staying at `datadog-labs/pack`. Formula's `url`/`homepage` will be updated in the `datadog-labs/pack` repo separately.
- `datadog-labs/agent-skills` references in `skills/dd-*/SKILL.md` frontmatter — different repo, not part of this transfer.

## Open question
Confirm with whoever owns dd-octo-sts at Datadog whether the trust policy is read from `.github/chainguard/release.sts.yaml` at runtime or from a central registry. If central, that registry entry needs updating too.

## Merge sequence
1. Repo transfer: `datadog-labs/pup` → `datadog/pup`
2. Receiver accepts on `datadog` side
3. Re-install/grant any GitHub Apps that didn't auto-carry
4. Merge this PR
5. Cut a patch release to validate end-to-end
6. Follow-up in `datadog-labs/pack`: update formula `url`/`homepage` + any release-watcher workflows to point at `datadog/pup`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)