### PR TITLE
chore: Migrate pup from datadog-labs to datadog org

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,7 +6,7 @@
     "name": "Datadog",
     "email": "support@datadoghq.com"
   },
-  "repository": "https://github.com/datadog/pup",
+  "repository": "https://github.com/DataDog/pup",
   "license": "Apache-2.0",
   "keywords": ["datadog", "monitoring", "logs", "apm", "metrics", "security", "infrastructure"]
 }

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,3 @@
 
 # Global owners - update with actual maintainer GitHub usernames
 * @DataDog/web-frameworks
-
-# Authentication and security-critical code
-/pkg/auth/ @DataDog/team-aaa
-/cmd/auth.go @DataDog/team-aaa

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,8 +4,8 @@
 # review when someone opens a pull request.
 
 # Global owners - update with actual maintainer GitHub usernames
-* @datadog/web-frameworks
+* @DataDog/web-frameworks
 
 # Authentication and security-critical code
-/pkg/auth/ @datadog/team-aaa
-/cmd/auth.go @datadog/team-aaa
+/pkg/auth/ @DataDog/team-aaa
+/cmd/auth.go @DataDog/team-aaa

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,8 +4,8 @@
 # review when someone opens a pull request.
 
 # Global owners - update with actual maintainer GitHub usernames
-* @datadog-labs/api-platform
+* @datadog/web-frameworks
 
 # Authentication and security-critical code
-/pkg/auth/ @datadog-labs/team-aaa
-/cmd/auth.go @datadog-labs/team-aaa
+/pkg/auth/ @datadog/team-aaa
+/cmd/auth.go @datadog/team-aaa

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,19 +285,19 @@ jobs:
 
           \`\`\`bash
           # macOS (Apple Silicon)
-          curl -L https://github.com/datadog/pup/releases/download/${TAG}/pup_${VERSION}_Darwin_arm64.tar.gz | tar xz
+          curl -L https://github.com/DataDog/pup/releases/download/${TAG}/pup_${VERSION}_Darwin_arm64.tar.gz | tar xz
 
           # macOS (Intel)
-          curl -L https://github.com/datadog/pup/releases/download/${TAG}/pup_${VERSION}_Darwin_x86_64.tar.gz | tar xz
+          curl -L https://github.com/DataDog/pup/releases/download/${TAG}/pup_${VERSION}_Darwin_x86_64.tar.gz | tar xz
 
           # Linux (x86_64)
-          curl -L https://github.com/datadog/pup/releases/download/${TAG}/pup_${VERSION}_Linux_x86_64.tar.gz | tar xz
+          curl -L https://github.com/DataDog/pup/releases/download/${TAG}/pup_${VERSION}_Linux_x86_64.tar.gz | tar xz
 
           # Linux (arm64)
-          curl -L https://github.com/datadog/pup/releases/download/${TAG}/pup_${VERSION}_Linux_arm64.tar.gz | tar xz
+          curl -L https://github.com/DataDog/pup/releases/download/${TAG}/pup_${VERSION}_Linux_arm64.tar.gz | tar xz
 
           # Windows (x86_64)
-          curl -L https://github.com/datadog/pup/releases/download/${TAG}/pup_${VERSION}_Windows_x86_64.zip -o pup.zip
+          curl -L https://github.com/DataDog/pup/releases/download/${TAG}/pup_${VERSION}_Windows_x86_64.zip -o pup.zip
           tar -xf pup.zip
           \`\`\`
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -131,19 +131,19 @@ release:
 
     ```bash
     # macOS (Apple Silicon)
-    curl -L https://github.com/datadog/pup/releases/download/{{ .Tag }}/pup_{{ .Version }}_Darwin_arm64.tar.gz | tar xz
+    curl -L https://github.com/DataDog/pup/releases/download/{{ .Tag }}/pup_{{ .Version }}_Darwin_arm64.tar.gz | tar xz
 
     # macOS (Intel)
-    curl -L https://github.com/datadog/pup/releases/download/{{ .Tag }}/pup_{{ .Version }}_Darwin_x86_64.tar.gz | tar xz
+    curl -L https://github.com/DataDog/pup/releases/download/{{ .Tag }}/pup_{{ .Version }}_Darwin_x86_64.tar.gz | tar xz
 
     # Linux (x86_64)
