### PR TITLE
feat(useragent): detect pi.dev agent via PI_CODING_AGENT env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ list of commands as built.
 | APM Services | ✅ | `apm services`, `apm entities`, `apm dependencies`, `apm flow-map` | Services stats, operations, resources; entity queries; dependencies; flow visualization |
 | Traces | ✅ | `traces search`, `traces aggregate`, `traces metrics` | Span search/aggregation and span-based metric definitions |
 | Profiling | ✅ | `profiling aggregate`, `profiling analytics`, `profiling timeline`, … | Continuous Profiler queries (requires API + App keys) |
+| Database Monitoring | ✅ | `dbm samples search` | DBM query sample search |
 | Session Replay | ❌ | - | Not yet implemented |
 
 </details>
@@ -96,6 +97,9 @@ list of commands as built.
 | Data Governance | ✅ | `data-governance scanner-rules list` | Sensitive data scanner rules |
 | CSM Threats | ✅ | `csm-threats` | Cloud Security Management threat rules and agent rules |
 | Sensitive Data Scanner | ✅ | `data-governance scanner-rules list` | Listed via Data Governance row above |
+| Agentless Scanning | ✅ | `agentless-scanning aws list/get/create/update/delete`, `agentless-scanning gcp list`, `agentless-scanning azure list` | Cloud agentless scanning configuration for AWS, GCP, and Azure |
+| Logs Restriction | ✅ | `logs-restriction list`, `logs-restriction get`, `logs-restriction create`, `logs-restriction update`, `logs-restriction delete` | Log restriction queries for fine-grained log access control |
+| Data Deletion | ✅ | `data-deletion requests list`, `data-deletion requests create`, `data-deletion requests cancel` | GDPR/compliance data deletion request management |
 
 </details>
 
@@ -132,6 +136,8 @@ list of commands as built.
 | Investigations | ✅ | `investigations list`, `investigations get`, `investigations trigger` | Bits AI SRE investigation management |
 | Change Management | ✅ | `change-management create`, `change-management get`, `change-management update`, `change-management create-branch`, `change-management decisions` | Change request management with decisions and branching |
 | Incident Services/Teams | ✅ | `incidents services`, `incidents teams` | Service and team CRUD scoped to incident management |
+| Live Debugger | ✅ | `debugger probes list`, `debugger probes get`, `debugger probes create`, `debugger probes delete`, `debugger probes watch` | Remote log probe management for Live Debugger |
+| Software Catalog | ✅ | `software-catalog entities list`, `software-catalog entities upsert`, `software-catalog kinds list`, `software-catalog relations list` | Software Catalog entity and kind management (next-gen catalog) |
 
 </details>
 
@@ -144,6 +150,7 @@ list of commands as built.
 | Test Optimization | ✅ | `cicd tests`, `cicd flaky-tests`, `test-optimization` | Test events, flaky test management, and Test Optimization API |
 | DORA Metrics | ✅ | `cicd dora` | DORA deployment patching |
 | Code Coverage | ✅ | `code-coverage branch-summary`, `code-coverage commit-summary` | Branch and commit-level coverage summaries |
+| Deployment Gates | ✅ | `deployment-gates gates`, `deployment-gates evaluations`, `deployment-gates rules` | Deployment gate CRUD, evaluation triggers, and rule management |
 
 </details>
 
@@ -158,6 +165,7 @@ list of commands as built.
 | App Keys | ✅ | `app-keys list`, `app-keys get`, `app-keys create`, `app-keys update`, `app-keys delete` | Full application key CRUD |
 | Service Accounts | ✅ | - | Managed via users commands |
 | Roles | ❌ | - | Only list via users |
+| AuthN Mappings | ✅ | `authn-mappings list`, `authn-mappings get`, `authn-mappings create`, `authn-mappings update`, `authn-mappings delete` | SAML/IdP attribute-to-role authentication mappings |
 
 </details>
 
