### PR TITLE
feat(auth): accept pasted callback URL as a fallback when no browser

### DIFF
--- a/src/auth/callback.rs
+++ b/src/auth/callback.rs
@@ -348,7 +348,10 @@ mod tests {
         // race against the HTTP listener. Verify by timing out.
         let fut = read_callback_url_from_reader(reader("garbage\nmore garbage\n"));
         let timed = tokio::time::timeout(std::time::Duration::from_millis(50), fut).await;
-        assert!(timed.is_err(), "expected pending (timeout), but future resolved");
+        assert!(
+            timed.is_err(),
+            "expected pending (timeout), but future resolved"
+        );
     }
 
     #[tokio::test]
@@ -356,7 +359,10 @@ mod tests {
         // Closed/empty stdin (ex: `cmd </dev/null`) must not short-circuit.
         let fut = read_callback_url_from_reader(reader(""));
         let timed = tokio::time::timeout(std::time::Duration::from_millis(50), fut).await;
-        assert!(timed.is_err(), "expected pending (timeout), but future resolved");
+        assert!(
+            timed.is_err(),
+            "expected pending (timeout), but future resolved"
+        );
     }
 
     #[tokio::test]

--- a/src/auth/callback.rs
+++ b/src/auth/callback.rs
@@ -223,6 +223,11 @@ pub async fn read_callback_url_from_stdin() -> Result<CallbackResult> {
 /// Read pasted callback URLs from `reader` until one parses, then return it.
 /// Errors are printed and the loop continues, so a typo doesn't end the
 /// login session: the HTTP listener may still fire.
+///
+/// On EOF without a valid URL the future stays pending forever rather than
+/// resolving to an error. This matters when the function is raced against
+/// the HTTP listener via `tokio::select!`: a closed or piped stdin must not
+/// short-circuit the HTTP branch.
 #[cfg(not(target_arch = "wasm32"))]
 async fn read_callback_url_from_reader<R: tokio::io::AsyncBufRead + Unpin>(
     reader: R,
@@ -238,7 +243,7 @@ async fn read_callback_url_from_reader<R: tokio::io::AsyncBufRead + Unpin>(
             Err(e) => eprintln!("⚠️  {e}. Paste the full callback URL again:"),
         }
     }
-    bail!("stdin closed before a valid callback URL was provided");
+    std::future::pending().await
 }
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
@@ -337,9 +342,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn read_callback_url_returns_error_on_eof_without_match() {
-        let r = read_callback_url_from_reader(reader("garbage\nmore garbage\n")).await;
-        assert!(r.is_err());
+    async fn read_callback_url_stays_pending_on_eof_without_match() {
+        // Reader closes after delivering only garbage. The future must NOT
+        // resolve to an error — that would let it short-circuit a `select!`
+        // race against the HTTP listener. Verify by timing out.
+        let fut = read_callback_url_from_reader(reader("garbage\nmore garbage\n"));
+        let timed = tokio::time::timeout(std::time::Duration::from_millis(50), fut).await;
+        assert!(timed.is_err(), "expected pending (timeout), but future resolved");
+    }
+
+    #[tokio::test]
+    async fn read_callback_url_stays_pending_on_immediate_eof() {
+        // Closed/empty stdin (ex: `cmd </dev/null`) must not short-circuit.
+        let fut = read_callback_url_from_reader(reader(""));
+        let timed = tokio::time::timeout(std::time::Duration::from_millis(50), fut).await;
+        assert!(timed.is_err(), "expected pending (timeout), but future resolved");
     }
 
     #[tokio::test]

--- a/src/auth/callback.rs
+++ b/src/auth/callback.rs
@@ -213,12 +213,22 @@ fn parse_callback_url(input: &str) -> Result<CallbackResult> {
 }
 
 /// Read pasted callback URLs from stdin until one parses, then return it.
+/// Thin wrapper around `read_callback_url_from_reader` so the loop logic
+/// stays unit-testable against a synthetic reader.
+#[cfg(not(target_arch = "wasm32"))]
+pub async fn read_callback_url_from_stdin() -> Result<CallbackResult> {
+    read_callback_url_from_reader(tokio::io::BufReader::new(tokio::io::stdin())).await
+}
+
+/// Read pasted callback URLs from `reader` until one parses, then return it.
 /// Errors are printed and the loop continues, so a typo doesn't end the
 /// login session: the HTTP listener may still fire.
 #[cfg(not(target_arch = "wasm32"))]
-pub async fn read_callback_url_from_stdin() -> Result<CallbackResult> {
+async fn read_callback_url_from_reader<R: tokio::io::AsyncBufRead + Unpin>(
+    reader: R,
+) -> Result<CallbackResult> {
     use tokio::io::AsyncBufReadExt;
-    let mut lines = tokio::io::BufReader::new(tokio::io::stdin()).lines();
+    let mut lines = reader.lines();
     while let Some(line) = lines.next_line().await? {
         if line.trim().is_empty() {
             continue;
@@ -284,5 +294,62 @@ mod tests {
             .unwrap();
         assert_eq!(r.code, "abc");
         assert_eq!(r.state, "xyz");
+    }
+
+    fn reader(input: &str) -> tokio::io::BufReader<&[u8]> {
+        tokio::io::BufReader::new(input.as_bytes())
+    }
+
+    #[tokio::test]
+    async fn read_callback_url_returns_first_valid_line() {
+        let r = read_callback_url_from_reader(reader(
+            "http://127.0.0.1:8000/oauth/callback?code=abc&state=xyz\n",
+        ))
+        .await
+        .unwrap();
+        assert_eq!(r.code, "abc");
+        assert_eq!(r.state, "xyz");
+    }
+
+    #[tokio::test]
+    async fn read_callback_url_skips_blank_lines() {
+        let r = read_callback_url_from_reader(reader(
+            "\n\n   \nhttp://127.0.0.1:8000/oauth/callback?code=abc&state=xyz\n",
+        ))
+        .await
+        .unwrap();
+        assert_eq!(r.code, "abc");
+    }
+
+    #[tokio::test]
+    async fn read_callback_url_loops_through_parse_errors_until_valid() {
+        // Garbage and a half-complete URL precede the valid one; the loop
+        // must keep going until a parse succeeds, not bail on first error.
+        let r = read_callback_url_from_reader(reader(
+            "not a url\n\
+             http://127.0.0.1:8000/oauth/callback?code=alpha\n\
+             http://127.0.0.1:8000/oauth/callback?code=beta&state=charlie\n",
+        ))
+        .await
+        .unwrap();
+        assert_eq!(r.code, "beta");
+        assert_eq!(r.state, "charlie");
+    }
+
+    #[tokio::test]
+    async fn read_callback_url_returns_error_on_eof_without_match() {
+        let r = read_callback_url_from_reader(reader("garbage\nmore garbage\n")).await;
+        assert!(r.is_err());
+    }
+
+    #[tokio::test]
+    async fn read_callback_url_passes_through_oauth_error_redirect() {
+        let r = read_callback_url_from_reader(reader(
+            "http://127.0.0.1:8000/oauth/callback?error=access_denied&error_description=denied\n",
+        ))
+        .await
+        .unwrap();
+        assert_eq!(r.error.as_deref(), Some("access_denied"));
+        assert_eq!(r.error_description.as_deref(), Some("denied"));
     }
 }

--- a/src/auth/callback.rs
+++ b/src/auth/callback.rs
@@ -181,3 +181,108 @@ h1{{color:#c00}}p{{color:#555}}</style></head>
 <p>Please close this window and try again.</p></div></body></html>"#
     )
 }
+
+/// Parse a pasted OAuth callback URL into a `CallbackResult`. Used as a
+/// fallback for users on remote machines where the laptop browser cannot
+/// reach the workspace's `127.0.0.1` listener.
+#[cfg(not(target_arch = "wasm32"))]
+fn parse_callback_url(input: &str) -> Result<CallbackResult> {
+    let url = url::Url::parse(input.trim()).map_err(|e| anyhow::anyhow!("not a valid URL: {e}"))?;
+    let mut code = None;
+    let mut state = None;
+    let mut error = None;
+    let mut error_description = None;
+    for (k, v) in url.query_pairs() {
+        match k.as_ref() {
+            "code" => code = Some(v.into_owned()),
+            "state" => state = Some(v.into_owned()),
+            "error" => error = Some(v.into_owned()),
+            "error_description" => error_description = Some(v.into_owned()),
+            _ => {}
+        }
+    }
+    if error.is_none() && (code.is_none() || state.is_none()) {
+        bail!("URL is missing 'code' and 'state' query parameters");
+    }
+    Ok(CallbackResult {
+        code: code.unwrap_or_default(),
+        state: state.unwrap_or_default(),
+        error,
+        error_description,
+    })
+}
+
+/// Read pasted callback URLs from stdin until one parses, then return it.
+/// Errors are printed and the loop continues, so a typo doesn't end the
+/// login session: the HTTP listener may still fire.
+#[cfg(not(target_arch = "wasm32"))]
+pub async fn read_callback_url_from_stdin() -> Result<CallbackResult> {
+    use tokio::io::AsyncBufReadExt;
+    let mut lines = tokio::io::BufReader::new(tokio::io::stdin()).lines();
+    while let Some(line) = lines.next_line().await? {
+        if line.trim().is_empty() {
+            continue;
+        }
+        match parse_callback_url(&line) {
+            Ok(result) => return Ok(result),
+            Err(e) => eprintln!("⚠️  {e}. Paste the full callback URL again:"),
+        }
+    }
+    bail!("stdin closed before a valid callback URL was provided");
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_callback_url_extracts_code_and_state() {
+        let r = parse_callback_url("http://127.0.0.1:8000/oauth/callback?code=abc123&state=xyz789")
+            .unwrap();
+        assert_eq!(r.code, "abc123");
+        assert_eq!(r.state, "xyz789");
+        assert!(r.error.is_none());
+        assert!(r.error_description.is_none());
+    }
+
+    #[test]
+    fn parse_callback_url_extracts_error() {
+        let r = parse_callback_url(
+            "http://127.0.0.1:8000/oauth/callback?error=access_denied&error_description=user%20cancelled",
+        )
+        .unwrap();
+        assert_eq!(r.error.as_deref(), Some("access_denied"));
+        assert_eq!(r.error_description.as_deref(), Some("user cancelled"));
+    }
+
+    #[test]
+    fn parse_callback_url_trims_whitespace() {
+        let r = parse_callback_url("  http://127.0.0.1:8000/oauth/callback?code=abc&state=xyz\n")
+            .unwrap();
+        assert_eq!(r.code, "abc");
+        assert_eq!(r.state, "xyz");
+    }
+
+    #[test]
+    fn parse_callback_url_rejects_missing_params() {
+        assert!(parse_callback_url("http://127.0.0.1:8000/oauth/callback").is_err());
+        assert!(parse_callback_url("http://127.0.0.1:8000/oauth/callback?code=abc").is_err());
+        assert!(parse_callback_url("http://127.0.0.1:8000/oauth/callback?state=xyz").is_err());
+    }
+
+    #[test]
+    fn parse_callback_url_rejects_garbage() {
+        assert!(parse_callback_url("not a url").is_err());
+        assert!(parse_callback_url("").is_err());
+    }
+
+    #[test]
+    fn parse_callback_url_accepts_any_host() {
+        // Tolerant of broker-style or non-localhost redirect URIs as long as
+        // the query carries the right params.
+        let r = parse_callback_url("https://oauth.example.com/cli/callback?code=abc&state=xyz")
+            .unwrap();
+        assert_eq!(r.code, "abc");
+        assert_eq!(r.state, "xyz");
+    }
+}

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -99,18 +99,25 @@ pub async fn login(cfg: &Config, scopes: Vec<String>, subdomain: Option<&str>) -
         );
     }
 
-    // 6. Wait for callback. Race the HTTP listener against a stdin paste path
-    // so users with no reachable browser can manually relay the redirect URL.
-    // tokio::select! cancels the loser.
+    // 6. Wait for callback. The happy path waits on the HTTP listener only,
+    // exactly as before this change. When the browser failed to open, also
+    // race a stdin paste path so users on remote machines can manually relay
+    // the redirect URL. The stdin path is only enabled in the headless branch
+    // so legitimate non-interactive launches (closed stdin, piped /dev/null)
+    // can't short-circuit a working browser flow.
     eprintln!("\n⏳ Waiting for authorization...");
-    if !browser_opened {
+    let result = if browser_opened {
+        server
+            .wait_for_callback(std::time::Duration::from_secs(300))
+            .await?
+    } else {
         use std::io::Write;
         eprint!("> ");
         let _ = std::io::stderr().flush();
-    }
-    let result = tokio::select! {
-        r = server.wait_for_callback(std::time::Duration::from_secs(300)) => r?,
-        r = crate::auth::callback::read_callback_url_from_stdin() => r?,
+        tokio::select! {
+            r = server.wait_for_callback(std::time::Duration::from_secs(300)) => r?,
+            r = crate::auth::callback::read_callback_url_from_stdin() => r?,
+        }
     };
 
     if let Some(err) = &result.error {

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -94,7 +94,8 @@ pub async fn login(cfg: &Config, scopes: Vec<String>, subdomain: Option<&str>) -
              1. Open the URL above on a machine with a browser and authorize.\n  \
              2. Your browser will redirect to {redirect_uri}?... and fail to load\n     \
              (expected). Copy that full URL from the address bar.\n  \
-             3. Paste it below, then press Enter."
+             3. Paste it below, then press Enter.\n     \
+             Example: {redirect_uri}?code=...&state=..."
         );
     }
 
@@ -102,6 +103,11 @@ pub async fn login(cfg: &Config, scopes: Vec<String>, subdomain: Option<&str>) -
     // so users with no reachable browser can manually relay the redirect URL.
     // tokio::select! cancels the loser.
     eprintln!("\n⏳ Waiting for authorization...");
+    if !browser_opened {
+        use std::io::Write;
+        eprint!("> ");
+        let _ = std::io::stderr().flush();
+    }
     let result = tokio::select! {
         r = server.wait_for_callback(std::time::Duration::from_secs(300)) => r?,
         r = crate::auth::callback::read_callback_url_from_stdin() => r?,

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -87,13 +87,25 @@ pub async fn login(cfg: &Config, scopes: Vec<String>, subdomain: Option<&str>) -
     // 5. Open browser
     eprintln!("\n🌐 Opening browser for authentication...");
     eprintln!("If the browser doesn't open, visit: {auth_url}");
-    let _ = open::that(&auth_url);
+    let browser_opened = open::that(&auth_url).is_ok();
+    if !browser_opened {
+        eprintln!(
+            "\nNo local browser detected (remote/SSH session?). To complete login:\n  \
+             1. Open the URL above on a machine with a browser and authorize.\n  \
+             2. Your browser will redirect to {redirect_uri}?... and fail to load\n     \
+             (expected). Copy that full URL from the address bar.\n  \
+             3. Paste it below, then press Enter."
+        );
+    }
 
-    // 6. Wait for callback
+    // 6. Wait for callback. Race the HTTP listener against a stdin paste path
+    // so users with no reachable browser can manually relay the redirect URL.
+    // tokio::select! cancels the loser.
     eprintln!("\n⏳ Waiting for authorization...");
-    let result = server
-        .wait_for_callback(std::time::Duration::from_secs(300))
-        .await?;
+    let result = tokio::select! {
+        r = server.wait_for_callback(std::time::Duration::from_secs(300)) => r?,
+        r = crate::auth::callback::read_callback_url_from_stdin() => r?,
+    };
 
     if let Some(err) = &result.error {
         let desc = result.error_description.as_deref().unwrap_or("");


### PR DESCRIPTION
## Summary

`pup auth login` hangs on remote machines without a reachable browser (SSH dev hosts, headless containers): the IdP redirects the user's laptop browser to `http://127.0.0.1:<port>/oauth/callback`, the laptop has nothing on that port, and the remote-side listener never receives the code.

When `open::that()` fails, pup now prompts the user to paste the failing redirect URL from their browser's address bar. The HTTP listener and stdin reader race via `tokio::select!`, gated to the headless path so non-interactive launches with closed or piped stdin can't regress the working browser flow. On EOF without a valid URL the stdin future stays pending instead of resolving early. Works on every OS that supports stdin, with no curl, wget, or other shell tool required.

## Changes

- `src/auth/callback.rs`: `parse_callback_url` extracts `code`/`state`/`error` from a pasted URL. `read_callback_url_from_stdin` delegates to a generic `read_callback_url_from_reader<R: AsyncBufRead + Unpin>` so the loop is unit-testable against a synthetic reader.
- `src/commands/auth.rs`: capture `open::that(&auth_url).is_ok()`; on failure print a 3-step paste prompt with an example callback URL and a `> ` input cue; race the HTTP listener and stdin reader via `tokio::select!` only in the headless branch.

## Behavior

Headless path:
```
🌐 Opening browser for authentication...
If the browser doesn't open, visit: https://app.datadoghq.com/oauth2/v1/authorize?...

No local browser detected (remote/SSH session?). To complete login:
  1. Open the URL above on a machine with a browser and authorize.
  2. Your browser will redirect to http://127.0.0.1:8000/oauth/callback?... and fail to load
     (expected). Copy that full URL from the address bar.
  3. Paste it below, then press Enter.
     Example: http://127.0.0.1:8000/oauth/callback?code=...&state=...

⏳ Waiting for authorization...
> http://127.0.0.1:8000/oauth/callback?code=ABC&state=XYZ
🔄 Exchanging authorization code for tokens...
✅ Login successful!
```

Happy path output is unchanged.

## Testing

- `cargo fmt` and `cargo clippy --all-targets -- -D warnings` clean.
- `cargo test --bin pup -- auth:: callback::` passes 58 tests. 11 new in callback.rs cover `parse_callback_url` and the EOF-stays-pending behavior of `read_callback_url_from_reader`.
- Live E2E on a Linux SSH host validates the headless prompt, stdin paste, code-for-token exchange, and a follow-up live API call.


---

Jira: https://datadoghq.atlassian.net/browse/DAL-671
