### PR TITLE
chore(docs): remove Preview notice from README ahead of GA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # :dog2: Give Your Agent a Puppy: Introducing Pup CLI
 
-**NOTICE: This is in Preview mode, we are fine tuning the interactions and bugs that arise. Please file issues or submit PRs. Thank you for your early interest!**
-
 [![CI](https://github.com/datadog/pup/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/datadog/pup/actions/workflows/ci.yml)
 [![Rust](https://img.shields.io/badge/rust-stable-orange?logo=rust)](https://www.rust-lang.org/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)


### PR DESCRIPTION
## Summary
Remove the top-of-README Preview banner stating pup is in Preview mode. Pup is going GA.

## Changes
- `README.md` — remove Preview notice banner (line 3)
- Collapse blank line so title flows directly to badges

## Out of Scope (deferred)
- `Cargo.toml` / `Cargo.lock` version bump to `1.0.0` — deferred for coordinated release
- Upstream API preview annotations in `agents/*.md` retained; they describe upstream API maturity, not pup

## Testing
- `cargo fmt --check` ✓
- `cargo clippy -- -D warnings` ✓
- `cargo test` — 1063 passed; 5 pre-existing network failures unrelated to this change
- `rg` confirms no remaining pup-self Preview claims

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)