### PR TITLE
fix(client): override SDK User-Agent on all DD API paths

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,13 @@
+use std::process::Command;
+
+fn main() {
+    let version = Command::new("rustc")
+        .arg("--version")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .and_then(|s| s.split_whitespace().nth(1).map(str::to_owned))
+        .unwrap_or_else(|| "unknown".to_owned());
+    println!("cargo:rustc-env=RUSTC_VERSION={version}");
+    println!("cargo:rerun-if-env-changed=RUSTC_VERSION");
+}

--- a/src/auth/storage.rs
+++ b/src/auth/storage.rs
@@ -1212,9 +1212,7 @@ mod tests {
 
     #[test]
     fn test_session_registry_empty() {
-        let _lock = crate::test_utils::ENV_LOCK
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
+        let _lock = crate::test_utils::ENV_LOCK.blocking_lock();
         let tmp = TempDir::new("sess_empty");
         std::env::set_var("PUP_CONFIG_DIR", tmp.path());
         let sessions = list_sessions().unwrap();
@@ -1224,9 +1222,7 @@ mod tests {
 
     #[test]
     fn test_session_registry_save_and_list() {
-        let _lock = crate::test_utils::ENV_LOCK
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
+        let _lock = crate::test_utils::ENV_LOCK.blocking_lock();
         let tmp = TempDir::new("sess_save");
         std::env::set_var("PUP_CONFIG_DIR", tmp.path());
 
@@ -1246,9 +1242,7 @@ mod tests {
 
     #[test]
     fn test_session_registry_dedup() {
-        let _lock = crate::test_utils::ENV_LOCK
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
+        let _lock = crate::test_utils::ENV_LOCK.blocking_lock();
         let tmp = TempDir::new("sess_dedup");
         std::env::set_var("PUP_CONFIG_DIR", tmp.path());
 
@@ -1262,9 +1256,7 @@ mod tests {
 
     #[test]
     fn test_session_registry_remove() {
-        let _lock = crate::test_utils::ENV_LOCK
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
+        let _lock = crate::test_utils::ENV_LOCK.blocking_lock();
         let tmp = TempDir::new("sess_remove");
         std::env::set_var("PUP_CONFIG_DIR", tmp.path());
 
@@ -1280,9 +1272,7 @@ mod tests {
 
     #[test]
     fn test_session_registry_remove_nonexistent() {
-        let _lock = crate::test_utils::ENV_LOCK
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
+        let _lock = crate::test_utils::ENV_LOCK.blocking_lock();
         let tmp = TempDir::new("sess_rm_none");
         std::env::set_var("PUP_CONFIG_DIR", tmp.path());
         let result = remove_session("datadoghq.com", Some("nonexistent"));
@@ -1299,9 +1289,7 @@ mod tests {
     #[test]
     #[cfg(not(any(target_arch = "wasm32", target_os = "macos")))]
     fn test_detect_backend_with_probe_failure_falls_back_to_file() {
-        let _lock = crate::test_utils::ENV_LOCK
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
+        let _lock = crate::test_utils::ENV_LOCK.blocking_lock();
         let tmp = TempDir::new("detect_fallback");
         std::env::set_var("PUP_CONFIG_DIR", tmp.path());
         std::env::remove_var("DD_TOKEN_STORAGE");
@@ -1316,9 +1304,7 @@ mod tests {
     #[test]
     #[cfg(not(target_arch = "wasm32"))]
     fn test_detect_backend_with_dd_keychain_panics_when_unavailable() {
-        let _lock = crate::test_utils::ENV_LOCK
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
+        let _lock = crate::test_utils::ENV_LOCK.blocking_lock();
         let tmp = TempDir::new("detect_kc_panic");
         std::env::set_var("PUP_CONFIG_DIR", tmp.path());
         std::env::set_var("DD_TOKEN_STORAGE", "keychain");
@@ -1335,9 +1321,7 @@ mod tests {
 
     #[test]
     fn test_detect_backend_dd_token_storage_file() {
-        let _lock = crate::test_utils::ENV_LOCK
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
+        let _lock = crate::test_utils::ENV_LOCK.blocking_lock();
         let tmp = TempDir::new("detect_file");
         std::env::set_var("PUP_CONFIG_DIR", tmp.path());
         std::env::set_var("DD_TOKEN_STORAGE", "file");
@@ -1352,9 +1336,7 @@ mod tests {
     fn test_detect_backend_windows_default_is_keychain() {
         // Windows defaults to KeychainStorage (chunked WinCred) now that the
         // chunked scheme keeps blobs within the 2560-byte platform limit.
-        let _lock = crate::test_utils::ENV_LOCK
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
+        let _lock = crate::test_utils::ENV_LOCK.blocking_lock();
         let tmp = TempDir::new("detect_win");
         std::env::set_var("PUP_CONFIG_DIR", tmp.path());
         std::env::remove_var("DD_TOKEN_STORAGE");
@@ -1370,9 +1352,7 @@ mod tests {
     #[test]
     #[cfg(target_os = "windows")]
     fn test_detect_backend_dd_token_storage_keychain_windows() {
-        let _lock = crate::test_utils::ENV_LOCK
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
+        let _lock = crate::test_utils::ENV_LOCK.blocking_lock();
         let tmp = TempDir::new("detect_kc_win");
         std::env::set_var("PUP_CONFIG_DIR", tmp.path());
         std::env::set_var("DD_TOKEN_STORAGE", "keychain");

--- a/src/client.rs
+++ b/src/client.rs
@@ -36,6 +36,38 @@ impl Middleware for BearerAuthMiddleware {
 }
 
 // ---------------------------------------------------------------------------
+// User-Agent override middleware
+//
+// The `datadog-api-client` SDK sets its own `User-Agent` header on every
+// request (`datadog-api-client-rust/<ver>...`) and exposes no way to override
+// it from outside the crate. This middleware runs after the SDK builds the
+// request and replaces the header with pup's branded UA so audit logs and
+// telemetry attribute traffic to pup, not the underlying SDK.
+// ---------------------------------------------------------------------------
+
+#[cfg(not(target_arch = "wasm32"))]
+struct UserAgentMiddleware;
+
+#[cfg(not(target_arch = "wasm32"))]
+#[async_trait]
+impl Middleware for UserAgentMiddleware {
+    async fn handle(
+        &self,
+        mut req: reqwest_middleware::reqwest::Request,
+        extensions: &mut Extensions,
+        next: Next<'_>,
+    ) -> reqwest_middleware::Result<reqwest_middleware::reqwest::Response> {
+        if let Ok(ua) =
+            reqwest_middleware::reqwest::header::HeaderValue::from_str(&crate::useragent::get())
+        {
+            req.headers_mut()
+                .insert(reqwest_middleware::reqwest::header::USER_AGENT, ua);
+        }
+        next.run(req, extensions).await
+    }
+}
+
+// ---------------------------------------------------------------------------
 // DD Configuration builder
 // ---------------------------------------------------------------------------
 
@@ -113,20 +145,50 @@ pub fn make_dd_config(cfg: &Config) -> datadog_api_client::datadog::Configuratio
     dd_cfg
 }
 
-/// Creates a reqwest middleware client that injects a bearer token on every
-/// request. Returns `None` if no bearer token is configured, or on WASM
-/// targets where the token-injection middleware is unavailable.
-pub fn make_bearer_client(cfg: &Config) -> Option<ClientWithMiddleware> {
+/// Creates a reqwest middleware client for SDK API calls. Always installs the
+/// `UserAgentMiddleware` so requests are tagged with pup's branded `User-Agent`
+/// (see `useragent::get()`) instead of the SDK's default
+/// `datadog-api-client-rust/...`. If a bearer token is configured, also installs
+/// `BearerAuthMiddleware` to inject `Authorization: Bearer ...` per request.
+///
+/// Returns `None` on WASM targets where the middleware stack is unavailable;
+/// callers fall back to the SDK's default client (which sends the SDK UA).
+pub fn make_dd_client(cfg: &Config) -> Option<ClientWithMiddleware> {
     #[cfg(not(target_arch = "wasm32"))]
     {
-        let token = cfg.access_token.as_ref()?.clone();
         let reqwest_client = reqwest_middleware::reqwest::Client::builder()
             .build()
             .expect("failed to build reqwest client");
-        let client = ClientBuilder::new(reqwest_client)
-            .with(BearerAuthMiddleware { token })
-            .build();
-        return Some(client);
+        let mut builder = ClientBuilder::new(reqwest_client).with(UserAgentMiddleware);
+        if let Some(token) = cfg.access_token.as_ref() {
+            builder = builder.with(BearerAuthMiddleware {
+                token: token.clone(),
+            });
+        }
+        return Some(builder.build());
+    }
+    #[allow(unreachable_code)]
+    {
+        let _ = cfg;
+        None
+    }
+}
+
+/// Like `make_dd_client` but never installs `BearerAuthMiddleware`. Use for
+/// endpoints that don't support OAuth bearer tokens (see
+/// `OAUTH_EXCLUDED_ENDPOINTS`); the SDK still injects API key/app key auth
+/// headers from the `Configuration`.
+pub fn make_dd_client_no_auth() -> Option<ClientWithMiddleware> {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let reqwest_client = reqwest_middleware::reqwest::Client::builder()
+            .build()
+            .expect("failed to build reqwest client");
+        return Some(
+            ClientBuilder::new(reqwest_client)
+                .with(UserAgentMiddleware)
+                .build(),
+        );
     }
     #[allow(unreachable_code)]
     None
@@ -137,7 +199,21 @@ macro_rules! make_api {
     ($api:ty, $cfg:expr) => {{
         let cfg = $cfg;
         let dd_cfg = $crate::client::make_dd_config(cfg);
-        match $crate::client::make_bearer_client(cfg) {
+        match $crate::client::make_dd_client(cfg) {
+            Some(c) => <$api>::with_client_and_config(dd_cfg, c),
+            None => <$api>::with_config(dd_cfg),
+        }
+    }};
+}
+
+/// Same as `make_api!` but uses a UA-only client (no bearer). For OAuth-
+/// incompatible endpoints; SDK still applies API key auth from `Configuration`.
+#[macro_export]
+macro_rules! make_api_no_auth {
+    ($api:ty, $cfg:expr) => {{
+        let cfg = $cfg;
+        let dd_cfg = $crate::client::make_dd_config(cfg);
+        match $crate::client::make_dd_client_no_auth() {
             Some(c) => <$api>::with_client_and_config(dd_cfg, c),
             None => <$api>::with_config(dd_cfg),
         }
@@ -1077,16 +1153,17 @@ mod tests {
     }
 
     #[test]
-    fn test_make_bearer_client_none_without_token() {
+    fn test_make_dd_client_some_without_token() {
+        // UA middleware is always installed, so the client is always Some on native.
         let cfg = test_cfg();
-        assert!(make_bearer_client(&cfg).is_none());
+        assert!(make_dd_client(&cfg).is_some());
     }
 
     #[test]
-    fn test_make_bearer_client_some_with_token() {
+    fn test_make_dd_client_some_with_token() {
         let mut cfg = test_cfg();
         cfg.access_token = Some("test-token".into());
-        assert!(make_bearer_client(&cfg).is_some());
+        assert!(make_dd_client(&cfg).is_some());
     }
 
     #[test]
@@ -1314,6 +1391,88 @@ mod tests {
             "GET",
             "/api/ui/profiling/profiles/abc/download"
         ));
+    }
+
+    /// Verifies that requests built via `make_api!` carry pup's branded
+    /// `User-Agent` rather than the SDK's default `datadog-api-client-rust/...`.
+    /// The mock only matches when the header starts with `pup/`; if the
+    /// middleware fails to override, mockito returns 501 and the SDK call fails.
+    ///
+    /// Holds the std `ENV_LOCK` only for the sync env-var setup so it
+    /// serializes with sibling sync tests like `test_make_dd_config_with_mock_server`.
+    /// The mockito URL is captured into the `Configuration` struct, so the env
+    /// var is no longer needed once `api` has been built.
+    #[tokio::test]
+    async fn test_make_api_sends_pup_user_agent() {
+        use datadog_api_client::datadogV1::api_monitors::{
+            ListMonitorsOptionalParams, MonitorsAPI,
+        };
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .match_header("User-Agent", mockito::Matcher::Regex("^pup/".into()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body("[]")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let api: MonitorsAPI = {
+            let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+            let cfg = test_config(&server.url());
+            crate::make_api!(MonitorsAPI, &cfg)
+        };
+
+        let resp = api
+            .list_monitors(ListMonitorsOptionalParams::default())
+            .await;
+        assert!(
+            resp.is_ok(),
+            "make_api! request did not carry pup/ User-Agent: {:?}",
+            resp.err()
+        );
+        mock.assert_async().await;
+
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        cleanup_env();
+    }
+
+    /// Same coverage for the no-auth variant used by OAuth-incompatible endpoints.
+    #[tokio::test]
+    async fn test_make_api_no_auth_sends_pup_user_agent() {
+        use datadog_api_client::datadogV2::api_authn_mappings::{
+            AuthNMappingsAPI, ListAuthNMappingsOptionalParams,
+        };
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .match_header("User-Agent", mockito::Matcher::Regex("^pup/".into()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data":[]}"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let api: AuthNMappingsAPI = {
+            let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+            let cfg = test_config(&server.url());
+            crate::make_api_no_auth!(AuthNMappingsAPI, &cfg)
+        };
+
+        let resp = api
+            .list_authn_mappings(ListAuthNMappingsOptionalParams::default())
+            .await;
+        assert!(
+            resp.is_ok(),
+            "make_api_no_auth! request did not carry pup/ User-Agent: {:?}",
+            resp.err()
+        );
+        mock.assert_async().await;
+
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        cleanup_env();
     }
 
     /// Verifies that raw_request attaches query parameters and returns Ok when the

--- a/src/client.rs
+++ b/src/client.rs
@@ -1142,7 +1142,7 @@ mod tests {
     #[test]
     fn test_make_api_macro_without_bearer_token() {
         use datadog_api_client::datadogV1::api_monitors::MonitorsAPI;
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = ENV_LOCK.blocking_lock();
         std::env::remove_var("PUP_MOCK_SERVER");
         let cfg = test_cfg();
         let _api: MonitorsAPI = crate::make_api!(MonitorsAPI, &cfg);
@@ -1151,7 +1151,7 @@ mod tests {
     #[test]
     fn test_make_api_macro_with_bearer_token() {
         use datadog_api_client::datadogV1::api_monitors::MonitorsAPI;
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = ENV_LOCK.blocking_lock();
         std::env::remove_var("PUP_MOCK_SERVER");
         let mut cfg = test_cfg();
         cfg.access_token = Some("test-token".into());
@@ -1160,7 +1160,7 @@ mod tests {
 
     #[test]
     fn test_make_dd_config_returns_valid() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = ENV_LOCK.blocking_lock();
         let cfg = test_cfg();
         // Ensure env vars are set for DD client
         std::env::set_var("DD_API_KEY", "test-key");
@@ -1175,7 +1175,7 @@ mod tests {
 
     #[test]
     fn test_make_dd_config_with_mock_server() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = ENV_LOCK.blocking_lock();
         let cfg = test_cfg();
         std::env::set_var("DD_API_KEY", "test-key");
         std::env::set_var("DD_APP_KEY", "test-app-key");
@@ -1194,7 +1194,7 @@ mod tests {
 
     #[test]
     fn test_make_dd_config_https_mock() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = ENV_LOCK.blocking_lock();
         let cfg = test_cfg();
         std::env::set_var("DD_API_KEY", "test-key");
         std::env::set_var("DD_APP_KEY", "test-app-key");
@@ -1370,16 +1370,12 @@ mod tests {
     /// `User-Agent` rather than the SDK's default `datadog-api-client-rust/...`.
     /// The mock only matches when the header starts with `pup/`; if the
     /// middleware fails to override, mockito returns 501 and the SDK call fails.
-    ///
-    /// Holds the std `ENV_LOCK` only for the sync env-var setup so it
-    /// serializes with sibling sync tests like `test_make_dd_config_with_mock_server`.
-    /// The mockito URL is captured into the `Configuration` struct, so the env
-    /// var is no longer needed once `api` has been built.
     #[tokio::test]
     async fn test_make_api_sends_pup_user_agent() {
         use datadog_api_client::datadogV1::api_monitors::{
             ListMonitorsOptionalParams, MonitorsAPI,
         };
+        let _lock = lock_env().await;
         let mut server = mockito::Server::new_async().await;
         let mock = server
             .mock("GET", mockito::Matcher::Any)
@@ -1391,12 +1387,8 @@ mod tests {
             .create_async()
             .await;
 
-        let api: MonitorsAPI = {
-            let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
-            let cfg = test_config(&server.url());
-            crate::make_api!(MonitorsAPI, &cfg)
-        };
-
+        let cfg = test_config(&server.url());
+        let api: MonitorsAPI = crate::make_api!(MonitorsAPI, &cfg);
         let resp = api
             .list_monitors(ListMonitorsOptionalParams::default())
             .await;
@@ -1406,21 +1398,59 @@ mod tests {
             resp.err()
         );
         mock.assert_async().await;
-
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         cleanup_env();
     }
 
-    /// Same coverage for the no-auth variant used by OAuth-incompatible endpoints.
+    /// Like `test_make_api_sends_pup_user_agent`, but with an OAuth bearer
+    /// token configured — verifies that the UA middleware coexists with the
+    /// bearer middleware (both headers land on the same request).
+    #[tokio::test]
+    async fn test_make_api_sends_pup_user_agent_with_bearer() {
+        use datadog_api_client::datadogV1::api_monitors::{
+            ListMonitorsOptionalParams, MonitorsAPI,
+        };
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .match_header("User-Agent", mockito::Matcher::Regex("^pup/".into()))
+            .match_header("Authorization", "Bearer test-bearer-token")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body("[]")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let mut cfg = test_config(&server.url());
+        cfg.access_token = Some("test-bearer-token".into());
+        let api: MonitorsAPI = crate::make_api!(MonitorsAPI, &cfg);
+        let resp = api
+            .list_monitors(ListMonitorsOptionalParams::default())
+            .await;
+        assert!(
+            resp.is_ok(),
+            "make_api! with bearer didn't carry both UA and Authorization: {:?}",
+            resp.err()
+        );
+        mock.assert_async().await;
+        cleanup_env();
+    }
+
+    /// Same coverage for the no-auth variant. Asserts the UA is overridden
+    /// AND that no `Authorization` header leaks through, even when a bearer
+    /// token exists in the config — that's the contract of `make_api_no_auth!`.
     #[tokio::test]
     async fn test_make_api_no_auth_sends_pup_user_agent() {
         use datadog_api_client::datadogV2::api_authn_mappings::{
             AuthNMappingsAPI, ListAuthNMappingsOptionalParams,
         };
+        let _lock = lock_env().await;
         let mut server = mockito::Server::new_async().await;
         let mock = server
             .mock("GET", mockito::Matcher::Any)
             .match_header("User-Agent", mockito::Matcher::Regex("^pup/".into()))
+            .match_header("Authorization", mockito::Matcher::Missing)
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(r#"{"data":[]}"#)
@@ -1428,23 +1458,20 @@ mod tests {
             .create_async()
             .await;
 
-        let api: AuthNMappingsAPI = {
-            let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
-            let cfg = test_config(&server.url());
-            crate::make_api_no_auth!(AuthNMappingsAPI, &cfg)
-        };
-
+        let mut cfg = test_config(&server.url());
+        // Set a token so the Authorization-absent assertion meaningfully
+        // exercises that `make_api_no_auth!` actively suppresses bearer.
+        cfg.access_token = Some("test-bearer-token".into());
+        let api: AuthNMappingsAPI = crate::make_api_no_auth!(AuthNMappingsAPI, &cfg);
         let resp = api
             .list_authn_mappings(ListAuthNMappingsOptionalParams::default())
             .await;
         assert!(
             resp.is_ok(),
-            "make_api_no_auth! request did not carry pup/ User-Agent: {:?}",
+            "make_api_no_auth! request leaked Authorization or wrong UA: {:?}",
             resp.err()
         );
         mock.assert_async().await;
-
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         cleanup_env();
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,10 +9,6 @@ use reqwest_middleware::{Middleware, Next};
 
 use crate::config::Config;
 
-// ---------------------------------------------------------------------------
-// Bearer token middleware (native only — requires task-local-extensions)
-// ---------------------------------------------------------------------------
-
 #[cfg(not(target_arch = "wasm32"))]
 struct BearerAuthMiddleware {
     token: String,
@@ -35,16 +31,9 @@ impl Middleware for BearerAuthMiddleware {
     }
 }
 
-// ---------------------------------------------------------------------------
-// User-Agent override middleware
-//
-// The `datadog-api-client` SDK sets its own `User-Agent` header on every
-// request (`datadog-api-client-rust/<ver>...`) and exposes no way to override
-// it from outside the crate. This middleware runs after the SDK builds the
-// request and replaces the header with pup's branded UA so audit logs and
-// telemetry attribute traffic to pup, not the underlying SDK.
-// ---------------------------------------------------------------------------
-
+// The `datadog-api-client` SDK's `Configuration.user_agent` is `pub(crate)`
+// with no setter, so the only way to override it from outside the crate is
+// via middleware that mutates the header after the SDK builds the request.
 #[cfg(not(target_arch = "wasm32"))]
 struct UserAgentMiddleware;
 
@@ -145,53 +134,36 @@ pub fn make_dd_config(cfg: &Config) -> datadog_api_client::datadog::Configuratio
     dd_cfg
 }
 
-/// Creates a reqwest middleware client for SDK API calls. Always installs the
-/// `UserAgentMiddleware` so requests are tagged with pup's branded `User-Agent`
-/// (see `useragent::get()`) instead of the SDK's default
-/// `datadog-api-client-rust/...`. If a bearer token is configured, also installs
-/// `BearerAuthMiddleware` to inject `Authorization: Bearer ...` per request.
+/// Builds a reqwest middleware client for SDK API calls. Always installs
+/// `UserAgentMiddleware` so requests carry pup's branded `User-Agent`
+/// instead of the SDK's `datadog-api-client-rust/...` default. When
+/// `send_bearer` is true and the config has an access token, also installs
+/// `BearerAuthMiddleware`. OAuth-incompatible endpoints (see
+/// `OAUTH_EXCLUDED_ENDPOINTS`) pass `false` so the SDK falls back to API key
+/// headers from the `Configuration`.
 ///
-/// Returns `None` on WASM targets where the middleware stack is unavailable;
-/// callers fall back to the SDK's default client (which sends the SDK UA).
-pub fn make_dd_client(cfg: &Config) -> Option<ClientWithMiddleware> {
+/// Returns `None` on WASM targets; callers use the SDK default client there.
+pub fn make_dd_client(cfg: &Config, send_bearer: bool) -> Option<ClientWithMiddleware> {
     #[cfg(not(target_arch = "wasm32"))]
     {
         let reqwest_client = reqwest_middleware::reqwest::Client::builder()
             .build()
             .expect("failed to build reqwest client");
         let mut builder = ClientBuilder::new(reqwest_client).with(UserAgentMiddleware);
-        if let Some(token) = cfg.access_token.as_ref() {
-            builder = builder.with(BearerAuthMiddleware {
-                token: token.clone(),
-            });
+        if send_bearer {
+            if let Some(token) = cfg.access_token.as_ref() {
+                builder = builder.with(BearerAuthMiddleware {
+                    token: token.clone(),
+                });
+            }
         }
         return Some(builder.build());
     }
     #[allow(unreachable_code)]
     {
-        let _ = cfg;
+        let _ = (cfg, send_bearer);
         None
     }
-}
-
-/// Like `make_dd_client` but never installs `BearerAuthMiddleware`. Use for
-/// endpoints that don't support OAuth bearer tokens (see
-/// `OAUTH_EXCLUDED_ENDPOINTS`); the SDK still injects API key/app key auth
-/// headers from the `Configuration`.
-pub fn make_dd_client_no_auth() -> Option<ClientWithMiddleware> {
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        let reqwest_client = reqwest_middleware::reqwest::Client::builder()
-            .build()
-            .expect("failed to build reqwest client");
-        return Some(
-            ClientBuilder::new(reqwest_client)
-                .with(UserAgentMiddleware)
-                .build(),
-        );
-    }
-    #[allow(unreachable_code)]
-    None
 }
 
 #[macro_export]
@@ -199,21 +171,20 @@ macro_rules! make_api {
     ($api:ty, $cfg:expr) => {{
         let cfg = $cfg;
         let dd_cfg = $crate::client::make_dd_config(cfg);
-        match $crate::client::make_dd_client(cfg) {
+        match $crate::client::make_dd_client(cfg, true) {
             Some(c) => <$api>::with_client_and_config(dd_cfg, c),
             None => <$api>::with_config(dd_cfg),
         }
     }};
 }
 
-/// Same as `make_api!` but uses a UA-only client (no bearer). For OAuth-
-/// incompatible endpoints; SDK still applies API key auth from `Configuration`.
+/// `make_api!` variant that skips bearer auth — for OAuth-incompatible endpoints.
 #[macro_export]
 macro_rules! make_api_no_auth {
     ($api:ty, $cfg:expr) => {{
         let cfg = $cfg;
         let dd_cfg = $crate::client::make_dd_config(cfg);
-        match $crate::client::make_dd_client_no_auth() {
+        match $crate::client::make_dd_client(cfg, false) {
             Some(c) => <$api>::with_client_and_config(dd_cfg, c),
             None => <$api>::with_config(dd_cfg),
         }
@@ -1156,14 +1127,16 @@ mod tests {
     fn test_make_dd_client_some_without_token() {
         // UA middleware is always installed, so the client is always Some on native.
         let cfg = test_cfg();
-        assert!(make_dd_client(&cfg).is_some());
+        assert!(make_dd_client(&cfg, true).is_some());
+        assert!(make_dd_client(&cfg, false).is_some());
     }
 
     #[test]
     fn test_make_dd_client_some_with_token() {
         let mut cfg = test_cfg();
         cfg.access_token = Some("test-token".into());
-        assert!(make_dd_client(&cfg).is_some());
+        assert!(make_dd_client(&cfg, true).is_some());
+        assert!(make_dd_client(&cfg, false).is_some());
     }
 
     #[test]

--- a/src/commands/authn_mappings.rs
+++ b/src/commands/authn_mappings.rs
@@ -4,14 +4,12 @@ use datadog_api_client::datadogV2::api_authn_mappings::{
 };
 use datadog_api_client::datadogV2::model::{AuthNMappingCreateRequest, AuthNMappingUpdateRequest};
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
 pub async fn list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = AuthNMappingsAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(AuthNMappingsAPI, cfg);
     let resp = api
         .list_authn_mappings(ListAuthNMappingsOptionalParams::default())
         .await
@@ -20,8 +18,7 @@ pub async fn list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn get(cfg: &Config, mapping_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = AuthNMappingsAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(AuthNMappingsAPI, cfg);
     let resp = api
         .get_authn_mapping(mapping_id.to_string())
         .await
@@ -31,8 +28,7 @@ pub async fn get(cfg: &Config, mapping_id: &str) -> Result<()> {
 
 pub async fn create(cfg: &Config, file: &str) -> Result<()> {
     let body: AuthNMappingCreateRequest = util::read_json_file(file)?;
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = AuthNMappingsAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(AuthNMappingsAPI, cfg);
     let resp = api
         .create_authn_mapping(body)
         .await
@@ -42,8 +38,7 @@ pub async fn create(cfg: &Config, file: &str) -> Result<()> {
 
 pub async fn update(cfg: &Config, mapping_id: &str, file: &str) -> Result<()> {
     let body: AuthNMappingUpdateRequest = util::read_json_file(file)?;
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = AuthNMappingsAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(AuthNMappingsAPI, cfg);
     let resp = api
         .update_authn_mapping(mapping_id.to_string(), body)
         .await
@@ -52,8 +47,7 @@ pub async fn update(cfg: &Config, mapping_id: &str, file: &str) -> Result<()> {
 }
 
 pub async fn delete(cfg: &Config, mapping_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = AuthNMappingsAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(AuthNMappingsAPI, cfg);
     api.delete_authn_mapping(mapping_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete AuthN mapping: {e:?}"))?;

--- a/src/commands/data_deletion.rs
+++ b/src/commands/data_deletion.rs
@@ -3,14 +3,12 @@ use datadog_api_client::datadogV2::api_data_deletion::{
     DataDeletionAPI, GetDataDeletionRequestsOptionalParams,
 };
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
 fn make_api(cfg: &Config) -> DataDeletionAPI {
-    let dd_cfg = client::make_dd_config(cfg);
-    DataDeletionAPI::with_config(dd_cfg)
+    crate::make_api_no_auth!(DataDeletionAPI, cfg)
 }
 
 pub async fn requests_list(

--- a/src/commands/datasets.rs
+++ b/src/commands/datasets.rs
@@ -1,14 +1,12 @@
 use anyhow::Result;
 use datadog_api_client::datadogV2::api_datasets::DatasetsAPI;
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
 fn make_api(cfg: &Config) -> DatasetsAPI {
-    let dd_cfg = client::make_dd_config(cfg);
-    DatasetsAPI::with_config(dd_cfg)
+    crate::make_api_no_auth!(DatasetsAPI, cfg)
 }
 
 pub async fn list(cfg: &Config) -> Result<()> {

--- a/src/commands/logs_restriction.rs
+++ b/src/commands/logs_restriction.rs
@@ -4,14 +4,12 @@ use datadog_api_client::datadogV2::api_logs_restriction_queries::{
     LogsRestrictionQueriesAPI,
 };
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
 pub async fn list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = LogsRestrictionQueriesAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(LogsRestrictionQueriesAPI, cfg);
     let resp = api
         .list_restriction_queries(ListRestrictionQueriesOptionalParams::default())
         .await
@@ -20,8 +18,7 @@ pub async fn list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn get(cfg: &Config, query_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = LogsRestrictionQueriesAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(LogsRestrictionQueriesAPI, cfg);
     let resp = api
         .get_restriction_query(query_id.to_string())
         .await
@@ -30,8 +27,7 @@ pub async fn get(cfg: &Config, query_id: &str) -> Result<()> {
 }
 
 pub async fn create(cfg: &Config, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = LogsRestrictionQueriesAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(LogsRestrictionQueriesAPI, cfg);
     let body = util::read_json_file(file)?;
     let resp = api
         .create_restriction_query(body)
@@ -41,8 +37,7 @@ pub async fn create(cfg: &Config, file: &str) -> Result<()> {
 }
 
 pub async fn update(cfg: &Config, query_id: &str, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = LogsRestrictionQueriesAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(LogsRestrictionQueriesAPI, cfg);
     let body = util::read_json_file(file)?;
     let resp = api
         .update_restriction_query(query_id.to_string(), body)
@@ -52,8 +47,7 @@ pub async fn update(cfg: &Config, query_id: &str, file: &str) -> Result<()> {
 }
 
 pub async fn delete(cfg: &Config, query_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = LogsRestrictionQueriesAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(LogsRestrictionQueriesAPI, cfg);
     api.delete_restriction_query(query_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete restriction query: {e:?}"))?;
@@ -62,8 +56,7 @@ pub async fn delete(cfg: &Config, query_id: &str) -> Result<()> {
 }
 
 pub async fn roles_list(cfg: &Config, query_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = LogsRestrictionQueriesAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(LogsRestrictionQueriesAPI, cfg);
     let resp = api
         .list_restriction_query_roles(
             query_id.to_string(),
@@ -75,8 +68,7 @@ pub async fn roles_list(cfg: &Config, query_id: &str) -> Result<()> {
 }
 
 pub async fn roles_add(cfg: &Config, query_id: &str, file: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = LogsRestrictionQueriesAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(LogsRestrictionQueriesAPI, cfg);
     let body = util::read_json_file(file)?;
     api.add_role_to_restriction_query(query_id.to_string(), body)
         .await

--- a/src/commands/obs_pipelines.rs
+++ b/src/commands/obs_pipelines.rs
@@ -4,14 +4,13 @@ use datadog_api_client::datadogV2::api_observability_pipelines::{
 };
 use datadog_api_client::datadogV2::model::{ObservabilityPipeline, ObservabilityPipelineSpec};
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
 fn make_api(cfg: &Config) -> ObservabilityPipelinesAPI {
     // Observability Pipelines does not support OAuth — API key auth only.
-    ObservabilityPipelinesAPI::with_config(client::make_dd_config(cfg))
+    crate::make_api_no_auth!(ObservabilityPipelinesAPI, cfg)
 }
 
 pub async fn list(cfg: &Config, limit: i64) -> Result<()> {

--- a/src/commands/security.rs
+++ b/src/commands/security.rs
@@ -1,4 +1,3 @@
-use crate::client;
 use crate::commands::ddsql;
 use crate::config::Config;
 use crate::formatter;
@@ -41,7 +40,7 @@ const SCHEMA_SECTION_MARKER: &str = "## Schema Reference";
 async fn fetch_schema_markdown() -> Result<String> {
     let resp = reqwest::Client::new()
         .get(SCHEMA_URL)
-        .header("User-Agent", "pup-cli")
+        .header("User-Agent", crate::useragent::get())
         .send()
         .await
         .map_err(|e| anyhow::anyhow!("failed to fetch schema from {SCHEMA_URL}: {e}"))?;
@@ -535,8 +534,7 @@ pub async fn suppressions_validate(cfg: &Config, file: &str) -> Result<()> {
 // ---- ASM WAF Custom Rules ----
 
 pub async fn asm_custom_rules_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = ApplicationSecurityAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(ApplicationSecurityAPI, cfg);
     let resp = api
         .list_application_security_waf_custom_rules()
         .await
@@ -545,8 +543,7 @@ pub async fn asm_custom_rules_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn asm_custom_rules_get(cfg: &Config, custom_rule_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = ApplicationSecurityAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(ApplicationSecurityAPI, cfg);
     let resp = api
         .get_application_security_waf_custom_rule(custom_rule_id.to_string())
         .await
@@ -556,8 +553,7 @@ pub async fn asm_custom_rules_get(cfg: &Config, custom_rule_id: &str) -> Result<
 
 pub async fn asm_custom_rules_create(cfg: &Config, file: &str) -> Result<()> {
     let body: ApplicationSecurityWafCustomRuleCreateRequest = util::read_json_file(file)?;
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = ApplicationSecurityAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(ApplicationSecurityAPI, cfg);
     let resp = api
         .create_application_security_waf_custom_rule(body)
         .await
@@ -567,8 +563,7 @@ pub async fn asm_custom_rules_create(cfg: &Config, file: &str) -> Result<()> {
 
 pub async fn asm_custom_rules_update(cfg: &Config, custom_rule_id: &str, file: &str) -> Result<()> {
     let body: ApplicationSecurityWafCustomRuleUpdateRequest = util::read_json_file(file)?;
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = ApplicationSecurityAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(ApplicationSecurityAPI, cfg);
     let resp = api
         .update_application_security_waf_custom_rule(custom_rule_id.to_string(), body)
         .await
@@ -577,8 +572,7 @@ pub async fn asm_custom_rules_update(cfg: &Config, custom_rule_id: &str, file: &
 }
 
 pub async fn asm_custom_rules_delete(cfg: &Config, custom_rule_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = ApplicationSecurityAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(ApplicationSecurityAPI, cfg);
     api.delete_application_security_waf_custom_rule(custom_rule_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete ASM WAF custom rule: {e:?}"))?;
@@ -589,8 +583,7 @@ pub async fn asm_custom_rules_delete(cfg: &Config, custom_rule_id: &str) -> Resu
 // ---- ASM WAF Exclusion Filters ----
 
 pub async fn asm_exclusions_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = ApplicationSecurityAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(ApplicationSecurityAPI, cfg);
     let resp = api
         .list_application_security_waf_exclusion_filters()
         .await
@@ -599,8 +592,7 @@ pub async fn asm_exclusions_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn asm_exclusions_get(cfg: &Config, exclusion_filter_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = ApplicationSecurityAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(ApplicationSecurityAPI, cfg);
     let resp = api
         .get_application_security_waf_exclusion_filter(exclusion_filter_id.to_string())
         .await
@@ -610,8 +602,7 @@ pub async fn asm_exclusions_get(cfg: &Config, exclusion_filter_id: &str) -> Resu
 
 pub async fn asm_exclusions_create(cfg: &Config, file: &str) -> Result<()> {
     let body: ApplicationSecurityWafExclusionFilterCreateRequest = util::read_json_file(file)?;
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = ApplicationSecurityAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(ApplicationSecurityAPI, cfg);
     let resp = api
         .create_application_security_waf_exclusion_filter(body)
         .await
@@ -625,8 +616,7 @@ pub async fn asm_exclusions_update(
     file: &str,
 ) -> Result<()> {
     let body: ApplicationSecurityWafExclusionFilterUpdateRequest = util::read_json_file(file)?;
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = ApplicationSecurityAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(ApplicationSecurityAPI, cfg);
     let resp = api
         .update_application_security_waf_exclusion_filter(exclusion_filter_id.to_string(), body)
         .await
@@ -635,8 +625,7 @@ pub async fn asm_exclusions_update(
 }
 
 pub async fn asm_exclusions_delete(cfg: &Config, exclusion_filter_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = ApplicationSecurityAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(ApplicationSecurityAPI, cfg);
     api.delete_application_security_waf_exclusion_filter(exclusion_filter_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete ASM WAF exclusion filter: {e:?}"))?;
@@ -647,8 +636,7 @@ pub async fn asm_exclusions_delete(cfg: &Config, exclusion_filter_id: &str) -> R
 // ---- Restriction Policies ----
 
 pub async fn restriction_policy_get(cfg: &Config, resource_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = RestrictionPoliciesAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(RestrictionPoliciesAPI, cfg);
     let resp = api
         .get_restriction_policy(resource_id.to_string())
         .await
@@ -658,8 +646,7 @@ pub async fn restriction_policy_get(cfg: &Config, resource_id: &str) -> Result<(
 
 pub async fn restriction_policy_update(cfg: &Config, resource_id: &str, file: &str) -> Result<()> {
     let body: RestrictionPolicyUpdateRequest = util::read_json_file(file)?;
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = RestrictionPoliciesAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(RestrictionPoliciesAPI, cfg);
     let resp = api
         .update_restriction_policy(
             resource_id.to_string(),
@@ -672,8 +659,7 @@ pub async fn restriction_policy_update(cfg: &Config, resource_id: &str, file: &s
 }
 
 pub async fn restriction_policy_delete(cfg: &Config, resource_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = RestrictionPoliciesAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(RestrictionPoliciesAPI, cfg);
     api.delete_restriction_policy(resource_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete restriction policy: {e:?}"))?;

--- a/src/commands/traces.rs
+++ b/src/commands/traces.rs
@@ -8,7 +8,6 @@ use datadog_api_client::datadogV2::model::{
     SpansListRequestType, SpansQueryFilter, SpansSort,
 };
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
@@ -18,8 +17,7 @@ use crate::util;
 // ---------------------------------------------------------------------------
 
 pub async fn metrics_list(cfg: &Config) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = SpansMetricsAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(SpansMetricsAPI, cfg);
     let resp = api
         .list_spans_metrics()
         .await
@@ -28,8 +26,7 @@ pub async fn metrics_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn metrics_get(cfg: &Config, metric_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = SpansMetricsAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(SpansMetricsAPI, cfg);
     let resp = api
         .get_spans_metric(metric_id.to_string())
         .await
@@ -40,8 +37,7 @@ pub async fn metrics_get(cfg: &Config, metric_id: &str) -> Result<()> {
 pub async fn metrics_create(cfg: &Config, file: &str) -> Result<()> {
     let body: datadog_api_client::datadogV2::model::SpansMetricCreateRequest =
         util::read_json_file(file)?;
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = SpansMetricsAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(SpansMetricsAPI, cfg);
     let resp = api
         .create_spans_metric(body)
         .await
@@ -52,8 +48,7 @@ pub async fn metrics_create(cfg: &Config, file: &str) -> Result<()> {
 pub async fn metrics_update(cfg: &Config, metric_id: &str, file: &str) -> Result<()> {
     let body: datadog_api_client::datadogV2::model::SpansMetricUpdateRequest =
         util::read_json_file(file)?;
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = SpansMetricsAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(SpansMetricsAPI, cfg);
     let resp = api
         .update_spans_metric(metric_id.to_string(), body)
         .await
@@ -62,8 +57,7 @@ pub async fn metrics_update(cfg: &Config, metric_id: &str, file: &str) -> Result
 }
 
 pub async fn metrics_delete(cfg: &Config, metric_id: &str) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = SpansMetricsAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(SpansMetricsAPI, cfg);
     api.delete_spans_metric(metric_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete spans metric: {e:?}"))?;

--- a/src/commands/workflows.rs
+++ b/src/commands/workflows.rs
@@ -6,7 +6,6 @@ use datadog_api_client::datadogV2::api_workflow_automation::{
     ListWorkflowInstancesOptionalParams, WorkflowAutomationAPI,
 };
 
-use crate::client;
 use crate::config::Config;
 use crate::formatter::{self, Metadata};
 use crate::util;
@@ -16,8 +15,7 @@ use crate::util;
 // ---------------------------------------------------------------------------
 
 fn make_api(cfg: &Config) -> WorkflowAutomationAPI {
-    let dd_cfg = client::make_dd_config(cfg);
-    WorkflowAutomationAPI::with_config(dd_cfg)
+    crate::make_api_no_auth!(WorkflowAutomationAPI, cfg)
 }
 
 // ---------------------------------------------------------------------------
@@ -76,8 +74,7 @@ pub async fn run(
     wait: bool,
     timeout: &str,
 ) -> Result<()> {
-    let dd_cfg = client::make_dd_config(cfg);
-    let api = WorkflowAutomationAPI::with_config(dd_cfg);
+    let api = crate::make_api_no_auth!(WorkflowAutomationAPI, cfg);
 
     let input_payload: Option<BTreeMap<String, serde_json::Value>> = match (&payload, &payload_file)
     {
@@ -135,8 +132,7 @@ pub async fn run(
 
         tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
-        let dd_cfg = client::make_dd_config(cfg);
-        let api = WorkflowAutomationAPI::with_config(dd_cfg);
+        let api = crate::make_api_no_auth!(WorkflowAutomationAPI, cfg);
         let status = api
             .get_workflow_instance(workflow_id.to_string(), instance_id.clone())
             .await
@@ -216,8 +212,7 @@ pub async fn instance_cancel(cfg: &Config, workflow_id: &str, instance_id: &str)
 // ---------------------------------------------------------------------------
 
 fn make_connection_api(cfg: &Config) -> ActionConnectionAPI {
-    let dd_cfg = client::make_dd_config(cfg);
-    ActionConnectionAPI::with_config(dd_cfg)
+    crate::make_api_no_auth!(ActionConnectionAPI, cfg)
 }
 
 pub async fn connections_get(cfg: &Config, connection_id: &str) -> Result<()> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -531,7 +531,7 @@ mod tests {
 
     #[test]
     fn test_api_host_standard() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = ENV_LOCK.blocking_lock();
         std::env::remove_var("PUP_MOCK_SERVER");
         let cfg = make_cfg(None, None, Some("t"));
         assert_eq!(cfg.api_host(), "api.datadoghq.com");
@@ -539,7 +539,7 @@ mod tests {
 
     #[test]
     fn test_api_host_eu() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = ENV_LOCK.blocking_lock();
         std::env::remove_var("PUP_MOCK_SERVER");
         let mut cfg = make_cfg(None, None, Some("t"));
         cfg.site = "datadoghq.eu".into();
@@ -548,7 +548,7 @@ mod tests {
 
     #[test]
     fn test_api_host_oncall() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = ENV_LOCK.blocking_lock();
         std::env::remove_var("PUP_MOCK_SERVER");
         let mut cfg = make_cfg(None, None, Some("t"));
         cfg.site = "navy.oncall.datadoghq.com".into();
@@ -642,7 +642,7 @@ mod tests {
 
     #[test]
     fn test_api_host_app_prefix_us1() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = ENV_LOCK.blocking_lock();
         std::env::remove_var("PUP_MOCK_SERVER");
         let mut cfg = make_cfg(None, None, Some("t"));
         cfg.site = normalize_site("app.datadoghq.com");
@@ -651,7 +651,7 @@ mod tests {
 
     #[test]
     fn test_api_host_app_prefix_eu() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = ENV_LOCK.blocking_lock();
         std::env::remove_var("PUP_MOCK_SERVER");
         let mut cfg = make_cfg(None, None, Some("t"));
         cfg.site = normalize_site("app.datadoghq.eu");
@@ -660,7 +660,7 @@ mod tests {
 
     #[test]
     fn test_api_host_app_prefix_gov() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = ENV_LOCK.blocking_lock();
         std::env::remove_var("PUP_MOCK_SERVER");
         let mut cfg = make_cfg(None, None, Some("t"));
         cfg.site = normalize_site("app.ddog-gov.com");
@@ -669,7 +669,7 @@ mod tests {
 
     #[test]
     fn test_api_host_app_prefix_staging() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = ENV_LOCK.blocking_lock();
         std::env::remove_var("PUP_MOCK_SERVER");
         let mut cfg = make_cfg(None, None, Some("t"));
         cfg.site = normalize_site("app.datad0g.com");
@@ -678,7 +678,7 @@ mod tests {
 
     #[test]
     fn test_api_host_region_us3() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = ENV_LOCK.blocking_lock();
         std::env::remove_var("PUP_MOCK_SERVER");
         let mut cfg = make_cfg(None, None, Some("t"));
         cfg.site = normalize_site("us3.datadoghq.com");
@@ -687,7 +687,7 @@ mod tests {
 
     #[test]
     fn test_api_host_app_region_us3() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = ENV_LOCK.blocking_lock();
         std::env::remove_var("PUP_MOCK_SERVER");
         let mut cfg = make_cfg(None, None, Some("t"));
         cfg.site = normalize_site("app.us3.datadoghq.com");
@@ -709,7 +709,7 @@ mod tests {
 
     #[test]
     fn test_api_base_url_standard() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = ENV_LOCK.blocking_lock();
         std::env::remove_var("PUP_MOCK_SERVER");
         let cfg = make_cfg(None, None, Some("t"));
         assert_eq!(cfg.api_base_url(), "https://api.datadoghq.com");
@@ -717,7 +717,7 @@ mod tests {
 
     #[test]
     fn test_api_base_url_eu() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = ENV_LOCK.blocking_lock();
         std::env::remove_var("PUP_MOCK_SERVER");
         let mut cfg = make_cfg(None, None, Some("t"));
         cfg.site = "datadoghq.eu".into();
@@ -726,7 +726,7 @@ mod tests {
 
     #[test]
     fn test_api_base_url_oncall() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = ENV_LOCK.blocking_lock();
         std::env::remove_var("PUP_MOCK_SERVER");
         let mut cfg = make_cfg(None, None, Some("t"));
         cfg.site = "navy.oncall.datadoghq.com".into();
@@ -735,7 +735,7 @@ mod tests {
 
     #[test]
     fn test_api_base_url_mock_server() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = ENV_LOCK.blocking_lock();
         std::env::set_var("PUP_MOCK_SERVER", "http://127.0.0.1:1234");
         let cfg = make_cfg(None, None, Some("t"));
         assert_eq!(cfg.api_base_url(), "http://127.0.0.1:1234");
@@ -744,7 +744,7 @@ mod tests {
 
     #[test]
     fn test_api_host_mock_server() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = ENV_LOCK.blocking_lock();
         std::env::set_var("PUP_MOCK_SERVER", "http://127.0.0.1:5678");
         let cfg = make_cfg(None, None, Some("t"));
         assert_eq!(cfg.api_host(), "127.0.0.1:5678");
@@ -779,7 +779,7 @@ mod tests {
 
     #[test]
     fn test_config_dir_returns_path() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = ENV_LOCK.blocking_lock();
         std::env::remove_var("PUP_CONFIG_DIR");
         let dir = config_dir();
         // On native builds, dirs::config_dir() should return Some
@@ -789,7 +789,7 @@ mod tests {
 
     #[test]
     fn test_config_dir_respects_override() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = ENV_LOCK.blocking_lock();
         std::env::set_var("PUP_CONFIG_DIR", "/tmp/pup_test_override");
         let dir = config_dir();
         std::env::remove_var("PUP_CONFIG_DIR");
@@ -828,7 +828,7 @@ mod tests {
 
     #[test]
     fn test_read_only_from_env() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = ENV_LOCK.blocking_lock();
         std::env::remove_var("DD_READ_ONLY");
         std::env::remove_var("DD_CLI_READ_ONLY");
         std::env::set_var("PUP_CONFIG_DIR", "/tmp/pup_test_nonexistent");

--- a/src/extensions/discovery.rs
+++ b/src/extensions/discovery.rs
@@ -136,7 +136,7 @@ mod tests {
         std::fs::write(&exe_path, "#!/bin/bash\necho hello").unwrap();
 
         // Use PUP_CONFIG_DIR to point discovery at our test dir
-        let _guard = crate::test_utils::ENV_LOCK.lock().unwrap();
+        let _guard = crate::test_utils::ENV_LOCK.blocking_lock();
         std::env::set_var("PUP_CONFIG_DIR", &dir);
 
         let result = extension_path("hello");
@@ -152,7 +152,7 @@ mod tests {
         let dir = make_test_dir("path-not-found");
         std::fs::create_dir_all(dir.join("extensions")).unwrap();
 
-        let _guard = crate::test_utils::ENV_LOCK.lock().unwrap();
+        let _guard = crate::test_utils::ENV_LOCK.blocking_lock();
         std::env::set_var("PUP_CONFIG_DIR", &dir);
 
         let result = extension_path("nonexistent");
@@ -167,7 +167,7 @@ mod tests {
         let dir = make_test_dir("list-empty");
         std::fs::create_dir_all(dir.join("extensions")).unwrap();
 
-        let _guard = crate::test_utils::ENV_LOCK.lock().unwrap();
+        let _guard = crate::test_utils::ENV_LOCK.blocking_lock();
         std::env::set_var("PUP_CONFIG_DIR", &dir);
 
         let result = list_extensions().unwrap();
@@ -194,7 +194,7 @@ mod tests {
         };
         manifest.save(&ext_dir.join("manifest.json")).unwrap();
 
-        let _guard = crate::test_utils::ENV_LOCK.lock().unwrap();
+        let _guard = crate::test_utils::ENV_LOCK.blocking_lock();
         std::env::set_var("PUP_CONFIG_DIR", &dir);
 
         let result = list_extensions().unwrap();
@@ -211,7 +211,7 @@ mod tests {
         let dir = make_test_dir("help-empty");
         std::fs::create_dir_all(dir.join("extensions")).unwrap();
 
-        let _guard = crate::test_utils::ENV_LOCK.lock().unwrap();
+        let _guard = crate::test_utils::ENV_LOCK.blocking_lock();
         std::env::set_var("PUP_CONFIG_DIR", &dir);
 
         let result = build_extensions_help_section();
@@ -241,7 +241,7 @@ mod tests {
             manifest.save(&ext_dir.join("manifest.json")).unwrap();
         }
 
-        let _guard = crate::test_utils::ENV_LOCK.lock().unwrap();
+        let _guard = crate::test_utils::ENV_LOCK.blocking_lock();
         std::env::set_var("PUP_CONFIG_DIR", &dir);
 
         let result = build_extensions_help_section();
@@ -273,7 +273,7 @@ mod tests {
         };
         manifest.save(&ext_dir.join("manifest.json")).unwrap();
 
-        let _guard = crate::test_utils::ENV_LOCK.lock().unwrap();
+        let _guard = crate::test_utils::ENV_LOCK.blocking_lock();
         std::env::set_var("PUP_CONFIG_DIR", &dir);
 
         let result = build_extensions_help_section();

--- a/src/extensions/install.rs
+++ b/src/extensions/install.rs
@@ -629,7 +629,7 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(dir.join("extensions")).unwrap();
 
-        let _guard = crate::test_utils::ENV_LOCK.lock().unwrap();
+        let _guard = crate::test_utils::ENV_LOCK.blocking_lock();
         std::env::set_var("PUP_CONFIG_DIR", &dir);
 
         let result = remove_extension("nonexistent");

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,9 +26,13 @@ mod test_support;
 /// Shared test utilities — only compiled in test builds.
 #[cfg(test)]
 pub(crate) mod test_utils {
-    use std::sync::Mutex;
+    use tokio::sync::Mutex;
     /// Serialize tests that mutate global env vars (PUP_MOCK_SERVER, DD_API_KEY, etc.).
-    pub static ENV_LOCK: Mutex<()> = Mutex::new(());
+    /// `tokio::sync::Mutex` so async tests can hold the guard across `.await`,
+    /// while sync tests acquire via `blocking_lock()`. Sharing one lock across
+    /// both flavors prevents the parallel-test races that previously required
+    /// running the suite with `--test-threads=1`.
+    pub static ENV_LOCK: Mutex<()> = Mutex::const_new(());
 }
 
 use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -8,15 +8,12 @@
 #![cfg(test)]
 
 use crate::config::{Config, OutputFormat};
-use tokio::sync::Mutex;
 
-/// Global async mutex to serialize tests that modify process-wide env vars.
-/// Uses `tokio::sync::Mutex` so the guard can be held across `.await` points
-/// without tripping `clippy::await_holding_lock`.
-static ENV_MUTEX: Mutex<()> = Mutex::const_new(());
-
+/// Async lock for tests that mutate process-wide env vars. Delegates to the
+/// shared `ENV_LOCK` (tokio Mutex) so async and sync tests serialize on the
+/// same primitive — sync tests use `ENV_LOCK.blocking_lock()` directly.
 pub(crate) async fn lock_env() -> tokio::sync::MutexGuard<'static, ()> {
-    ENV_MUTEX.lock().await
+    crate::test_utils::ENV_LOCK.lock().await
 }
 
 pub(crate) fn test_config(mock_url: &str) -> Config {

--- a/src/useragent.rs
+++ b/src/useragent.rs
@@ -96,8 +96,26 @@ pub fn get() -> String {
     get_with_command(None)
 }
 
+/// Returns the underlying Datadog SDK's `name/version` token (e.g.
+/// `datadog-api-client-rust/0.30.0`) for inclusion in pup's User-Agent.
+/// `None` when the SDK isn't compiled in (any non-default-feature build).
+#[cfg(any(feature = "native", feature = "wasi", feature = "browser"))]
+fn sdk_token() -> Option<&'static str> {
+    datadog_api_client::datadog::DEFAULT_USER_AGENT
+        .as_str()
+        .split_whitespace()
+        .next()
+}
+
+#[cfg(not(any(feature = "native", feature = "wasi", feature = "browser")))]
+fn sdk_token() -> Option<&'static str> {
+    None
+}
+
 /// Build the User-Agent string, optionally including a command identifier
 /// so that audit logs can differentiate which pup command made the request.
+///
+/// Format: `pup/<ver> (rust; os <os>; arch <arch>[; ai-agent <name>][; sdk <sdk_name/ver>][; cmd <cmd>])`
 pub fn get_with_command(command: Option<&str>) -> String {
     let agent = detect_agent_info();
     let base = format!(
@@ -111,10 +129,14 @@ pub fn get_with_command(command: Option<&str>) -> String {
     } else {
         base
     };
+    let with_sdk = match sdk_token() {
+        Some(sdk) => format!("{}; sdk {}", with_agent, sdk),
+        None => with_agent,
+    };
     if let Some(cmd) = command {
-        format!("{}; cmd {})", with_agent, cmd)
+        format!("{}; cmd {})", with_sdk, cmd)
     } else {
-        format!("{})", with_agent)
+        format!("{})", with_sdk)
     }
 }
 

--- a/src/useragent.rs
+++ b/src/useragent.rs
@@ -115,12 +115,20 @@ fn sdk_token() -> Option<&'static str> {
 /// Build the User-Agent string, optionally including a command identifier
 /// so that audit logs can differentiate which pup command made the request.
 ///
-/// Format: `pup/<ver> (rust; os <os>; arch <arch>[; ai-agent <name>][; sdk <sdk_name/ver>][; cmd <cmd>])`
+/// Format: `pup/<ver> (rust <rustver>; os <os>; arch <arch>[; ai-agent <name>][; sdk <sdk_name/ver>][; cmd <cmd>])`
+///
+/// Each parenthesized comment must be a `key value` 2-tuple so the
+/// smart-edge audit logger's `client_telemetry` metric parser accepts it
+/// (see `dd-source/.../web_traffic_dashboard/client_sdk_info.go`). A bare
+/// token like `rust` (without a version) causes the parser to reject the
+/// entire UA, dropping all pup product-version telemetry — that's why we
+/// always emit `rust <version>` (falling back to `rust unknown`).
 pub fn get_with_command(command: Option<&str>) -> String {
     let agent = detect_agent_info();
     let base = format!(
-        "pup/{} (rust; os {}; arch {}",
+        "pup/{} (rust {}; os {}; arch {}",
         version::VERSION,
+        version::rustc_version(),
         std::env::consts::OS,
         std::env::consts::ARCH,
     );
@@ -179,6 +187,43 @@ mod tests {
         let ua = get_with_command(Some("security-findings-analyze"));
         assert!(ua.starts_with("pup/"));
         assert!(ua.contains("; cmd security-findings-analyze)"));
+    }
+
+    /// Mirrors the smart-edge audit logger's `client_telemetry` parser
+    /// (`dd-source/.../web_traffic_dashboard/client_sdk_info.go`): each
+    /// parenthesized comment must split into exactly 2 tokens on the first
+    /// space. If this assertion fails, the metric stops firing for pup
+    /// until the UA is fixed.
+    #[test]
+    fn test_user_agent_parses_for_smart_edge_telemetry() {
+        for ua in [
+            get_with_command(None),
+            get_with_command(Some("monitors-list")),
+        ] {
+            let open = ua
+                .find('(')
+                .unwrap_or_else(|| panic!("UA missing '(' : {ua}"));
+            let close = ua
+                .rfind(')')
+                .unwrap_or_else(|| panic!("UA missing ')' : {ua}"));
+            let inside = &ua[open + 1..close];
+            for raw in inside.split(';') {
+                let trimmed = raw.trim();
+                let mut parts = trimmed.splitn(2, ' ');
+                let key = parts.next().unwrap_or("");
+                let value = parts.next();
+                assert!(
+                    value.is_some(),
+                    "smart-edge parser requires `key value` tuples — \
+                     bare comment {trimmed:?} in {ua:?} would drop the entire UA",
+                );
+                assert!(!key.is_empty(), "empty key in comment {trimmed:?}");
+                assert!(
+                    !value.unwrap().is_empty(),
+                    "empty value in comment {trimmed:?}",
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/version.rs
+++ b/src/version.rs
@@ -11,7 +11,7 @@ pub fn build_info() -> String {
     )
 }
 
-fn rustc_version() -> &'static str {
+pub fn rustc_version() -> &'static str {
     option_env!("RUSTC_VERSION").unwrap_or("unknown")
 }
 


### PR DESCRIPTION
## Summary

Pup currently sends two different `User-Agent` headers depending on the code path: raw HTTP helpers send `pup/<ver> (...)`, but most commands go through the typed `datadog-api-client` SDK and send `datadog-api-client-rust/<ver> (...)` because the SDK's `Configuration.user_agent` field is `pub(crate)` with no setter. As a result, the bulk of pup's API traffic is attributed to the underlying SDK rather than to pup, and dashboards or analytics that segment by client cannot tell pup apart from any other Rust SDK consumer.

## Approach

Add a `reqwest_middleware::Middleware` (`UserAgentMiddleware`) that runs after the SDK builds the request and replaces the `User-Agent` header with `useragent::get()`. The SDK exposes `with_client_and_config`, so pup supplies its own `ClientWithMiddleware` and the middleware always wins.

The existing `make_api!` macro is updated to wire the middleware in automatically — covering all 322 existing call sites with no change at the call site. A new `make_api_no_auth!` macro is added for the 38 sites that previously called `XxxAPI::with_config(dd_cfg)` directly (deliberately bypassing the bearer-token middleware for endpoints that don't accept OAuth — e.g. observability pipelines). Their no-bearer behavior is preserved.

## User-Agent format

Before:
- raw HTTP path: `pup/0.55.0 (rust; os macos; arch aarch64)`
- SDK path: `datadog-api-client-rust/0.30.0 (rust ?; os macos; arch aarch64)`

After (everything DD-bound):
- `pup/0.55.0 (rust 1.95.0; os macos; arch aarch64; sdk datadog-api-client-rust/0.30.0)`
- with optional `; ai-agent <name>` and `; cmd <name>` suffixes when applicable

The `sdk` token is read from the SDK's exposed `DEFAULT_USER_AGENT` so it stays in sync with the pinned SDK version. The `rust <version>` token comes from a tiny new `build.rs` that captures `rustc --version` at compile time. Each parenthesized comment is a `key value` 2-tuple, which is the format the server-side parser expects — without that shape, the bare `rust;` token previously caused server-side product/version attribution to fail entirely for Rust-era pup.

## Coverage

| Code path | Before | After |
|---|---|---|
| `client.rs` raw helpers (`raw_get/post/...`) | `pup/...` ✓ | `pup/...` ✓ (unchanged) |
| `commands/api.rs`, `bits.rs`, `acp.rs`, `synthetics.rs`, `ddsql.rs` | `pup/...` ✓ | `pup/...` ✓ (unchanged) |
| `make_api!` (322 call sites) | SDK default | `pup/...` ✓ |
| 38 stragglers across 9 files | SDK default | `pup/...` ✓ |
| `commands/security.rs` docs fetch | literal `"pup-cli"` | `pup/...` ✓ |
| `extensions/install.rs` (GitHub API) | `pup/<ver>` | unchanged (out of scope; not DD-bound) |

## Files changed

- `src/client.rs` — adds `UserAgentMiddleware`, refactors `make_bearer_client` → `make_dd_client(cfg, send_bearer)`, adds `make_api_no_auth!` macro, adds 3 new tokio integration tests.
- `src/useragent.rs` — adds `sdk_token()` and includes `sdk <name>/<ver>` plus `rust <ver>` in the UA. Adds a regression test that mirrors the server-side parser's tuple-format requirement.
- `src/version.rs` — `rustc_version()` made `pub` so `useragent.rs` can use it.
- `build.rs` — new, 13 lines. Runs `rustc --version` at compile and exposes `RUSTC_VERSION` via `cargo:rustc-env`.
- `src/commands/{authn_mappings,data_deletion,datasets,logs_restriction,obs_pipelines,security,traces,workflows}.rs` — 38 stragglers converted to `make_api_no_auth!`; also fixes the literal `"pup-cli"` UA in `security.rs`'s docs-fetch.
- `src/main.rs`, `src/test_support.rs`, `src/auth/storage.rs`, `src/config.rs`, `src/extensions/{discovery,install}.rs` — opportunistic cleanup: unify the test env-var lock (sync `std::sync::Mutex` and async `tokio::sync::Mutex` were separate, requiring CI to run `--test-threads=1`). Now both share one `tokio::sync::Mutex`; sync tests use `blocking_lock()`, async tests use `lock().await`. `cargo test` passes 973/973 in parallel.

## Test plan

- [x] `cargo test` (parallel) — 973 passed, 0 failed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] New tests:
  - `test_make_api_sends_pup_user_agent` — asserts `User-Agent` matches `^pup/` via mockito `match_header(Regex)`. Mock returns 501 if the middleware fails to override, so a regression fails loudly.
  - `test_make_api_sends_pup_user_agent_with_bearer` — same, with `cfg.access_token = Some(...)`. Asserts both `User-Agent: pup/...` AND `Authorization: Bearer ...` land on the same request — covers UA + bearer middleware coexistence.
  - `test_make_api_no_auth_sends_pup_user_agent` — sets a token but uses `make_api_no_auth!`. Asserts `User-Agent: pup/...` AND `Authorization: Missing` — verifies the no-auth variant actively suppresses bearer rather than passively passing through.
  - `test_user_agent_parses_for_smart_edge_telemetry` — mirrors the server-side parser logic locally so any future drift in the UA format fails CI before reaching prod.
- [x] End-to-end smoke: built the patched binary locally and ran 4 read-only commands against prod (monitors list, dashboards list, users list, logs search). Verified the audit log shape `pup/0.55.0 (rust 1.95.0; os macos; arch aarch64; ai-agent claude-code; sdk datadog-api-client-rust/0.30.0)` lands as expected, and that the corresponding server-side telemetry pipeline now attributes those calls to pup with the correct version (previously all Rust-era pup traffic failed parsing and was dropped).

## Follow-ups (out of scope)

- The middleware uses `useragent::get()` so SDK-routed requests don't carry the `; cmd <name>` token today. Adding it would require either threading `cmd` through the `make_api!` macros or staging the command name in a `OnceCell` from `main.rs` at dispatch — worth a follow-up but not a regression vs. the current state of `main`.
- The 37 stragglers (excluding obs_pipelines, which is explicitly OAuth-incompatible) are converted to `make_api_no_auth!` to preserve their pre-existing no-bearer auth semantics. Most of those endpoints likely DO accept OAuth, so migrating them to the bearer-supporting `make_api!` is a separate behavior change worth considering on its own.

## Dependencies

WASM (browser, WASI) targets fall back to the SDK's default UA — `reqwest_middleware`'s middleware stack isn't available there. Native is the path that matters for pup's actual users.