### PR TITLE
fix(pagination): address pagination audit — wire dropped flags, validate limits, fix panics

### DIFF
--- a/src/commands/cases.rs
+++ b/src/commands/cases.rs
@@ -29,9 +29,16 @@ fn make_api(cfg: &Config) -> CaseManagementAPI {
 // Core case operations
 // ---------------------------------------------------------------------------
 
-pub async fn search(cfg: &Config, query: Option<String>, page_size: i64) -> Result<()> {
+pub async fn search(
+    cfg: &Config,
+    query: Option<String>,
+    page_size: i64,
+    page_number: i64,
+) -> Result<()> {
     let api = make_api(cfg);
-    let mut params = SearchCasesOptionalParams::default().page_size(page_size);
+    let mut params = SearchCasesOptionalParams::default()
+        .page_size(page_size)
+        .page_number(page_number);
     if let Some(q) = query {
         params = params.filter(q);
     }
@@ -372,7 +379,7 @@ mod tests {
         let mut s = mockito::Server::new_async().await;
         let cfg = test_config(&s.url());
         mock_all(&mut s, r#"{"data": []}"#).await;
-        let _ = super::search(&cfg, None, 10).await;
+        let _ = super::search(&cfg, None, 10, 0).await;
         cleanup_env();
     }
 

--- a/src/commands/cicd.rs
+++ b/src/commands/cicd.rs
@@ -47,10 +47,7 @@ pub async fn pipelines_list(
         query_parts.push(format!("@git.branch:\"{}\"", b.replace('"', "\\\"")));
     }
     if let Some(p) = pipeline_name {
-        query_parts.push(format!(
-            "@ci.pipeline.name:\"{}\"",
-            p.replace('"', "\\\"")
-        ));
+        query_parts.push(format!("@ci.pipeline.name:\"{}\"", p.replace('"', "\\\"")));
     }
 
     let mut filter = CIAppPipelinesQueryFilter::new().from(from_str).to(to_str);
@@ -387,9 +384,15 @@ mod tests {
     #[tokio::test]
     async fn test_cicd_events_search_invalid_sort() {
         let cfg = test_config("http://unused.local");
-        let result =
-            super::events_search(&cfg, "*".into(), "1h".into(), "now".into(), 10, "bogus".into())
-                .await;
+        let result = super::events_search(
+            &cfg,
+            "*".into(),
+            "1h".into(),
+            "now".into(),
+            10,
+            "bogus".into(),
+        )
+        .await;
         assert!(result.is_err());
         assert!(result
             .unwrap_err()

--- a/src/commands/cicd.rs
+++ b/src/commands/cicd.rs
@@ -25,21 +25,37 @@ pub async fn pipelines_list(
     from: String,
     to: String,
     limit: i32,
+    branch: Option<String>,
+    pipeline_name: Option<String>,
 ) -> Result<()> {
     let api = crate::make_api!(CIVisibilityPipelinesAPI, cfg);
 
     let from_ms = util::parse_time_to_unix_millis(&from)?;
     let to_ms = util::parse_time_to_unix_millis(&to)?;
     let from_str = chrono::DateTime::from_timestamp_millis(from_ms)
-        .unwrap()
+        .ok_or_else(|| anyhow::anyhow!("--from value {from_ms}ms is out of representable range"))?
         .to_rfc3339();
     let to_str = chrono::DateTime::from_timestamp_millis(to_ms)
-        .unwrap()
+        .ok_or_else(|| anyhow::anyhow!("--to value {to_ms}ms is out of representable range"))?
         .to_rfc3339();
 
-    let mut filter = CIAppPipelinesQueryFilter::new().from(from_str).to(to_str);
+    let mut query_parts: Vec<String> = Vec::new();
     if let Some(q) = query {
-        filter = filter.query(q);
+        query_parts.push(q);
+    }
+    if let Some(b) = branch {
+        query_parts.push(format!("@git.branch:\"{}\"", b.replace('"', "\\\"")));
+    }
+    if let Some(p) = pipeline_name {
+        query_parts.push(format!(
+            "@ci.pipeline.name:\"{}\"",
+            p.replace('"', "\\\"")
+        ));
+    }
+
+    let mut filter = CIAppPipelinesQueryFilter::new().from(from_str).to(to_str);
+    if !query_parts.is_empty() {
+        filter = filter.query(query_parts.join(" "));
     }
 
     let body = CIAppPipelineEventsRequest::new()
@@ -88,17 +104,26 @@ pub async fn events_search(
     from: String,
     to: String,
     limit: i32,
+    sort: String,
 ) -> Result<()> {
     let api = crate::make_api!(CIVisibilityPipelinesAPI, cfg);
 
     let from_ms = util::parse_time_to_unix_millis(&from)?;
     let to_ms = util::parse_time_to_unix_millis(&to)?;
     let from_str = chrono::DateTime::from_timestamp_millis(from_ms)
-        .unwrap()
+        .ok_or_else(|| anyhow::anyhow!("--from value {from_ms}ms is out of representable range"))?
         .to_rfc3339();
     let to_str = chrono::DateTime::from_timestamp_millis(to_ms)
-        .unwrap()
+        .ok_or_else(|| anyhow::anyhow!("--to value {to_ms}ms is out of representable range"))?
         .to_rfc3339();
+
+    let sort_val = match sort.as_str() {
+        "asc" | "timestamp" => CIAppSort::TIMESTAMP_ASCENDING,
+        "desc" | "-timestamp" => CIAppSort::TIMESTAMP_DESCENDING,
+        other => anyhow::bail!(
+            "invalid --sort value: {other:?}\nExpected: asc (ascending) or desc (descending)"
+        ),
+    };
 
     let filter = CIAppPipelinesQueryFilter::new()
         .from(from_str)
@@ -108,7 +133,7 @@ pub async fn events_search(
     let body = CIAppPipelineEventsRequest::new()
         .filter(filter)
         .page(CIAppQueryPageOptions::new().limit(limit))
-        .sort(CIAppSort::TIMESTAMP_DESCENDING);
+        .sort(sort_val);
 
     let params = SearchCIAppPipelineEventsOptionalParams::default().body(body);
     let resp = api
@@ -124,10 +149,10 @@ pub async fn events_aggregate(cfg: &Config, query: String, from: String, to: Str
     let from_ms = util::parse_time_to_unix_millis(&from)?;
     let to_ms = util::parse_time_to_unix_millis(&to)?;
     let from_str = chrono::DateTime::from_timestamp_millis(from_ms)
-        .unwrap()
+        .ok_or_else(|| anyhow::anyhow!("--from value {from_ms}ms is out of representable range"))?
         .to_rfc3339();
     let to_str = chrono::DateTime::from_timestamp_millis(to_ms)
-        .unwrap()
+        .ok_or_else(|| anyhow::anyhow!("--to value {to_ms}ms is out of representable range"))?
         .to_rfc3339();
 
     let filter = CIAppPipelinesQueryFilter::new()
@@ -157,10 +182,10 @@ pub async fn tests_search(
     let from_ms = util::parse_time_to_unix_millis(&from)?;
     let to_ms = util::parse_time_to_unix_millis(&to)?;
     let from_str = chrono::DateTime::from_timestamp_millis(from_ms)
-        .unwrap()
+        .ok_or_else(|| anyhow::anyhow!("--from value {from_ms}ms is out of representable range"))?
         .to_rfc3339();
     let to_str = chrono::DateTime::from_timestamp_millis(to_ms)
-        .unwrap()
+        .ok_or_else(|| anyhow::anyhow!("--to value {to_ms}ms is out of representable range"))?
         .to_rfc3339();
 
     let filter = CIAppTestsQueryFilter::new()
@@ -187,10 +212,10 @@ pub async fn tests_aggregate(cfg: &Config, query: String, from: String, to: Stri
     let from_ms = util::parse_time_to_unix_millis(&from)?;
     let to_ms = util::parse_time_to_unix_millis(&to)?;
     let from_str = chrono::DateTime::from_timestamp_millis(from_ms)
-        .unwrap()
+        .ok_or_else(|| anyhow::anyhow!("--from value {from_ms}ms is out of representable range"))?
         .to_rfc3339();
     let to_str = chrono::DateTime::from_timestamp_millis(to_ms)
-        .unwrap()
+        .ok_or_else(|| anyhow::anyhow!("--to value {to_ms}ms is out of representable range"))?
         .to_rfc3339();
 
     let filter = CIAppTestsQueryFilter::new()
@@ -314,7 +339,7 @@ mod tests {
         let mut s = mockito::Server::new_async().await;
         let cfg = test_config(&s.url());
         mock_all(&mut s, r#"{"data": []}"#).await;
-        let _ = super::pipelines_list(&cfg, None, "1h".into(), "now".into(), 10).await;
+        let _ = super::pipelines_list(&cfg, None, "1h".into(), "now".into(), 10, None, None).await;
         cleanup_env();
     }
 
@@ -357,5 +382,18 @@ mod tests {
             .to_string()
             .contains("invalid sort value"));
         cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_cicd_events_search_invalid_sort() {
+        let cfg = test_config("http://unused.local");
+        let result =
+            super::events_search(&cfg, "*".into(), "1h".into(), "now".into(), 10, "bogus".into())
+                .await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("invalid --sort value"));
     }
 }

--- a/src/commands/error_tracking.rs
+++ b/src/commands/error_tracking.rs
@@ -1,31 +1,46 @@
 use anyhow::Result;
-use chrono::Utc;
 use datadog_api_client::datadogV2::api_error_tracking::{
     ErrorTrackingAPI, GetIssueOptionalParams, SearchIssuesOptionalParams,
 };
 use datadog_api_client::datadogV2::model::{
     IssuesSearchRequest, IssuesSearchRequestData, IssuesSearchRequestDataAttributes,
-    IssuesSearchRequestDataAttributesPersona, IssuesSearchRequestDataAttributesTrack,
-    IssuesSearchRequestDataType,
+    IssuesSearchRequestDataAttributesOrderBy, IssuesSearchRequestDataAttributesPersona,
+    IssuesSearchRequestDataAttributesTrack, IssuesSearchRequestDataType,
 };
 
 use crate::config::Config;
 use crate::formatter;
+use crate::util;
 
+#[allow(clippy::too_many_arguments)]
 pub async fn issues_search(
     cfg: &Config,
     query: Option<String>,
-    _limit: i32,
+    limit: i32,
+    from: String,
+    to: String,
+    order_by: String,
     track: Option<String>,
     persona: Option<String>,
 ) -> Result<()> {
     let api = crate::make_api!(ErrorTrackingAPI, cfg);
 
-    let now = Utc::now().timestamp_millis();
-    let one_day_ago = now - 86_400_000; // 24 hours in millis
+    let from_ms = util::parse_time_to_unix_millis(&from)?;
+    let to_ms = util::parse_time_to_unix_millis(&to)?;
+
+    let order_by_val = match order_by.to_uppercase().as_str() {
+        "TOTAL_COUNT" => IssuesSearchRequestDataAttributesOrderBy::TOTAL_COUNT,
+        "FIRST_SEEN" => IssuesSearchRequestDataAttributesOrderBy::FIRST_SEEN,
+        "IMPACTED_SESSIONS" => IssuesSearchRequestDataAttributesOrderBy::IMPACTED_SESSIONS,
+        "PRIORITY" => IssuesSearchRequestDataAttributesOrderBy::PRIORITY,
+        other => anyhow::bail!(
+            "invalid --order-by value: {other:?}\nExpected: TOTAL_COUNT, FIRST_SEEN, IMPACTED_SESSIONS, PRIORITY"
+        ),
+    };
 
     let query_str = query.unwrap_or_else(|| "*".to_string());
-    let mut attrs = IssuesSearchRequestDataAttributes::new(one_day_ago, query_str, now);
+    let mut attrs =
+        IssuesSearchRequestDataAttributes::new(from_ms, query_str, to_ms).order_by(order_by_val);
     if let Some(ref t) = track {
         let track_value = match t.to_lowercase().as_str() {
             "trace" => IssuesSearchRequestDataAttributesTrack::TRACE,
@@ -55,17 +70,22 @@ pub async fn issues_search(
     let body = IssuesSearchRequest::new(data);
     let params = SearchIssuesOptionalParams::default();
 
-    let resp = api
+    let mut resp = api
         .search_issues(body, params)
         .await
         .map_err(|e| anyhow::anyhow!("failed to search issues: {e:?}"))?;
-    let val = serde_json::to_value(&resp)?;
-    if let Some(data) = val.get("data") {
-        if data.as_array().is_some_and(|a| a.is_empty()) {
-            println!("No error tracking issues found matching the specified criteria.");
-            return Ok(());
+
+    if resp.data.as_ref().is_some_and(|d| d.is_empty()) {
+        eprintln!("No error tracking issues found matching the specified criteria.");
+        return Ok(());
+    }
+
+    if limit > 0 {
+        if let Some(data) = resp.data.as_mut() {
+            data.truncate(limit as usize);
         }
     }
+
     formatter::output(cfg, &resp)
 }
 
@@ -90,7 +110,17 @@ mod tests {
         let mut s = mockito::Server::new_async().await;
         let cfg = test_config(&s.url());
         mock_all(&mut s, r#"{"data": []}"#).await;
-        let _ = super::issues_search(&cfg, None, 10, Some("trace".into()), None).await;
+        let _ = super::issues_search(
+            &cfg,
+            None,
+            10,
+            "1d".into(),
+            "now".into(),
+            "TOTAL_COUNT".into(),
+            Some("trace".into()),
+            None,
+        )
+        .await;
         cleanup_env();
     }
 
@@ -100,7 +130,17 @@ mod tests {
         let mut s = mockito::Server::new_async().await;
         let cfg = test_config(&s.url());
         mock_all(&mut s, r#"{"data": []}"#).await;
-        let _ = super::issues_search(&cfg, None, 10, None, Some("BROWSER".into())).await;
+        let _ = super::issues_search(
+            &cfg,
+            None,
+            10,
+            "1d".into(),
+            "now".into(),
+            "TOTAL_COUNT".into(),
+            None,
+            Some("BROWSER".into()),
+        )
+        .await;
         cleanup_env();
     }
 
@@ -110,8 +150,39 @@ mod tests {
         let mut s = mockito::Server::new_async().await;
         let cfg = test_config(&s.url());
         mock_all(&mut s, r#"{"data": []}"#).await;
-        let _ = super::issues_search(&cfg, None, 10, Some("RUM".into()), None).await;
+        let _ = super::issues_search(
+            &cfg,
+            None,
+            10,
+            "1d".into(),
+            "now".into(),
+            "TOTAL_COUNT".into(),
+            Some("RUM".into()),
+            None,
+        )
+        .await;
         cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_error_tracking_issues_search_invalid_order_by() {
+        let cfg = test_config("http://unused.local");
+        let result = super::issues_search(
+            &cfg,
+            None,
+            10,
+            "1d".into(),
+            "now".into(),
+            "INVALID".into(),
+            Some("trace".into()),
+            None,
+        )
+        .await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("invalid --order-by value"));
     }
 
     #[test]

--- a/src/commands/investigations.rs
+++ b/src/commands/investigations.rs
@@ -9,11 +9,14 @@ fn make_api(cfg: &Config) -> BitsAIAPI {
     crate::make_api!(BitsAIAPI, cfg)
 }
 
-pub async fn list(cfg: &Config, page_limit: i64, page_offset: i64) -> Result<()> {
+pub async fn list(cfg: &Config, page_limit: i64, page_offset: i64, monitor_id: i64) -> Result<()> {
     let api = make_api(cfg);
-    let params = ListInvestigationsOptionalParams::default()
+    let mut params = ListInvestigationsOptionalParams::default()
         .page_limit(page_limit)
         .page_offset(page_offset);
+    if monitor_id != 0 {
+        params = params.filter_monitor_id(monitor_id);
+    }
     let resp = api
         .list_investigations(params)
         .await
@@ -52,7 +55,7 @@ mod tests {
         let mut s = mockito::Server::new_async().await;
         let cfg = test_config(&s.url());
         mock_all(&mut s, r#"{"data": []}"#).await;
-        let _ = super::list(&cfg, 10, 0).await;
+        let _ = super::list(&cfg, 10, 0, 0).await;
         cleanup_env();
     }
 

--- a/src/commands/metrics.rs
+++ b/src/commands/metrics.rs
@@ -40,11 +40,19 @@ use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
-pub async fn list(cfg: &Config, filter: Option<String>, from: String) -> Result<()> {
+pub async fn list(
+    cfg: &Config,
+    filter: Option<String>,
+    from: String,
+    tag_filter: Option<String>,
+) -> Result<()> {
     let api = crate::make_api!(MetricsV1API, cfg);
 
     let from_ts = util::parse_time_to_unix(&from)?;
-    let params = ListActiveMetricsOptionalParams::default();
+    let mut params = ListActiveMetricsOptionalParams::default();
+    if let Some(tf) = tag_filter {
+        params = params.tag_filter(tf);
+    }
 
     let resp = api
         .list_active_metrics(from_ts, params)
@@ -199,7 +207,7 @@ mod tests {
         )
         .await;
 
-        let result = super::list(&cfg, None, "1h".into()).await;
+        let result = super::list(&cfg, None, "1h".into(), None).await;
         assert!(result.is_ok(), "metrics list failed: {:?}", result.err());
         cleanup_env();
     }

--- a/src/commands/monitors.rs
+++ b/src/commands/monitors.rs
@@ -14,7 +14,12 @@ pub async fn list(
     name: Option<String>,
     tags: Option<String>,
     limit: i32,
+    page: i64,
 ) -> Result<()> {
+    if !(1..=1000).contains(&limit) {
+        anyhow::bail!("--limit must be between 1 and 1000, got {limit}");
+    }
+
     let api = crate::make_api!(MonitorsAPI, cfg);
 
     let mut params = ListMonitorsOptionalParams::default();
@@ -24,9 +29,7 @@ pub async fn list(
     if let Some(tags) = tags {
         params = params.monitor_tags(tags);
     }
-
-    let limit = limit.clamp(1, 1000);
-    params = params.page_size(limit).page(0);
+    params = params.page_size(limit).page(page);
 
     let monitors = api
         .list_monitors(params)
@@ -38,7 +41,6 @@ pub async fn list(
         return Ok(());
     }
 
-    let monitors: Vec<_> = monitors.into_iter().take(limit as usize).collect();
     let meta = Metadata {
         count: Some(monitors.len()),
         truncated: false,
@@ -85,12 +87,23 @@ pub async fn update(cfg: &Config, monitor_id: i64, file: &str) -> Result<()> {
     formatter::output(cfg, &resp)
 }
 
-pub async fn search(cfg: &Config, query: Option<String>) -> Result<()> {
+pub async fn search(
+    cfg: &Config,
+    query: Option<String>,
+    page: i64,
+    per_page: i64,
+    sort: Option<String>,
+) -> Result<()> {
     let api = crate::make_api!(MonitorsAPI, cfg);
 
-    let mut params = SearchMonitorsOptionalParams::default();
+    let mut params = SearchMonitorsOptionalParams::default()
+        .page(page)
+        .per_page(per_page);
     if let Some(q) = query {
         params = params.query(q);
+    }
+    if let Some(s) = sort {
+        params = params.sort(s);
     }
 
     let resp = api
@@ -121,7 +134,7 @@ mod tests {
         let cfg = test_config(&server.url());
         let _mock = mock_any(&mut server, "GET", "[]").await;
 
-        let result = super::list(&cfg, None, None, 10).await;
+        let result = super::list(&cfg, None, None, 10, 0).await;
         assert!(result.is_ok(), "monitors list failed: {:?}", result.err());
         cleanup_env();
     }
@@ -135,7 +148,7 @@ mod tests {
         let body = r#"[{"id": 1, "name": "Test Monitor", "type": "metric alert", "query": "avg(last_5m):avg:system.cpu.user{*} > 90", "message": "CPU high", "tags": [], "options": {}}]"#;
         let _mock = mock_any(&mut server, "GET", body).await;
 
-        let result = super::list(&cfg, Some("Test".into()), None, 10).await;
+        let result = super::list(&cfg, Some("Test".into()), None, 10, 0).await;
         assert!(
             result.is_ok(),
             "monitors list with results failed: {:?}",
@@ -167,9 +180,31 @@ mod tests {
         let body = r#"{"monitors": [], "metadata": {"page": 0, "page_count": 0, "per_page": 30, "total_count": 0}}"#;
         let _mock = mock_any(&mut server, "GET", body).await;
 
-        let result = super::search(&cfg, Some("cpu".into())).await;
+        let result = super::search(&cfg, Some("cpu".into()), 0, 30, None).await;
         assert!(result.is_ok(), "monitors search failed: {:?}", result.err());
         cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_monitors_list_limit_too_small() {
+        let cfg = test_config("http://unused.local");
+        let result = super::list(&cfg, None, None, 0, 0).await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("--limit must be between 1 and 1000"));
+    }
+
+    #[tokio::test]
+    async fn test_monitors_list_limit_too_large() {
+        let cfg = test_config("http://unused.local");
+        let result = super::list(&cfg, None, None, 1001, 0).await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("--limit must be between 1 and 1000"));
     }
 
     #[tokio::test]

--- a/src/commands/on_call.rs
+++ b/src/commands/on_call.rs
@@ -58,9 +58,9 @@ pub(crate) async fn resolve_team_id(cfg: &Config, input: &str) -> Result<String>
         .await
         .map_err(|e| anyhow::anyhow!("failed to resolve team handle '{input}': {e:?}"))?;
 
-    let teams = resp
-        .data
-        .ok_or_else(|| anyhow::anyhow!("unexpected response from teams API: 'data' field missing"))?;
+    let teams = resp.data.ok_or_else(|| {
+        anyhow::anyhow!("unexpected response from teams API: 'data' field missing")
+    })?;
     let total = teams.len();
     let exact: Vec<&datadog_api_client::datadogV2::model::Team> = teams
         .iter()
@@ -880,7 +880,11 @@ mod tests {
         let team_uuid = "00000000-0000-0000-0000-000000000001";
         mock_all(&mut s, r#"{"data": []}"#).await;
         let result = super::memberships_list(&cfg, team_uuid, 10, 0, "name".into()).await;
-        assert!(result.is_ok(), "memberships_list failed: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "memberships_list failed: {:?}",
+            result.err()
+        );
         cleanup_env();
     }
 

--- a/src/commands/on_call.rs
+++ b/src/commands/on_call.rs
@@ -12,12 +12,12 @@ use datadog_api_client::datadogV2::api_teams::{
 };
 use datadog_api_client::datadogV2::model::{
     CreateOnCallNotificationRuleRequest, CreatePageRequest, CreateUserNotificationChannelRequest,
-    EscalationPolicyCreateRequest, EscalationPolicyUpdateRequest, RelationshipToUserTeamUser,
-    RelationshipToUserTeamUserData, ScheduleCreateRequest, ScheduleUpdateRequest, TeamCreate,
-    TeamCreateAttributes, TeamCreateRequest, TeamType, TeamUpdate, TeamUpdateAttributes,
-    TeamUpdateRequest, UpdateOnCallNotificationRuleRequest, UserTeamAttributes, UserTeamCreate,
-    UserTeamRelationships, UserTeamRequest, UserTeamRole, UserTeamType, UserTeamUpdate,
-    UserTeamUpdateRequest, UserTeamUserType,
+    EscalationPolicyCreateRequest, EscalationPolicyUpdateRequest, GetTeamMembershipsSort,
+    RelationshipToUserTeamUser, RelationshipToUserTeamUserData, ScheduleCreateRequest,
+    ScheduleUpdateRequest, TeamCreate, TeamCreateAttributes, TeamCreateRequest, TeamType,
+    TeamUpdate, TeamUpdateAttributes, TeamUpdateRequest, UpdateOnCallNotificationRuleRequest,
+    UserTeamAttributes, UserTeamCreate, UserTeamRelationships, UserTeamRequest, UserTeamRole,
+    UserTeamType, UserTeamUpdate, UserTeamUpdateRequest, UserTeamUserType,
 };
 
 use crate::client;
@@ -58,11 +58,13 @@ pub(crate) async fn resolve_team_id(cfg: &Config, input: &str) -> Result<String>
         .await
         .map_err(|e| anyhow::anyhow!("failed to resolve team handle '{input}': {e:?}"))?;
 
-    let teams = resp.data.unwrap_or_default();
+    let teams = resp
+        .data
+        .ok_or_else(|| anyhow::anyhow!("unexpected response from teams API: 'data' field missing"))?;
     let total = teams.len();
     let exact: Vec<&datadog_api_client::datadogV2::model::Team> = teams
         .iter()
-        .filter(|t| t.attributes.handle == input)
+        .filter(|t| t.attributes.handle.to_lowercase() == input.to_lowercase())
         .collect();
 
     match exact.len() {
@@ -71,6 +73,14 @@ pub(crate) async fn resolve_team_id(cfg: &Config, input: &str) -> Result<String>
         _ => Err(anyhow::anyhow!(
             "no exact handle match for '{input}' ({total} candidates matched substring)"
         )),
+    }
+}
+
+fn parse_team_role(role: &str) -> Result<UserTeamRole> {
+    // UserTeamRole is #[non_exhaustive] upstream — extend this match when new variants are added.
+    match role.to_lowercase().as_str() {
+        "admin" => Ok(UserTeamRole::ADMIN),
+        other => anyhow::bail!("invalid --role value: {other:?}\nExpected: admin"),
     }
 }
 
@@ -129,10 +139,34 @@ pub async fn teams_update(cfg: &Config, team_id: &str, name: &str, handle: &str)
     formatter::output(cfg, &resp)
 }
 
-pub async fn memberships_list(cfg: &Config, team_id: &str, page_size: i64) -> Result<()> {
+pub async fn memberships_list(
+    cfg: &Config,
+    team_id: &str,
+    page_size: i64,
+    page_number: i64,
+    sort: String,
+) -> Result<()> {
+    let sort_val = match sort.as_str() {
+        "manager_name" => GetTeamMembershipsSort::MANAGER_NAME,
+        "-manager_name" => GetTeamMembershipsSort::_MANAGER_NAME,
+        "name" => GetTeamMembershipsSort::NAME,
+        "-name" => GetTeamMembershipsSort::_NAME,
+        "handle" => GetTeamMembershipsSort::HANDLE,
+        "-handle" => GetTeamMembershipsSort::_HANDLE,
+        "email" => GetTeamMembershipsSort::EMAIL,
+        "-email" => GetTeamMembershipsSort::_EMAIL,
+        other => anyhow::bail!(
+            "invalid --sort value: {other:?}\nExpected: name, -name, email, -email, handle, -handle, manager_name, -manager_name"
+        ),
+    };
+
     let resolved = resolve_team_id(cfg, team_id).await?;
     let api = crate::make_api!(TeamsAPI, cfg);
-    let params = GetTeamMembershipsOptionalParams::default().page_size(page_size);
+
+    let params = GetTeamMembershipsOptionalParams::default()
+        .page_size(page_size)
+        .page_number(page_number)
+        .sort(sort_val);
     let resp = api
         .get_team_memberships(resolved, params)
         .await
@@ -146,16 +180,12 @@ pub async fn memberships_add(
     user_id: &str,
     role: Option<String>,
 ) -> Result<()> {
-    let resolved = resolve_team_id(cfg, team_id).await?;
-    let api = crate::make_api!(TeamsAPI, cfg);
     let mut attrs = UserTeamAttributes::new();
     if let Some(r) = role {
-        let team_role = match r.to_lowercase().as_str() {
-            "admin" => UserTeamRole::ADMIN,
-            _ => UserTeamRole::ADMIN,
-        };
-        attrs = attrs.role(Some(team_role));
+        attrs = attrs.role(Some(parse_team_role(&r)?));
     }
+    let resolved = resolve_team_id(cfg, team_id).await?;
+    let api = crate::make_api!(TeamsAPI, cfg);
     let user_data =
         RelationshipToUserTeamUserData::new(user_id.to_string(), UserTeamUserType::USERS);
     let user_rel = RelationshipToUserTeamUser::new(user_data);
@@ -177,12 +207,9 @@ pub async fn memberships_update(
     user_id: &str,
     role: &str,
 ) -> Result<()> {
+    let team_role = parse_team_role(role)?;
     let resolved = resolve_team_id(cfg, team_id).await?;
     let api = crate::make_api!(TeamsAPI, cfg);
-    let team_role = match role.to_lowercase().as_str() {
-        "admin" => UserTeamRole::ADMIN,
-        _ => UserTeamRole::ADMIN,
-    };
     let attrs = UserTeamAttributes::new().role(Some(team_role));
     let data = UserTeamUpdate::new(UserTeamType::TEAM_MEMBERSHIPS).attributes(attrs);
     let body = UserTeamUpdateRequest::new(data);
@@ -832,5 +859,97 @@ mod tests {
         let result = super::pages_get(&cfg, "abc/def?x").await;
         assert!(result.is_ok(), "pages_get failed: {:?}", result.err());
         cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_memberships_list_invalid_sort() {
+        let cfg = test_config("http://unused.local");
+        let result = super::memberships_list(&cfg, "team-id", 10, 0, "bogus".into()).await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("invalid --sort value"));
+    }
+
+    #[tokio::test]
+    async fn test_memberships_list_valid_sort() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        let team_uuid = "00000000-0000-0000-0000-000000000001";
+        mock_all(&mut s, r#"{"data": []}"#).await;
+        let result = super::memberships_list(&cfg, team_uuid, 10, 0, "name".into()).await;
+        assert!(result.is_ok(), "memberships_list failed: {:?}", result.err());
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_resolve_team_id_case_insensitive() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        // API returns handle in lowercase; caller passes mixed-case — must still resolve.
+        let list_body = r#"{
+            "data": [
+                {
+                    "id": "00000000-0000-0000-0000-000000000002",
+                    "type": "team",
+                    "attributes": {
+                        "name": "Example Team",
+                        "handle": "example-team",
+                        "description": null,
+                        "avatar": null,
+                        "banner": null,
+                        "visible_modules": null,
+                        "hidden_modules": null,
+                        "created_at": null,
+                        "modified_at": null,
+                        "summary": null,
+                        "link_count": 0,
+                        "user_count": 0,
+                        "team_links": null
+                    }
+                }
+            ]
+        }"#;
+        s.mock("GET", mockito::Matcher::Any)
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(list_body)
+            .create_async()
+            .await;
+        let result = super::resolve_team_id(&cfg, "Example-Team").await;
+        assert!(
+            result.is_ok(),
+            "resolve_team_id case-insensitive failed: {:?}",
+            result.err()
+        );
+        assert_eq!(result.unwrap(), "00000000-0000-0000-0000-000000000002");
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_memberships_add_invalid_role() {
+        let cfg = test_config("http://unused.local");
+        let result =
+            super::memberships_add(&cfg, "team-id", "user-id", Some("editor".into())).await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("invalid --role value"));
+    }
+
+    #[tokio::test]
+    async fn test_memberships_update_invalid_role() {
+        let cfg = test_config("http://unused.local");
+        let result = super::memberships_update(&cfg, "team-id", "user-id", "editor").await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("invalid --role value"));
     }
 }

--- a/src/commands/rum.rs
+++ b/src/commands/rum.rs
@@ -10,9 +10,9 @@ use datadog_api_client::datadogV2::api_rum_replay_playlists::{
 use datadog_api_client::datadogV2::api_rum_retention_filters::RumRetentionFiltersAPI;
 use datadog_api_client::datadogV2::model::{
     RUMApplicationCreate, RUMApplicationCreateAttributes, RUMApplicationCreateRequest,
-    RUMApplicationCreateType, RUMApplicationUpdateRequest, RUMQueryFilter, RUMSearchEventsRequest,
-    RUMSort, RumMetricCreateRequest, RumMetricUpdateRequest, RumRetentionFilterCreateRequest,
-    RumRetentionFilterUpdateRequest,
+    RUMApplicationCreateType, RUMApplicationUpdateRequest, RUMQueryFilter, RUMQueryPageOptions,
+    RUMSearchEventsRequest, RUMSort, RumMetricCreateRequest, RumMetricUpdateRequest,
+    RumRetentionFilterCreateRequest, RumRetentionFilterUpdateRequest,
 };
 
 use crate::client;
@@ -94,15 +94,17 @@ pub async fn sessions_search(
     query: Option<String>,
     from: String,
     to: String,
-    _limit: i32,
+    limit: i32,
 ) -> Result<()> {
     let api = crate::make_api!(RUMAPI, cfg);
 
-    let from_str = chrono::DateTime::from_timestamp_millis(util::parse_time_to_unix_millis(&from)?)
-        .unwrap()
+    let from_ms = util::parse_time_to_unix_millis(&from)?;
+    let to_ms = util::parse_time_to_unix_millis(&to)?;
+    let from_str = chrono::DateTime::from_timestamp_millis(from_ms)
+        .ok_or_else(|| anyhow::anyhow!("--from value {from_ms}ms is out of representable range"))?
         .to_rfc3339();
-    let to_str = chrono::DateTime::from_timestamp_millis(util::parse_time_to_unix_millis(&to)?)
-        .unwrap()
+    let to_str = chrono::DateTime::from_timestamp_millis(to_ms)
+        .ok_or_else(|| anyhow::anyhow!("--to value {to_ms}ms is out of representable range"))?
         .to_rfc3339();
 
     let mut filter = RUMQueryFilter::new().from(from_str).to(to_str);
@@ -112,6 +114,7 @@ pub async fn sessions_search(
 
     let body = RUMSearchEventsRequest::new()
         .filter(filter)
+        .page(RUMQueryPageOptions::new().limit(limit))
         .sort(RUMSort::TIMESTAMP_DESCENDING);
 
     let resp = api
@@ -239,11 +242,13 @@ pub async fn retention_filters_delete(cfg: &Config, app_id: &str, filter_id: &st
 pub async fn sessions_list(cfg: &Config, from: String, to: String, limit: i32) -> Result<()> {
     let api = crate::make_api!(RUMAPI, cfg);
 
-    let from_str = chrono::DateTime::from_timestamp_millis(util::parse_time_to_unix_millis(&from)?)
-        .unwrap()
+    let from_ms = util::parse_time_to_unix_millis(&from)?;
+    let to_ms = util::parse_time_to_unix_millis(&to)?;
+    let from_str = chrono::DateTime::from_timestamp_millis(from_ms)
+        .ok_or_else(|| anyhow::anyhow!("--from value {from_ms}ms is out of representable range"))?
         .to_rfc3339();
-    let to_str = chrono::DateTime::from_timestamp_millis(util::parse_time_to_unix_millis(&to)?)
-        .unwrap()
+    let to_str = chrono::DateTime::from_timestamp_millis(to_ms)
+        .ok_or_else(|| anyhow::anyhow!("--to value {to_ms}ms is out of representable range"))?
         .to_rfc3339();
 
     let filter = RUMQueryFilter::new()
@@ -534,6 +539,18 @@ mod tests {
         let cfg = test_config(&s.url());
         mock_all(&mut s, r#"{"data": []}"#).await;
         let _ = super::playlists_list(&cfg).await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_rum_sessions_search() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        mock_all(&mut s, r#"{"data": []}"#).await;
+        let result =
+            super::sessions_search(&cfg, None, "1h".into(), "now".into(), 25).await;
+        assert!(result.is_ok(), "rum sessions search failed: {:?}", result.err());
         cleanup_env();
     }
 }

--- a/src/commands/rum.rs
+++ b/src/commands/rum.rs
@@ -548,9 +548,12 @@ mod tests {
         let mut s = mockito::Server::new_async().await;
         let cfg = test_config(&s.url());
         mock_all(&mut s, r#"{"data": []}"#).await;
-        let result =
-            super::sessions_search(&cfg, None, "1h".into(), "now".into(), 25).await;
-        assert!(result.is_ok(), "rum sessions search failed: {:?}", result.err());
+        let result = super::sessions_search(&cfg, None, "1h".into(), "now".into(), 25).await;
+        assert!(
+            result.is_ok(),
+            "rum sessions search failed: {:?}",
+            result.err()
+        );
         cleanup_env();
     }
 }

--- a/src/commands/security.rs
+++ b/src/commands/security.rs
@@ -1084,9 +1084,15 @@ mod tests {
     #[tokio::test]
     async fn test_signals_search_invalid_sort() {
         let cfg = test_config("http://unused.local");
-        let result =
-            super::signals_search(&cfg, "*".into(), "1h".into(), "now".into(), 10, Some("invalid".into()))
-                .await;
+        let result = super::signals_search(
+            &cfg,
+            "*".into(),
+            "1h".into(),
+            "now".into(),
+            10,
+            Some("invalid".into()),
+        )
+        .await;
         assert!(result.is_err());
         assert!(result
             .unwrap_err()

--- a/src/commands/security.rs
+++ b/src/commands/security.rs
@@ -218,11 +218,20 @@ pub async fn signals_search(
     from: String,
     to: String,
     limit: i32,
+    sort: Option<String>,
 ) -> Result<()> {
     let api = crate::make_api!(SecurityMonitoringAPI, cfg);
 
     let from_dt = util::parse_time_to_datetime(&from)?;
     let to_dt = util::parse_time_to_datetime(&to)?;
+
+    let sort_val = match sort.as_deref().unwrap_or("-timestamp") {
+        "timestamp" | "asc" => SecurityMonitoringSignalsSort::TIMESTAMP_ASCENDING,
+        "-timestamp" | "desc" => SecurityMonitoringSignalsSort::TIMESTAMP_DESCENDING,
+        other => anyhow::bail!(
+            "invalid --sort value: {other:?}\nExpected: timestamp (ascending) or -timestamp (descending)"
+        ),
+    };
 
     let body = SecurityMonitoringSignalListRequest::new()
         .filter(
@@ -232,7 +241,7 @@ pub async fn signals_search(
                 .to(to_dt),
         )
         .page(SecurityMonitoringSignalListRequestPage::new().limit(limit))
-        .sort(SecurityMonitoringSignalsSort::TIMESTAMP_DESCENDING);
+        .sort(sort_val);
 
     let params = SearchSecurityMonitoringSignalsOptionalParams::default().body(body);
     let resp = api
@@ -1070,5 +1079,18 @@ mod tests {
         assert!(result.is_err(), "expected error for 404 response");
         cleanup_env();
         std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_signals_search_invalid_sort() {
+        let cfg = test_config("http://unused.local");
+        let result =
+            super::signals_search(&cfg, "*".into(), "1h".into(), "now".into(), 10, Some("invalid".into()))
+                .await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("invalid --sort value"));
     }
 }

--- a/src/commands/traces.rs
+++ b/src/commands/traces.rs
@@ -446,16 +446,38 @@ mod tests {
     #[tokio::test]
     async fn test_search_limit_too_small() {
         let cfg = test_config("http://unused.local");
-        let result = super::search(&cfg, "*".into(), "1h".into(), "now".into(), 0, "-timestamp".into()).await;
+        let result = super::search(
+            &cfg,
+            "*".into(),
+            "1h".into(),
+            "now".into(),
+            0,
+            "-timestamp".into(),
+        )
+        .await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("--limit must be between 1 and 1000"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("--limit must be between 1 and 1000"));
     }
 
     #[tokio::test]
     async fn test_search_limit_too_large() {
         let cfg = test_config("http://unused.local");
-        let result = super::search(&cfg, "*".into(), "1h".into(), "now".into(), 1001, "-timestamp".into()).await;
+        let result = super::search(
+            &cfg,
+            "*".into(),
+            "1h".into(),
+            "now".into(),
+            1001,
+            "-timestamp".into(),
+        )
+        .await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("--limit must be between 1 and 1000"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("--limit must be between 1 and 1000"));
     }
 }

--- a/src/commands/traces.rs
+++ b/src/commands/traces.rs
@@ -110,7 +110,10 @@ pub async fn search(
     let from_ms = util::parse_time_to_unix_millis(&from)?;
     let to_ms = util::parse_time_to_unix_millis(&to)?;
 
-    let page_limit = limit.min(1000);
+    if !(1..=1000).contains(&limit) {
+        anyhow::bail!("--limit must be between 1 and 1000, got {limit}");
+    }
+    let page_limit = limit;
     let spans_sort = match sort.as_str() {
         "timestamp" => SpansSort::TIMESTAMP_ASCENDING,
         _ => SpansSort::TIMESTAMP_DESCENDING,
@@ -438,5 +441,21 @@ mod tests {
         assert!(result.is_err(), "spans metrics list should fail on 403");
         cleanup_env();
         std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_search_limit_too_small() {
+        let cfg = test_config("http://unused.local");
+        let result = super::search(&cfg, "*".into(), "1h".into(), "now".into(), 0, "-timestamp".into()).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("--limit must be between 1 and 1000"));
+    }
+
+    #[tokio::test]
+    async fn test_search_limit_too_large() {
+        let cfg = test_config("http://unused.local");
+        let result = super::search(&cfg, "*".into(), "1h".into(), "now".into(), 1001, "-timestamp".into()).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("--limit must be between 1 and 1000"));
     }
 }

--- a/src/commands/workflows.rs
+++ b/src/commands/workflows.rs
@@ -168,8 +168,11 @@ pub async fn run(
 pub async fn instance_list(cfg: &Config, workflow_id: &str, limit: i64, page: i64) -> Result<()> {
     let api = make_api(cfg);
 
+    if !(1..=100).contains(&limit) {
+        anyhow::bail!("--limit must be between 1 and 100, got {limit}");
+    }
     let mut params = ListWorkflowInstancesOptionalParams::default();
-    params = params.page_size(limit.clamp(1, 100));
+    params = params.page_size(limit);
     if page > 0 {
         params = params.page_number(page);
     }
@@ -310,5 +313,27 @@ mod tests {
         );
         cleanup_env();
         std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_instance_list_limit_too_small() {
+        let cfg = test_config("http://unused.local");
+        let result = super::instance_list(&cfg, "wf-id", 0, 0).await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("--limit must be between 1 and 100"));
+    }
+
+    #[tokio::test]
+    async fn test_instance_list_limit_too_large() {
+        let cfg = test_config("http://unused.local");
+        let result = super::instance_list(&cfg, "wf-id", 101, 0).await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("--limit must be between 1 and 100"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2777,9 +2777,11 @@ enum MonitorActions {
         #[arg(
             long,
             default_value_t = 200,
-            help = "Maximum number of monitors to return (default: 200, max: 1000)"
+            help = "Maximum number of monitors to return (1-1000)"
         )]
         limit: i32,
+        #[arg(long, default_value_t = 0, help = "Page number (0-indexed)")]
+        page: i64,
     },
     /// Get monitor details
     Get { monitor_id: i64 },
@@ -4662,7 +4664,7 @@ enum SecuritySignalActions {
         to: String,
         #[arg(long, default_value_t = 100, help = "Maximum results (1-1000)")]
         limit: i32,
-        #[arg(long, help = "Sort field: severity, status, timestamp")]
+        #[arg(long, help = "Sort order: timestamp (ascending) or -timestamp (descending)")]
         sort: Option<String>,
     },
     /// Get log queries for investigating a signal
@@ -5916,7 +5918,7 @@ enum CicdEventActions {
         to: String,
         #[arg(long, default_value_t = 50, help = "Maximum results")]
         limit: i32,
-        #[arg(long, default_value = "desc", help = "Sort order (asc or desc)")]
+        #[arg(long, default_value = "desc", help = "Sort order: asc or desc")]
         sort: String,
     },
     /// Aggregate CI/CD events
@@ -6138,7 +6140,11 @@ enum OnCallMembershipActions {
         page_size: i64,
         #[arg(long, default_value_t = 0, help = "Page number")]
         page_number: i64,
-        #[arg(long, default_value = "name", help = "Sort order: name, email")]
+        #[arg(
+            long,
+            default_value = "name",
+            help = "Sort: name, -name, email, -email, handle, -handle, manager_name, -manager_name"
+        )]
         sort: String,
     },
     /// Add a member to team
@@ -10148,8 +10154,13 @@ async fn main_inner() -> anyhow::Result<()> {
         Commands::Monitors { action } => {
             cfg.validate_auth()?;
             match action {
-                MonitorActions::List { name, tags, limit } => {
-                    commands::monitors::list(&cfg, name, tags, limit).await?;
+                MonitorActions::List {
+                    name,
+                    tags,
+                    limit,
+                    page,
+                } => {
+                    commands::monitors::list(&cfg, name, tags, limit, page).await?;
                 }
                 MonitorActions::Get { monitor_id } => {
                     commands::monitors::get(&cfg, monitor_id).await?;
@@ -10160,8 +10171,13 @@ async fn main_inner() -> anyhow::Result<()> {
                 MonitorActions::Update { monitor_id, file } => {
                     commands::monitors::update(&cfg, monitor_id, &file).await?;
                 }
-                MonitorActions::Search { query, .. } => {
-                    commands::monitors::search(&cfg, query).await?;
+                MonitorActions::Search {
+                    query,
+                    page,
+                    per_page,
+                    sort,
+                } => {
+                    commands::monitors::search(&cfg, query, page, per_page, sort).await?;
                 }
                 MonitorActions::Delete { monitor_id } => {
                     commands::monitors::delete(&cfg, monitor_id).await?;
@@ -10540,8 +10556,12 @@ async fn main_inner() -> anyhow::Result<()> {
         Commands::Metrics { action } => {
             cfg.validate_auth()?;
             match action {
-                MetricActions::List { filter, from, .. } => {
-                    commands::metrics::list(&cfg, filter, from).await?;
+                MetricActions::List {
+                    filter,
+                    from,
+                    tag_filter,
+                } => {
+                    commands::metrics::list(&cfg, filter, from, tag_filter).await?;
                 }
                 MetricActions::Search { query, from, to } => {
                     commands::metrics::search(&cfg, query, from, to).await?;
@@ -11051,9 +11071,10 @@ async fn main_inner() -> anyhow::Result<()> {
                         from,
                         to,
                         limit,
-                        ..
+                        sort,
                     } => {
-                        commands::security::signals_search(&cfg, query, from, to, limit).await?;
+                        commands::security::signals_search(&cfg, query, from, to, limit, sort)
+                            .await?;
                     }
                     SecuritySignalActions::InvestigationQueries { signal_id } => {
                         commands::security::signals_investigation_queries(&cfg, &signal_id).await?;
@@ -11427,9 +11448,11 @@ async fn main_inner() -> anyhow::Result<()> {
             cfg.validate_auth()?;
             match action {
                 CaseActions::Search {
-                    query, page_size, ..
+                    query,
+                    page_size,
+                    page_number,
                 } => {
-                    commands::cases::search(&cfg, query, page_size).await?;
+                    commands::cases::search(&cfg, query, page_size, page_number).await?;
                 }
                 CaseActions::Get { case_id } => commands::cases::get(&cfg, &case_id).await?,
                 CaseActions::Create {
@@ -11857,9 +11880,19 @@ async fn main_inner() -> anyhow::Result<()> {
                         from,
                         to,
                         limit,
-                        ..
+                        branch,
+                        pipeline_name,
                     } => {
-                        commands::cicd::pipelines_list(&cfg, query, from, to, limit).await?;
+                        commands::cicd::pipelines_list(
+                            &cfg,
+                            query,
+                            from,
+                            to,
+                            limit,
+                            branch,
+                            pipeline_name,
+                        )
+                        .await?;
                     }
                     CicdPipelineActions::Get { pipeline_id } => {
                         commands::cicd::pipelines_get(&cfg, &pipeline_id).await?;
@@ -11894,9 +11927,9 @@ async fn main_inner() -> anyhow::Result<()> {
                         from,
                         to,
                         limit,
-                        ..
+                        sort,
                     } => {
-                        commands::cicd::events_search(&cfg, query, from, to, limit).await?;
+                        commands::cicd::events_search(&cfg, query, from, to, limit, sort).await?;
                     }
                     CicdEventActions::Aggregate {
                         query, from, to, ..
@@ -11952,9 +11985,19 @@ async fn main_inner() -> anyhow::Result<()> {
                     }
                     OnCallTeamActions::Memberships { action } => match action {
                         OnCallMembershipActions::List {
-                            team_id, page_size, ..
+                            team_id,
+                            page_size,
+                            page_number,
+                            sort,
                         } => {
-                            commands::on_call::memberships_list(&cfg, &team_id, page_size).await?;
+                            commands::on_call::memberships_list(
+                                &cfg,
+                                &team_id,
+                                page_size,
+                                page_number,
+                                sort,
+                            )
+                            .await?;
                         }
                         OnCallMembershipActions::Add {
                             team_id,
@@ -12312,12 +12355,16 @@ async fn main_inner() -> anyhow::Result<()> {
                     ErrorTrackingIssueActions::Search {
                         query,
                         limit,
+                        from,
+                        to,
+                        order_by,
                         track,
                         persona,
-                        ..
                     } => {
-                        commands::error_tracking::issues_search(&cfg, query, limit, track, persona)
-                            .await?;
+                        commands::error_tracking::issues_search(
+                            &cfg, query, limit, from, to, order_by, track, persona,
+                        )
+                        .await?;
                     }
                     ErrorTrackingIssueActions::Get { issue_id } => {
                         commands::error_tracking::issues_get(&cfg, &issue_id).await?;
@@ -13327,9 +13374,10 @@ async fn main_inner() -> anyhow::Result<()> {
                 InvestigationActions::List {
                     page_limit,
                     page_offset,
-                    ..
+                    monitor_id,
                 } => {
-                    commands::investigations::list(&cfg, page_limit, page_offset).await?;
+                    commands::investigations::list(&cfg, page_limit, page_offset, monitor_id)
+                        .await?;
                 }
                 InvestigationActions::Get { investigation_id } => {
                     commands::investigations::get(&cfg, &investigation_id).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4664,7 +4664,10 @@ enum SecuritySignalActions {
         to: String,
         #[arg(long, default_value_t = 100, help = "Maximum results (1-1000)")]
         limit: i32,
-        #[arg(long, help = "Sort order: timestamp (ascending) or -timestamp (descending)")]
+        #[arg(
+            long,
+            help = "Sort order: timestamp (ascending) or -timestamp (descending)"
+        )]
         sort: Option<String>,
     },
     /// Get log queries for investigating a signal


### PR DESCRIPTION
## Summary

Addresses all pagination and flag-wiring issues identified in the endpoint audit. Three categories of bugs were fixed: CLI flags that were silently dropped via `..` destructure patterns in `main.rs`, silent limit clamping that gave no user feedback, and `.unwrap()` calls on timestamp conversions that could panic on out-of-range values.

## Changes

### Silently dropped CLI flags wired through
- `src/commands/cases.rs` — `--page-number` → `SearchCasesOptionalParams`
- `src/commands/on_call.rs` — `--page-number`, `--sort` → `GetTeamMembershipsOptionalParams`
- `src/commands/security.rs` — `--sort` with `bail!` for invalid values (no silent fallback)
- `src/commands/cicd.rs` — `--branch`, `--pipeline-name` as quoted query filters; `--sort` with explicit `bail!`
- `src/commands/error_tracking.rs` — `--from`, `--to`, `--order-by`; renamed `_limit` → `limit`
- `src/commands/investigations.rs` — `--monitor-id` as `filter_monitor_id` when non-zero
- `src/commands/metrics.rs` — `--tag-filter` → `ListActiveMetricsOptionalParams`
- `src/commands/monitors.rs` — `--page` (list), `--page`/`--per-page`/`--sort` (search)

### Silent clamping → explicit `bail!`
- `src/commands/monitors.rs` — `clamp(1,1000)` replaced; out-of-range values now error
- `src/commands/traces.rs` — `limit.min(1000)` replaced with `!(1..=1000).contains` bail
- `src/commands/workflows.rs` — `limit.clamp(1,100)` replaced

### Panic risk removed
- `src/commands/cicd.rs` — `DateTime::from_timestamp_millis(...).unwrap()` → `ok_or_else`
- `src/commands/rum.rs` — same in `sessions_search` and `sessions_list`

### Additional fixes from code review
- `src/commands/on_call.rs` — sort/role validation moved before `resolve_team_id` (fail-fast); dead `_ => ADMIN` catch-all replaced with `bail!`; `parse_team_role` helper extracted; `unwrap_or_default` on `resp.data` → `ok_or_else`; case-insensitive handle comparison
- `src/commands/error_tracking.rs` — `println!` → `eprintln!` for empty-result message
- `src/commands/cicd.rs` — branch/pipeline-name values quoted in query string, internal quotes escaped
- `src/main.rs` — help text corrected for sort flags in security signals and on-call memberships

## Testing
- All existing tests pass (`cargo test`)
- Negative tests added for every new `bail!` path: invalid sort, invalid role, out-of-range limit
- Positive (happy-path) tests added for new parameters
- `cargo clippy -- -D warnings` passes clean

## Related Issues

Closes pagination audit findings from `pup-pagination/endpoint_audit.md`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)