@@ -169,7 +177,10 @@ list of commands as built.
 | Usage Metering | ✅ | `usage summary`, `usage hourly` | Usage and billing metrics |
 | Cost Management | ✅ | `costs datadog projected`, `costs datadog attribution`, `costs datadog by-org`, `costs datadog aws-config`, `costs datadog azure-config`, `costs datadog gcp-config`, `costs ccm custom-costs`, `costs ccm tag-descriptions`, `costs ccm tag-metadata`, `costs ccm tags`, `costs ccm tag-keys`, `costs ccm budgets`, `costs ccm commitments` | Cost attribution, cloud cost configs (AWS/Azure/GCP), and Cloud Cost Management (custom costs, tag descriptions, budgets, commitment programs) |
 | Product Analytics | ✅ | `product-analytics events send`, `product-analytics query` | Server-side product analytics events and queries |
-| Integrations | ✅ | `integrations slack`, `integrations pagerduty`, `integrations webhooks`, `integrations jira`, `integrations servicenow`, `integrations google-chat` | Third-party integrations with Jira, ServiceNow, and Google Chat support |
+| Integrations | ✅ | `integrations slack`, `integrations pagerduty`, `integrations webhooks`, `integrations jira`, `integrations servicenow`, `integrations google-chat`, `integrations ms-teams` | Third-party integrations including Jira, ServiceNow, Google Chat, and Microsoft Teams |
+| Feature Flags | ✅ | `feature-flags flags`, `feature-flags environments`, `feature-flags allocations`, `feature-flags exposure`, `feature-flags enable`, `feature-flags disable` | Feature flag management with environment, allocation, and exposure control |
+| Data Streams (Kafka) | ✅ | `kafka topic-configs`, `kafka broker-configs`, `kafka client-configs`, `kafka read-messages` | **Experimental** — Kafka cluster inspection via Datadog |
+| Restricted Datasets | ✅ | `datasets list`, `datasets get`, `datasets create`, `datasets update`, `datasets delete` | Restricted dataset management for data access control |
 | Observability Pipelines | ✅ | `obs-pipelines list`, `obs-pipelines get`, `obs-pipelines create`, `obs-pipelines update`, `obs-pipelines delete`, `obs-pipelines validate` | Full pipeline CRUD and validation |
 | LLM Observability | ✅ | `llm-obs projects`, `llm-obs experiments`, `llm-obs datasets` | **New** — LLM Obs projects, experiments, and dataset management |
 | Reference Tables | ✅ | `reference-tables list`, `reference-tables get`, `reference-tables create`, `reference-tables batch-query` | **New** — Reference table management for log enrichment |
@@ -383,6 +394,7 @@ Agent mode is **auto-detected** when any of these environment variables are set 
 | `AMAZON_Q` or `AWS_Q_DEVELOPER` | Amazon Q |
 | `GEMINI_CODE_ASSIST` | Gemini Code Assist |
 | `SRC_CODY` | Sourcegraph Cody |
+| `PI_CODING_AGENT` | pi.dev |
 | `FORCE_AGENT_MODE` | Any agent (manual override) |
 
 You can also enable it explicitly with the `--agent` flag or by setting `FORCE_AGENT_MODE=1`:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -147,7 +147,7 @@ pup/v0.1.0 (rust; os darwin; arch arm64; ai-agent claude-code)  # With agent
 **AI Agent Detection** (`src/useragent.rs`):
 
 Table-driven registry detecting AI coding agents via environment variables. First match wins:
