### PR TITLE
feat(audit-logs): add `audit` as visible alias for audit-logs command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -432,17 +432,20 @@ enum Commands {
     ///
     /// EXAMPLES:
     ///   # List recent audit logs
-    ///   pup audit-logs list
+    ///   pup audit list
     ///
     ///   # Search for specific user actions
-    ///   pup audit-logs search --query="@usr.name:admin@example.com"
+    ///   pup audit search --query="@usr.email:admin@example.com"
     ///
-    ///   # Search for failed actions
-    ///   pup audit-logs search --query="@evt.outcome:error"
+    ///   # Who deleted resources in the last 24h
+    ///   pup audit search --query="@action:deleted" --from=24h
+    ///
+    ///   # Investigate a specific API key
+    ///   pup audit search --query="@metadata.api_key.id:KEY_ID" --from=90d
     ///
     /// AUTHENTICATION:
-    ///   Requires either OAuth2 authentication or API keys.
-    #[command(name = "audit-logs", verbatim_doc_comment)]
+    ///   Requires either OAuth2 authentication or API keys with audit_logs_read scope.
+    #[command(name = "audit-logs", visible_alias = "audit", verbatim_doc_comment)]
     AuditLogs {
         #[command(subcommand)]
         action: AuditLogActions,

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -306,7 +306,12 @@ fn test_audit_alias_search_parses() {
 
     match cli.command {
         crate::Commands::AuditLogs { action } => match action {
-            crate::AuditLogActions::Search { query, from, to, limit } => {
+            crate::AuditLogActions::Search {
+                query,
+                from,
+                to,
+                limit,
+            } => {
                 assert_eq!(query, "@action:deleted");
                 assert_eq!(from, "24h");
                 assert_eq!(to, "now");
@@ -383,7 +388,12 @@ fn test_audit_search_all_flags() {
 
     match cli.command {
         crate::Commands::AuditLogs { action } => match action {
-            crate::AuditLogActions::Search { query, from, to, limit } => {
+            crate::AuditLogActions::Search {
+                query,
+                from,
+                to,
+                limit,
+            } => {
                 assert_eq!(query, "@metadata.api_key.id:KEY123");
                 assert_eq!(from, "90d");
                 assert_eq!(to, "2026-01-01T00:00:00Z");

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -284,3 +284,132 @@ fn test_symdb_view_display() {
         "probe-locations"
     );
 }
+
+// -------------------------------------------------------------------------
+// Audit logs alias: `pup audit` == `pup audit-logs`
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_audit_alias_search_parses() {
+    use clap::Parser;
+
+    let cli = crate::Cli::try_parse_from([
+        "pup",
+        "audit",
+        "search",
+        "--query",
+        "@action:deleted",
+        "--from",
+        "24h",
+    ])
+    .expect("pup audit search should parse via alias");
+
+    match cli.command {
+        crate::Commands::AuditLogs { action } => match action {
+            crate::AuditLogActions::Search { query, from, to, limit } => {
+                assert_eq!(query, "@action:deleted");
+                assert_eq!(from, "24h");
+                assert_eq!(to, "now");
+                assert_eq!(limit, 100);
+            }
+            _ => panic!("expected AuditLogActions::Search"),
+        },
+        _ => panic!("expected Commands::AuditLogs"),
+    }
+}
+
+#[test]
+fn test_audit_alias_list_parses() {
+    use clap::Parser;
+
+    let cli = crate::Cli::try_parse_from(["pup", "audit", "list", "--from", "6h", "--limit", "50"])
+        .expect("pup audit list should parse via alias");
+
+    match cli.command {
+        crate::Commands::AuditLogs { action } => match action {
+            crate::AuditLogActions::List { from, to, limit } => {
+                assert_eq!(from, "6h");
+                assert_eq!(to, "now");
+                assert_eq!(limit, 50);
+            }
+            _ => panic!("expected AuditLogActions::List"),
+        },
+        _ => panic!("expected Commands::AuditLogs"),
+    }
+}
+
+#[test]
+fn test_audit_canonical_name_still_parses() {
+    use clap::Parser;
+
+    let cli = crate::Cli::try_parse_from([
+        "pup",
+        "audit-logs",
+        "search",
+        "--query",
+        "@usr.email:admin@example.com",
+    ])
+    .expect("pup audit-logs search should still parse");
+
+    match cli.command {
+        crate::Commands::AuditLogs { action } => match action {
+            crate::AuditLogActions::Search { query, .. } => {
+                assert_eq!(query, "@usr.email:admin@example.com");
+            }
+            _ => panic!("expected AuditLogActions::Search"),
+        },
+        _ => panic!("expected Commands::AuditLogs"),
+    }
+}
+
+#[test]
+fn test_audit_search_all_flags() {
+    use clap::Parser;
+
+    let cli = crate::Cli::try_parse_from([
+        "pup",
+        "audit",
+        "search",
+        "--query",
+        "@metadata.api_key.id:KEY123",
+        "--from",
+        "90d",
+        "--to",
+        "2026-01-01T00:00:00Z",
+        "--limit",
+        "200",
+    ])
+    .expect("pup audit search with all flags should parse");
+
+    match cli.command {
+        crate::Commands::AuditLogs { action } => match action {
+            crate::AuditLogActions::Search { query, from, to, limit } => {
+                assert_eq!(query, "@metadata.api_key.id:KEY123");
+                assert_eq!(from, "90d");
+                assert_eq!(to, "2026-01-01T00:00:00Z");
+                assert_eq!(limit, 200);
+            }
+            _ => panic!("expected AuditLogActions::Search"),
+        },
+        _ => panic!("expected Commands::AuditLogs"),
+    }
+}
+
+#[test]
+fn test_audit_alias_is_visible() {
+    use clap::CommandFactory;
+
+    let app = crate::Cli::command();
+    // find_subcommand searches both canonical names and aliases
+    let found = app.find_subcommand("audit");
+    assert!(
+        found.is_some(),
+        "`audit` should be findable as a visible alias of audit-logs"
+    );
+    // confirm it resolves to the audit-logs command, not a different one
+    assert_eq!(
+        found.unwrap().get_name(),
+        "audit-logs",
+        "`audit` alias should resolve to the audit-logs command"
+    );
+}


### PR DESCRIPTION
## Summary

Adds `audit` as a visible alias for the `audit-logs` command so that `pup audit search` and `pup audit list` work as shorthands. Both forms remain supported — existing scripts using `audit-logs` are unaffected.

## Changes

- `src/main.rs`: `visible_alias = "audit"` on `AuditLogs` command; updated `--help` examples with representative audit queries; fixed `@usr.name` → `@usr.email`
- `src/test_commands.rs`: 5 Clap parse tests covering alias routing, default values, all flags, canonical name backwards-compatibility, and alias visibility

## Testing

```
cargo test test_audit
```

All 6 tests pass (5 new + 1 existing `test_audit_logs_list`).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)