### PR TITLE
feat(dashboards): add time-scoped url command

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,9 @@ pup dashboards list
 # Get dashboard details
 pup dashboards get abc-123-def
 
+# Print a live 1 week dashboard URL
+pup dashboards url abc-123-def --from=now-1w --to=now --live=true
+
 # Delete dashboard
 pup dashboards delete abc-123-def --yes
 ```

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -170,6 +170,9 @@ pup dashboards get "abc-123-def"
 
 # Get public URL for sharing
 pup dashboards url "abc-123-def"
+
+# Open with a live 1 week time window
+pup dashboards url "abc-123-def" --from=now-1w --to=now --live=true
 ```
 
 ### Delete Dashboard

--- a/src/commands/dashboards.rs
+++ b/src/commands/dashboards.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use datadog_api_client::datadogV1::api_dashboards::{DashboardsAPI, ListDashboardsOptionalParams};
 use datadog_api_client::datadogV1::model::Dashboard;
+use url::Url;
 
 use crate::config::Config;
 use crate::formatter;
@@ -51,6 +52,35 @@ pub async fn delete(cfg: &Config, id: &str) -> Result<()> {
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete dashboard: {e:?}"))?;
     formatter::output(cfg, &resp)
+}
+
+pub async fn url(cfg: &Config, id: &str, from: &str, to: &str, live: bool) -> Result<()> {
+    let api = crate::make_api!(DashboardsAPI, cfg);
+    let dashboard = api
+        .get_dashboard(id.to_string())
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to get dashboard: {e:?}"))?;
+    let base_url = dashboard
+        .url
+        .ok_or_else(|| anyhow::anyhow!("dashboard response did not include url"))?;
+    println!("{}", dashboard_url_with_time(&base_url, from, to, live)?);
+    Ok(())
+}
+
+fn dashboard_url_with_time(base_url: &str, from: &str, to: &str, live: bool) -> Result<String> {
+    let mut url = Url::parse(base_url).map_err(|e| {
+        anyhow::anyhow!("dashboard response included invalid url {base_url:?}: {e}")
+    })?;
+    let mut query_pairs: Vec<(String, String)> = url
+        .query_pairs()
+        .filter(|(key, _)| key != "from_ts" && key != "to_ts" && key != "live")
+        .map(|(key, value)| (key.into_owned(), value.into_owned()))
+        .collect();
+    query_pairs.push(("from_ts".to_string(), from.to_string()));
+    query_pairs.push(("to_ts".to_string(), to.to_string()));
+    query_pairs.push(("live".to_string(), live.to_string()));
+    url.query_pairs_mut().clear().extend_pairs(query_pairs);
+    Ok(url.to_string())
 }
 
 #[cfg(test)]
@@ -106,5 +136,37 @@ mod tests {
             result.err()
         );
         cleanup_env();
+    }
+
+    #[test]
+    fn test_dashboard_url_with_time_adds_live_window() {
+        let url = super::dashboard_url_with_time(
+            "https://app.datadoghq.com/dashboard/abc-123/test-dashboard?tpl_var_env=prod",
+            "now-1w",
+            "now",
+            true,
+        )
+        .expect("dashboard URL should be valid");
+
+        assert_eq!(
+            url,
+            "https://app.datadoghq.com/dashboard/abc-123/test-dashboard?tpl_var_env=prod&from_ts=now-1w&to_ts=now&live=true"
+        );
+    }
+
+    #[test]
+    fn test_dashboard_url_with_time_replaces_existing_time_params() {
+        let url = super::dashboard_url_with_time(
+            "https://app.datadoghq.com/dashboard/abc-123/test-dashboard?from_ts=old&to_ts=old&live=false",
+            "now-1w",
+            "now",
+            true,
+        )
+        .expect("dashboard URL should be valid");
+
+        assert_eq!(
+            url,
+            "https://app.datadoghq.com/dashboard/abc-123/test-dashboard?from_ts=now-1w&to_ts=now&live=true"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3198,6 +3198,16 @@ enum DashboardActions {
     List,
     /// Get dashboard details
     Get { id: String },
+    /// Print dashboard URL, optionally scoped to a live time window
+    Url {
+        id: String,
+        #[arg(long = "from", default_value = "now-1w")]
+        from_ts: String,
+        #[arg(long = "to", default_value = "now")]
+        to_ts: String,
+        #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
+        live: bool,
+    },
     /// Create a dashboard from JSON file
     Create {
         #[arg(long)]
@@ -10370,6 +10380,12 @@ async fn main_inner() -> anyhow::Result<()> {
             match action {
                 DashboardActions::List => commands::dashboards::list(&cfg).await?,
                 DashboardActions::Get { id } => commands::dashboards::get(&cfg, &id).await?,
+                DashboardActions::Url {
+                    id,
+                    from_ts,
+                    to_ts,
+                    live,
+                } => commands::dashboards::url(&cfg, &id, &from_ts, &to_ts, live).await?,
                 DashboardActions::Create { file } => {
                     commands::dashboards::create(&cfg, &file).await?;
                 }


### PR DESCRIPTION
## Summary

Add the missing `pup dashboards url` command. This command was already referenced in the README/command docs/examples, but the CLI enum did not implement it.

The command prints a dashboard link with Datadog time params so callers can open dashboards with a live window without manually appending `from_ts`, `to_ts`, and `live`.

## Changes

- Adds `dashboards url <id>` with defaults for a live 1 week window.
- Preserves existing query params while replacing any existing `from_ts`, `to_ts`, or `live` params.
- Updates README/examples with explicit time-window usage.

## Testing

- `cargo test dashboards --features native`
- `cargo fmt --check`
- `cargo clippy --features native -- -D warnings`
- `cargo run --features native -- dashboards url --help`

## Repro Command

```bash
pup dashboards url abc-123-def --from=now-1w --to=now --live=true
```

## Did this cause any problems?

Rollback/revert this commit and release pup again.