-    curl -L https://github.com/datadog/pup/releases/download/{{ .Tag }}/pup_{{ .Version }}_Linux_x86_64.tar.gz | tar xz
+    curl -L https://github.com/DataDog/pup/releases/download/{{ .Tag }}/pup_{{ .Version }}_Linux_x86_64.tar.gz | tar xz
 
     # Linux (arm64)
-    curl -L https://github.com/datadog/pup/releases/download/{{ .Tag }}/pup_{{ .Version }}_Linux_arm64.tar.gz | tar xz
+    curl -L https://github.com/DataDog/pup/releases/download/{{ .Tag }}/pup_{{ .Version }}_Linux_arm64.tar.gz | tar xz
 
     # Windows (x86_64)
-    curl -L https://github.com/datadog/pup/releases/download/{{ .Tag }}/pup_{{ .Version }}_Windows_x86_64.zip -o pup.zip
+    curl -L https://github.com/DataDog/pup/releases/download/{{ .Tag }}/pup_{{ .Version }}_Windows_x86_64.zip -o pup.zip
     tar -xf pup.zip
     ```
 
@@ -165,4 +165,4 @@ release:
     ```
 
   footer: |
-    **Full Changelog**: https://github.com/datadog/pup/compare/{{ .PreviousTag }}...{{ .Tag }}
+    **Full Changelog**: https://github.com/DataDog/pup/compare/{{ .PreviousTag }}...{{ .Tag }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
 # Changelog
 
