### PR TITLE
feat(users): add --page-size and --page-number flags to users list

### DIFF
--- a/src/commands/users.rs
+++ b/src/commands/users.rs
@@ -9,10 +9,14 @@ use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
-pub async fn list(cfg: &Config) -> Result<()> {
+pub async fn list(cfg: &Config, page_size: i64, page_number: i64) -> Result<()> {
     let api = crate::make_api!(UsersAPI, cfg);
     let resp = api
-        .list_users(ListUsersOptionalParams::default())
+        .list_users(
+            ListUsersOptionalParams::default()
+                .page_size(page_size)
+                .page_number(page_number),
+        )
         .await
         .map_err(|e| anyhow::anyhow!("failed to list users: {e:?}"))?;
     formatter::output(cfg, &resp)
@@ -130,7 +134,7 @@ mod tests {
         let mut s = mockito::Server::new_async().await;
         let cfg = test_config(&s.url());
         mock_all(&mut s, r#"{"data": []}"#).await;
-        let _ = super::list(&cfg).await;
+        let _ = super::list(&cfg, 10, 0).await;
         cleanup_env();
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4013,7 +4013,12 @@ enum TagActions {
 #[derive(Subcommand)]
 enum UserActions {
     /// List users
-    List,
+    List {
+        #[arg(long, default_value_t = 10, help = "Results per page (max 100)")]
+        page_size: i64,
+        #[arg(long, default_value_t = 0, help = "Page number (0-indexed)")]
+        page_number: i64,
+    },
     /// Get user details
     Get { user_id: String },
     /// Manage roles
@@ -10837,7 +10842,10 @@ async fn main_inner() -> anyhow::Result<()> {
         Commands::Users { action } => {
             cfg.validate_auth()?;
             match action {
-                UserActions::List => commands::users::list(&cfg).await?,
+                UserActions::List {
+                    page_size,
+                    page_number,
+                } => commands::users::list(&cfg, page_size, page_number).await?,
                 UserActions::Get { user_id } => commands::users::get(&cfg, &user_id).await?,
                 UserActions::Roles { action } => match action {
                     UserRoleActions::List => commands::users::roles_list(&cfg).await?,


### PR DESCRIPTION
## Summary

Fixes #448 (why not scratch my own itch right?) 

Add `--page-size` and `--page-number` flags to `pup users list` so it can return more than the first 10 users in orgs with larger user counts.

## Background
`pup users list` calls `ListUsersOptionalParams::default()`, and the underlying [datadog-api-client-rust](https://github.com/DataDog/datadog-api-client-rust/blob/main/src/datadogV2/api/api_users.rs) crate hardcodes `page_size=10` when the optional param is unset. The API supports up to 100 per page, and the response correctly reports `meta.page.total_filtered_count` — but a user has no way to ask `pup` for more than 10 records, so any org with >10 users silently sees a truncated list.

This PR exposes the SDK's existing `page_size` and `page_number` setters as CLI flags, matching the pattern already used by `synthetics tests list` (see `src/main.rs:3540` and `src/commands/synthetics.rs:214`).

## Changes
- `src/main.rs:4015` — `UserActions::List` becomes a struct variant with `page_size` and `page_number` clap args
- `src/main.rs:10845` — dispatch destructures the new fields and forwards them
- `src/commands/users.rs:12` — `list()` accepts `page_size: i64, page_number: i64` and threads them through `ListUsersOptionalParams`
- `src/commands/users.rs:128` — existing unit test updated for the new signature

## Testing
- `cargo build` — compiles cleanly
- `cargo test users` — `test_users_list` passes with the new signature
- `cargo clippy` — no new warnings
- Manual verification against a real org:
  ```
  pup users list                          # default 10 (matches old behavior)
  pup users list --page-size 100          # returns up to 100 in one call
  pup users list --page-size 100 --page-number 1   # next page
  ```

## Compatibility
Defaults (`page_size=10`, `page_number=0`) preserve existing behavior — no breaking change.

---
Generated with [Claude Code](https://claude.com/claude-code)
