### PR TITLE
fix(client): bypass serde_json's 128-level recursion limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+dependencies = [
+ "object",
+]
+
+[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2231,6 +2240,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2709,6 +2727,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
+]
+
+[[package]]
 name = "pup"
 version = "0.56.2"
 dependencies = [
@@ -2742,6 +2770,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "serde_norway",
+ "serde_stacker",
  "sha2 0.11.0",
  "ssh-key",
  "tokio",
@@ -3579,6 +3608,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_stacker"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4936375d50c4be7eff22293a9344f8e46f323ed2b3c243e52f89138d9bb0f4a"
+dependencies = [
+ "serde",
+ "serde_core",
+ "stacker",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3835,6 +3875,19 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stacker"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,8 @@ tokio = { version = "1", default-features = false }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
-serde_json = { version = "1", features = ["preserve_order"] }
+serde_json = { version = "1", features = ["preserve_order", "unbounded_depth"] }
+serde_stacker = "0.1"
 serde_norway = "0.9"
 
 # HTTP — stream feature omitted on wasm32 (wasm-streams pulls in wasm-bindgen,

--- a/src/client.rs
+++ b/src/client.rs
@@ -407,6 +407,19 @@ static UNSTABLE_OPS: &[&str] = &[
 
 use crate::useragent;
 
+// Parse a reqwest response body as JSON without serde_json's default 128-level
+// recursion cap. Some Datadog endpoints (e.g. /profiling/api/v1/aggregate)
+// return deeply-nested flame-graph trees that exceed it. serde_stacker grows
+// the thread stack on demand so disabling the limit can't blow it.
+async fn parse_response_json(resp: reqwest::Response) -> anyhow::Result<serde_json::Value> {
+    use serde::Deserialize;
+    let bytes = resp.bytes().await?;
+    let mut de = serde_json::Deserializer::from_slice(&bytes);
+    de.disable_recursion_limit();
+    let de = serde_stacker::Deserializer::new(&mut de);
+    Ok(serde_json::Value::deserialize(de)?)
+}
+
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AuthType {
@@ -806,7 +819,7 @@ pub async fn raw_get(
         let body = resp.text().await.unwrap_or_default();
         anyhow::bail!("GET {url} failed (HTTP {status}): {body}");
     }
-    Ok(resp.json().await?)
+    parse_response_json(resp).await
 }
 
 /// Makes an authenticated PATCH request directly via reqwest.
@@ -835,7 +848,7 @@ pub async fn raw_patch(
         let body = resp.text().await.unwrap_or_default();
         anyhow::bail!("PATCH {url} failed (HTTP {status}): {body}");
     }
-    Ok(resp.json().await?)
+    parse_response_json(resp).await
 }
 
 /// Makes an authenticated POST request directly via reqwest.
@@ -884,7 +897,7 @@ async fn raw_post_impl(
         let body = resp.text().await.unwrap_or_default();
         anyhow::bail!("POST {url} failed (HTTP {status}): {body}");
     }
-    Ok(resp.json().await?)
+    parse_response_json(resp).await
 }
 
 fn apply_auth(
@@ -949,7 +962,7 @@ pub async fn raw_post_jsonapi(
         let body = resp.text().await.unwrap_or_default();
         anyhow::bail!("POST {url} failed (HTTP {status}): {body}");
     }
-    Ok(resp.json().await?)
+    parse_response_json(resp).await
 }
 
 /// Like `raw_post`, but returns the parsed JSON body even on non-2xx responses.
@@ -980,7 +993,7 @@ pub async fn raw_post_lenient(
         .json(&body)
         .send()
         .await?;
-    Ok(resp.json().await?)
+    parse_response_json(resp).await
 }
 
 /// Makes an authenticated DELETE request directly via reqwest.


### PR DESCRIPTION
## Summary

`reqwest::Response::json()` uses `serde_json`'s default deserializer, which caps recursion depth at 128. Some Datadog endpoints — notably `/profiling/api/v1/aggregate` — return deeply-nested flame-graph trees that exceed this and fail with `recursion limit exceeded at line 1 column N`, leaving the response unusable. This patch routes every JSON-decoding call site through a shared helper that lifts the cap safely.

Reproducible from any non-trivial service:

```
$ pup profiling aggregate --query='service:<some-real-service>' --from=1h
Error: failed to aggregate profiles: error decoding response body

Caused by:
    recursion limit exceeded at line 1 column 96555
```

## Changes

- New `parse_response_json` helper in `src/client.rs:412` that:
  - Reads the response body as bytes.
  - Constructs a `serde_json::Deserializer` with `disable_recursion_limit()` (gated behind the new `unbounded_depth` feature on `serde_json`).
  - Wraps it in `serde_stacker::Deserializer`, which grows the thread stack on demand to prevent stack overflow on deeply-nested input.
- Replaced 5 `Ok(resp.json().await?)` call sites with `parse_response_json(resp).await`:
  - `raw_get` (`src/client.rs`)
  - `raw_post_impl` (`src/client.rs`)
  - `raw_patch` (`src/client.rs`)
  - `raw_post_jsonapi` (`src/client.rs`)
  - `raw_post_lenient` (`src/client.rs`)
- `Cargo.toml`:
  - `serde_json` features: added `unbounded_depth`.
  - New dep: `serde_stacker = "0.1"`.

## Why pair `disable_recursion_limit` with `serde_stacker`?

`disable_recursion_limit()` alone would risk stack overflow on deeply-nested input, since the only reason the cap exists is to catch this. `serde_stacker::Deserializer` checks remaining stack at each recursion and allocates a new stack chunk when low — the standard pattern documented in `serde_json`'s own README. Threat model here is trusted Datadog API responses over TLS, but the `serde_stacker` pairing makes this safe even for less-trusted inputs.

## Testing

- Verified against `pup profiling aggregate --query='service:<real-service> language:(go OR ebpf)' --from=14h` on a real production org. Before the fix: decode error. After the fix: 43 MB JSON parses cleanly.
- Confirmed the same error occurred on staging (datad0g.com), so it's a deserializer bug independent of org or data size.
- No existing tests required updates (the helper preserves the previous return type).

## Follow-up

A separate (draft) PR will add `--show-from <function_name>` to `pup profiling aggregate` to mirror the UI's `show_from(...)` flame-graph filter. It depends on this fix to be useful, since you can't filter what you can't decode.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)