-- Claude Code (`CLAUDECODE`, `CLAUDE_CODE`), Cursor (`CURSOR_AGENT`), Codex (`CODEX`, `OPENAI_CODEX`), OpenCode (`OPENCODE`), Aider (`AIDER`), Cline (`CLINE`), Windsurf (`WINDSURF_AGENT`), GitHub Copilot (`GITHUB_COPILOT`), Amazon Q (`AMAZON_Q`, `AWS_Q_DEVELOPER`), Gemini Code Assist (`GEMINI_CODE_ASSIST`), Sourcegraph Cody (`SRC_CODY`), Generic Agent (`AGENT`)
+- Claude Code (`CLAUDECODE`, `CLAUDE_CODE`), Cursor (`CURSOR_AGENT`), Codex (`CODEX`, `OPENAI_CODEX`), OpenCode (`OPENCODE`), Aider (`AIDER`), Cline (`CLINE`), Windsurf (`WINDSURF_AGENT`), GitHub Copilot (`GITHUB_COPILOT`), Amazon Q (`AMAZON_Q`, `AWS_Q_DEVELOPER`), Gemini Code Assist (`GEMINI_CODE_ASSIST`), Sourcegraph Cody (`SRC_CODY`), pi.dev (`PI_CODING_AGENT`), Generic Agent (`AGENT`)
 - Manual override: `FORCE_AGENT_MODE=1` or `--agent` flag
 
 **Agent Mode Behavior** (when detected):

--- a/docs/LLM_GUIDE.md
+++ b/docs/LLM_GUIDE.md
@@ -10,7 +10,7 @@ Pup auto-detects AI coding agents and switches to **agent mode**, which changes 
 
 | Method | Example |
 |--------|---------|
-| Auto-detect | `CLAUDECODE=1`, `CLAUDE_CODE=1`, `CURSOR_AGENT=1`, `CODEX=1`, `OPENAI_CODEX=1`, `OPENCODE=1`, `AIDER=1`, `CLINE=1`, `WINDSURF_AGENT=1`, `GITHUB_COPILOT=1`, `AMAZON_Q=1`, `AWS_Q_DEVELOPER=1`, `GEMINI_CODE_ASSIST=1`, `SRC_CODY=1`, `AGENT=1` |
+| Auto-detect | `CLAUDECODE=1`, `CLAUDE_CODE=1`, `CURSOR_AGENT=1`, `CODEX=1`, `OPENAI_CODEX=1`, `OPENCODE=1`, `AIDER=1`, `CLINE=1`, `WINDSURF_AGENT=1`, `GITHUB_COPILOT=1`, `AMAZON_Q=1`, `AWS_Q_DEVELOPER=1`, `GEMINI_CODE_ASSIST=1`, `SRC_CODY=1`, `PI_CODING_AGENT=1`, `AGENT=1` |
 | Explicit flag | `pup --agent <command>` |
 | Environment override | `FORCE_AGENT_MODE=1` |
 

--- a/src/useragent.rs
+++ b/src/useragent.rs
@@ -58,6 +58,10 @@ static AGENT_DETECTORS: &[AgentDetector] = &[
         env_vars: &["SRC_CODY"],
     },
     AgentDetector {
+        name: "pi-dev",
+        env_vars: &["PI_CODING_AGENT"],
+    },
+    AgentDetector {
         name: "generic-agent",
         env_vars: &["AGENT"],
     },
