### PR TITLE
feat(auth): print copy-paste hint when no local browser is available

### DIFF
--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -87,7 +87,15 @@ pub async fn login(cfg: &Config, scopes: Vec<String>, subdomain: Option<&str>) -
     // 5. Open browser
     eprintln!("\n🌐 Opening browser for authentication...");
     eprintln!("If the browser doesn't open, visit: {auth_url}");
-    let _ = open::that(&auth_url);
+    if open::that(&auth_url).is_err() {
+        eprintln!(
+            "\nNo local browser detected (remote/SSH session?). To complete login:\n  \
+             1. Open the URL above on a machine with a browser and authorize.\n  \
+             2. Your browser will redirect to {redirect_uri}?... and fail to load\n     \
+             (expected). Copy that full URL from the address bar.\n  \
+             3. Run on this machine:  curl '<paste copied URL>'"
+        );
+    }
 
     // 6. Wait for callback
     eprintln!("\n⏳ Waiting for authorization...");


### PR DESCRIPTION
## Summary

Until pup supports OAuth Device Code Flow, `pup auth login` cannot complete on a remote machine without a reachable browser (SSH dev machines, headless containers, etc.). The IdP redirects the user's laptop browser to `http://127.0.0.1:<port>/oauth/callback`. The laptop has nothing on that port, the user sees `ERR_EMPTY_RESPONSE`, and the remote-side listener never gets the code.

This PR detects the headless case and prints a 3-step hint that walks the user through manually relaying the redirect URL via `curl` on the remote machine.

Device Code Flow is the right long-term answer (cleaner UX, no copy-paste, no curl assumption) but requires IdP-side support and is a much larger effort.

## Changes

- `src/commands/auth.rs:87-99`: capture the `open::that(&auth_url)` return value (previously discarded with `let _ =`). On error, print a 3-step hint pointing at the callback URL.

The `open` crate's `that()` waits for the spawned opener (`open` on macOS, `xdg-open` on Linux) and returns `Err` on non-zero exit, which is the headless case. On a normal laptop with a working browser the call succeeds and the hint is suppressed.

## How users see it

Old (headless, hangs forever):
```
🌐 Opening browser for authentication...
If the browser doesn't open, visit: https://app.datadoghq.com/oauth2/v1/authorize?...

⏳ Waiting for authorization...
```

New (headless):
```
🌐 Opening browser for authentication...
If the browser doesn't open, visit: https://app.datadoghq.com/oauth2/v1/authorize?...

No local browser detected (remote/SSH session?). To complete login:
  1. Open the URL above on a machine with a browser and authorize.
  2. Your browser will redirect to http://127.0.0.1:8000/oauth/callback?... and fail to load
     (expected). Copy that full URL from the address bar.
  3. Run on this machine:  curl '<paste copied URL>'

⏳ Waiting for authorization...
```

On a machine with a working browser, output is unchanged.

## Testing

- `cargo fmt` clean.
- `cargo clippy --all-targets -- -D warnings` clean.
- `cargo test --bin pup -- auth::` — 46/46 auth tests pass.
- The change is print-only with no behavior beyond stderr output.