-See the [GitHub Releases](https://github.com/datadog/pup/releases) page for
+See the [GitHub Releases](https://github.com/DataDog/pup/releases) page for
 the authoritative list of changes per release.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ brew tap datadog-labs/pack
 brew install pup
 
 # Or clone and build from source
-git clone https://github.com/datadog/pup.git && cd pup
+git clone https://github.com/DataDog/pup.git && cd pup
 cargo build --release
 cp target/release/pup /usr/local/bin/pup
 
@@ -213,5 +213,5 @@ Apache 2.0 - Copyright 2024-present Datadog, Inc.
 
 ## Support
 
-- Issues: [GitHub Issues](https://github.com/datadog/pup/issues)
+- Issues: [GitHub Issues](https://github.com/DataDog/pup/issues)
 - Community: [Datadog Community](https://community.datadoghq.com/)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **NOTICE: This is in Preview mode, we are fine tuning the interactions and bugs that arise. Please file issues or submit PRs. Thank you for your early interest!**
 
-[![CI](https://github.com/datadog/pup/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/datadog/pup/actions/workflows/ci.yml)
+[![CI](https://github.com/DataDog/pup/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/DataDog/pup/actions/workflows/ci.yml)
 [![Rust](https://img.shields.io/badge/rust-stable-orange?logo=rust)](https://www.rust-lang.org/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
@@ -44,7 +44,7 @@ Pup covers most major Datadog product surfaces. See
 `pup --help` (or `pup agent schema` for machine-readable output) for the live
 list of commands as built.
 
-💡 **Tip:** Use Ctrl/Cmd+F to search for specific APIs. [Request features via GitHub Issues](https://github.com/datadog/pup/issues).
+💡 **Tip:** Use Ctrl/Cmd+F to search for specific APIs. [Request features via GitHub Issues](https://github.com/DataDog/pup/issues).
 
 ---
 
@@ -202,14 +202,14 @@ brew install datadog-labs/pack/pup
 ### Build from Source
 
 ```bash
-git clone https://github.com/datadog/pup.git && cd pup
+git clone https://github.com/DataDog/pup.git && cd pup
 cargo build --release
 cp target/release/pup /usr/local/bin/pup
 ```
 
 ### Manual Download
 
-Download pre-built binaries from the [latest release](https://github.com/datadog/pup/releases/latest).
+Download pre-built binaries from the [latest release](https://github.com/DataDog/pup/releases/latest).
 
 ## Authentication
 
@@ -522,7 +522,7 @@ For Claude Code, skills install to `.claude/skills/` and agents install to `.cla
 Pup is also available as a **Claude Code plugin marketplace**:
 
 ```
-/plugin marketplace add datadog/pup
+/plugin marketplace add DataDog/pup
 ```
 
 ## ACP Server

--- a/SKILL.md
+++ b/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   author:
     name: Datadog
     email: support@datadoghq.com
-  repository: https://github.com/datadog/pup
+  repository: https://github.com/DataDog/pup
   tags: datadog,cli,monitoring,logs,apm,metrics,security,infrastructure
 ---
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Guidelines for contributing to Pup.
 
 Pup uses the **fork and pull** model: contributors push changes to their
 personal fork and open pull requests to bring those changes into this
-repository. Direct pushes to `datadog/pup` are not permitted.
+repository. Direct pushes to `DataDog/pup` are not permitted.
 
 ### 1. Fork and clone
 
@@ -16,7 +16,7 @@ git clone https://github.com/<your-username>/pup.git
 cd pup
 
 # Add upstream remote and disable accidental pushes to it
-git remote add upstream https://github.com/datadog/pup.git
+git remote add upstream https://github.com/DataDog/pup.git
 git remote set-url --push upstream no_push
 ```
 
@@ -224,7 +224,7 @@ EOF
 
 ### 4. Push and open a pull request
 
-Push to your fork, then open a PR against `datadog/pup:main`:
+Push to your fork, then open a PR against `DataDog/pup:main`:
 
 ```bash
 git push -u origin <type>/<short-description>
@@ -234,7 +234,7 @@ Use `gh` CLI for efficiency:
 
 ```bash
 gh pr create \
-  --repo datadog/pup \
+  --repo DataDog/pup \
   --head <your-username>:<branch-name> \
   --title "<type>(<scope>): <clear, concise title>" \
   --body "$(cat <<'EOF'
@@ -278,7 +278,7 @@ EOF
 **Example PR:**
 ```bash
 gh pr create \
-  --repo datadog/pup \
+  --repo DataDog/pup \
   --head your-username:feat/oauth2-token-refresh \
   --title "feat(auth): implement OAuth2 token refresh with PKCE" \
   --body "$(cat <<'EOF'

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -510,7 +510,7 @@ When opening a GitHub issue, include:
 
 ### Community Support
 
-- **GitHub Issues:** [github.com/datadog/pup/issues](https://github.com/datadog/pup/issues)
+- **GitHub Issues:** [github.com/DataDog/pup/issues](https://github.com/DataDog/pup/issues)
 - **Datadog Community:** [community.datadoghq.com](https://community.datadoghq.com/)
 
 ## Common Workarounds

--- a/skills/dd-logs/SKILL.md
+++ b/skills/dd-logs/SKILL.md
@@ -19,7 +19,7 @@ Search, process, and archive logs with cost awareness.
 Datadog Pup (dd-pup/pup) should already be installed:
 
 ```bash
-go install github.com/datadog/pup@latest
+cargo install --git https://github.com/DataDog/pup
 ```
 
 ## Quick Start

--- a/skills/dd-monitors/SKILL.md
+++ b/skills/dd-monitors/SKILL.md
@@ -16,10 +16,9 @@ Create, manage, and maintain monitors for alerting.
 
 
 ## Prerequisites
-This requires Go or the pup binary in your path. 
+This requires the pup binary in your path.
 
-`pup` - `go install github.com/datadog/pup@latest`
-Ensure `~/go/bin` is in `$PATH`.
+`pup` - `cargo install --git https://github.com/DataDog/pup`
 
 
 ## Quick Start

--- a/skills/dd-pup/SKILL.md
+++ b/skills/dd-pup/SKILL.md
@@ -304,7 +304,7 @@ brew tap datadog-labs/pack
 brew install pup
 
 # Or build from source
-cargo install --git https://github.com/datadog/pup
+cargo install --git https://github.com/DataDog/pup
 ```
 
 ### Verify Installation


### PR DESCRIPTION
- Update CODEOWNERS team handles to the DataDog org
- Normalize repo URL/identifier casing to DataDog/pup
- Replace stale `go install` lines in dd-logs/dd-monitors skills with cargo install (pup is a Rust project)

## What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

## Motivation

<!-- What inspired you to submit this pull request? -->

## Additional Notes

<!-- Anything else we should know when reviewing? -->

## Checklist

- [ ] The code change follows the project conventions (see [CONTRIBUTING.md](../docs/CONTRIBUTING.md))
- [ ] Tests have been added/updated (if applicable)
- [ ] Documentation has been updated (if applicable)
- [ ] All CI checks pass
- [ ] Code coverage is maintained or improved

## Related Issues

<!-- Link related issues here. Use "Closes #123" to automatically close issues when the PR is merged. -->