@@ -151,22 +155,27 @@ pub fn get_with_command(command: Option<&str>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::ENV_LOCK;
+
+    fn clear_all_agent_vars() {
+        for det in AGENT_DETECTORS {
+            for var in det.env_vars {
+                std::env::remove_var(var);
+            }
+        }
+        std::env::remove_var("FORCE_AGENT_MODE");
+    }
 
     #[test]
     fn test_is_env_truthy() {
-        // These tests use env vars that shouldn't be set in normal environments
+        let _guard = ENV_LOCK.blocking_lock();
         std::env::set_var("__PUP_TEST_TRUE__", "true");
         assert!(is_env_truthy("__PUP_TEST_TRUE__"));
-
         std::env::set_var("__PUP_TEST_ONE__", "1");
         assert!(is_env_truthy("__PUP_TEST_ONE__"));
-
         std::env::set_var("__PUP_TEST_FALSE__", "false");
         assert!(!is_env_truthy("__PUP_TEST_FALSE__"));
-
         assert!(!is_env_truthy("__PUP_TEST_NONEXISTENT__"));
-
-        // Clean up
         std::env::remove_var("__PUP_TEST_TRUE__");
         std::env::remove_var("__PUP_TEST_ONE__");
         std::env::remove_var("__PUP_TEST_FALSE__");
@@ -174,6 +183,8 @@ mod tests {
 
     #[test]
     fn test_user_agent_format() {
+        let _guard = ENV_LOCK.blocking_lock();
+        clear_all_agent_vars();
         let ua = get();
         assert!(ua.starts_with("pup/"));
         assert!(ua.contains("rust"));
@@ -184,6 +195,8 @@ mod tests {
 
     #[test]
     fn test_user_agent_with_command() {
+        let _guard = ENV_LOCK.blocking_lock();
+        clear_all_agent_vars();
         let ua = get_with_command(Some("security-findings-analyze"));
         assert!(ua.starts_with("pup/"));
         assert!(ua.contains("; cmd security-findings-analyze)"));
@@ -196,6 +209,8 @@ mod tests {
     /// until the UA is fixed.
     #[test]
     fn test_user_agent_parses_for_smart_edge_telemetry() {
+        let _guard = ENV_LOCK.blocking_lock();
+        clear_all_agent_vars();
         for ua in [
             get_with_command(None),
             get_with_command(Some("monitors-list")),
@@ -228,6 +243,8 @@ mod tests {
 
     #[test]
     fn test_user_agent_with_no_command() {
+        let _guard = ENV_LOCK.blocking_lock();
+        clear_all_agent_vars();
         let ua = get_with_command(None);
         assert!(!ua.contains("cmd "));
         assert_eq!(ua, get());
@@ -241,14 +258,8 @@ mod tests {
 
     #[test]
     fn test_detect_agent_info_no_agent() {
-        // Clear all agent env vars
-        for det in AGENT_DETECTORS {
-            for var in det.env_vars {
-                std::env::remove_var(var);
-            }
-        }
-        std::env::remove_var("FORCE_AGENT_MODE");
-
+        let _guard = ENV_LOCK.blocking_lock();
+        clear_all_agent_vars();
         let info = detect_agent_info();
         assert!(!info.detected);
         assert!(info.name.is_empty());
@@ -256,6 +267,8 @@ mod tests {
 
     #[test]
     fn test_detect_agent_info_claude_code() {
+        let _guard = ENV_LOCK.blocking_lock();
+        clear_all_agent_vars();
         std::env::set_var("CLAUDE_CODE", "1");
         let info = detect_agent_info();
         assert!(info.detected);
@@ -265,9 +278,8 @@ mod tests {
 
     #[test]
     fn test_detect_agent_info_cursor() {
-        // Clear higher-priority detectors
-        std::env::remove_var("CLAUDECODE");
-        std::env::remove_var("CLAUDE_CODE");
+        let _guard = ENV_LOCK.blocking_lock();
+        clear_all_agent_vars();
         std::env::set_var("CURSOR_AGENT", "true");
         let info = detect_agent_info();
         assert!(info.detected);
@@ -277,6 +289,8 @@ mod tests {
 
     #[test]
     fn test_is_agent_mode_force() {
+        let _guard = ENV_LOCK.blocking_lock();
+        clear_all_agent_vars();
         std::env::set_var("FORCE_AGENT_MODE", "1");
         assert!(is_agent_mode());
         std::env::remove_var("FORCE_AGENT_MODE");
@@ -284,7 +298,8 @@ mod tests {
 
     #[test]
     fn test_is_agent_mode_via_detector() {
-        std::env::remove_var("FORCE_AGENT_MODE");
+        let _guard = ENV_LOCK.blocking_lock();
+        clear_all_agent_vars();
         std::env::set_var("CLAUDE_CODE", "true");
         assert!(is_agent_mode());
         std::env::remove_var("CLAUDE_CODE");
@@ -292,17 +307,15 @@ mod tests {
 
     #[test]
     fn test_is_agent_mode_false() {
-        std::env::remove_var("FORCE_AGENT_MODE");
-        for det in AGENT_DETECTORS {
-            for var in det.env_vars {
-                std::env::remove_var(var);
-            }
-        }
+        let _guard = ENV_LOCK.blocking_lock();
+        clear_all_agent_vars();
         assert!(!is_agent_mode());
     }
 
     #[test]
     fn test_user_agent_with_detected_agent() {
+        let _guard = ENV_LOCK.blocking_lock();
+        clear_all_agent_vars();
         std::env::set_var("CLAUDE_CODE", "1");
         let ua = get();
         assert!(
@@ -314,11 +327,8 @@ mod tests {
 
     #[test]
     fn test_user_agent_without_agent() {
-        for det in AGENT_DETECTORS {
-            for var in det.env_vars {
-                std::env::remove_var(var);
-            }
-        }
+        let _guard = ENV_LOCK.blocking_lock();
+        clear_all_agent_vars();
         let ua = get();
         assert!(
             !ua.contains("ai-agent"),
@@ -328,12 +338,30 @@ mod tests {
     }
 
     #[test]
+    fn test_detect_agent_info_pi_dev() {
+        let _guard = ENV_LOCK.blocking_lock();
+        clear_all_agent_vars();
+        std::env::set_var("PI_CODING_AGENT", "true");
+        let info = detect_agent_info();
+        assert!(info.detected);
+        assert_eq!(info.name, "pi-dev");
+        std::env::remove_var("PI_CODING_AGENT");
+    }
+
+    #[test]
+    fn test_detect_agent_info_pi_dev_falsy() {
+        let _guard = ENV_LOCK.blocking_lock();
+        clear_all_agent_vars();
+        std::env::set_var("PI_CODING_AGENT", "false");
+        let info = detect_agent_info();
+        assert!(!info.detected);
+        std::env::remove_var("PI_CODING_AGENT");
+    }
+
+    #[test]
     fn test_detect_agent_info_generic_agent() {
-        for det in AGENT_DETECTORS {
-            for var in det.env_vars {
-                std::env::remove_var(var);
-            }
-        }
+        let _guard = ENV_LOCK.blocking_lock();
+        clear_all_agent_vars();
         std::env::set_var("AGENT", "1");
         let info = detect_agent_info();
         assert!(info.detected);


### PR DESCRIPTION
## Summary

Adds pi.dev to the agent detector table so pup automatically switches to agent mode when running inside the pi.dev coding agent. Checks `PI_CODING_AGENT=true|1`, consistent with all other agent detectors.

## Changes

- `src/useragent.rs:61-63` — new `AgentDetector` entry for `pi-dev` / `PI_CODING_AGENT`, placed between `sourcegraph-cody` and `generic-agent`
- `src/useragent.rs` (tests) — refactored all env-var-touching tests to acquire `ENV_LOCK` and use a shared `clear_all_agent_vars()` helper, eliminating latent parallel-test races in the prior ad-hoc per-test cleanup; added positive and negative tests for the new detector
- `README.md` — added `PI_CODING_AGENT` row to Agent Mode detection table; also added missing API coverage rows for commands that were implemented but undocumented (DBM, Agentless Scanning, Logs Restriction, Data Deletion, Live Debugger, Software Catalog, Deployment Gates, AuthN Mappings, Feature Flags, Kafka, Restricted Datasets, MS Teams integration)
- `docs/ARCHITECTURE.md:150` — added pi.dev to the agent detector list
- `docs/LLM_GUIDE.md:13` — added `PI_CODING_AGENT=1` to auto-detect env var list

## Testing

- `cargo test useragent` — 18 tests pass (2 new: `test_detect_agent_info_pi_dev`, `test_detect_agent_info_pi_dev_falsy`)
- `cargo clippy -- -D warnings` — clean
- `cargo fmt --check` — clean

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)