### PR TITLE
chore(ci): drop Zig from release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,6 @@ jobs:
   cross-compile-linux:
     name: Cross Compile (Linux)
     runs-on: ubuntu-latest
-    # CI builds link against the runner's glibc; release artifacts still use
-    # cargo-zigbuild in release.yml for proper glibc-version pinning.
     env:
       CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
       CC_aarch64_unknown_linux_gnu: aarch64-linux-gnu-gcc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,29 +17,20 @@ jobs:
   build-linux:
     name: Build Linux
     runs-on: ubuntu-latest
+    env:
+      CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+      CC_aarch64_unknown_linux_gnu: aarch64-linux-gnu-gcc
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Fetch all tags
         run: git fetch --force --tags
-      - name: Cache Zig
-        id: cache-zig
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ${{ github.workspace }}/zig-linux-x86_64-0.13.0
-          key: zig-0.13.0-linux-x86_64
-      - name: Download Zig
-        if: steps.cache-zig.outputs.cache-hit != 'true'
-        run: |
-          ZIG_VERSION="0.13.0"
-          curl -sL "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-x86_64-${ZIG_VERSION}.tar.xz" | tar xJ
-      - name: Add Zig to PATH
-        run: echo "${{ github.workspace }}/zig-linux-x86_64-0.13.0" >> "$GITHUB_PATH"
       - name: Install Rust
         run: |
           rustup toolchain install stable --profile minimal
           rustup default stable
+          rustup target add aarch64-unknown-linux-gnu
       - name: Cache Rust dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -51,8 +42,13 @@ jobs:
           key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-release-
-      - name: Install build tools
-        run: cargo install cargo-zigbuild
+      - name: Install aarch64 cross toolchain
+        run: |
+          for i in 1 2 3; do
+            sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu && exit 0
+            sleep 5
+          done
+          exit 1
       - name: Install syft
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
       - uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1

--- a/.goreleaser-linux.yaml
+++ b/.goreleaser-linux.yaml
@@ -18,6 +18,7 @@ builds:
   - id: linux
     builder: rust
     binary: pup
+    command: build
     targets:
       - x86_64-unknown-linux-gnu
       - aarch64-unknown-linux-gnu


### PR DESCRIPTION
## Summary
- Drops Zig / cargo-zigbuild from the Linux release build, mirroring the same change made to CI in #471 (commit 9649065). The recurring `xz: Unexpected end of input` flake from ziglang.org's CDN was breaking PR builds; leaving it in the release path means the same flake can break tag-driven releases.
- Trade-off: Linux release artifacts now link against the GitHub runner's glibc (Ubuntu 24.04's 2.39) rather than a Zig-pinned older glibc. Deliberate operational choice — pinning was nice-to-have, but not worth the CDN flake.

## Changes
- `.github/workflows/release.yml` — `build-linux` now uses apt-installed `gcc-aarch64-linux-gnu` (with 3-attempt retry), `rustup target add aarch64-unknown-linux-gnu`, and job-level `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER` / `CC_aarch64_unknown_linux_gnu` so openssl-sys picks up the cross compiler. Removes the Zig cache, Zig download, Zig PATH, and `cargo install cargo-zigbuild` steps.
- `.goreleaser-linux.yaml:21` — adds `command: build` so goreleaser's rust builder shells out to `cargo build` instead of its default `cargo zigbuild` (same pattern as `.goreleaser-macos.yaml`).
- `.github/workflows/ci.yml` — removes the now-stale comment that pointed at `release.yml` as the place where cargo-zigbuild was still in use.

## Testing
- Validated by symmetry with the existing CI job (`cross-compile-linux` in `ci.yml`), which has been running this exact env-var + apt-toolchain pattern successfully since #471.
- The `command: build` key has been the production path in `.goreleaser-macos.yaml` since v0.56.x.
- Real verification will land on the next tagged release; consider a manual `workflow_dispatch` dry-run before tagging if extra confidence is wanted.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)