### PR TITLE
feat(auth): sort scopes alphabetically wherever they're displayed

### DIFF
--- a/src/auth/dcr.rs
+++ b/src/auth/dcr.rs
@@ -199,7 +199,13 @@ impl DcrClient {
         scopes: &[&str],
         subdomain: Option<&str>,
     ) -> String {
-        let scope = scopes.join(" ");
+        // Sort scopes so the printed authorize URL has a deterministic
+        // `scope=` parameter order — easier to diff and grep across runs.
+        // OAuth treats `scope` as an unordered set, so this is a no-op for
+        // the issuer.
+        let mut sorted_scopes: Vec<&str> = scopes.to_vec();
+        sorted_scopes.sort();
+        let scope = sorted_scopes.join(" ");
         let params = url::form_urlencoded::Serializer::new(String::new())
             .append_pair("response_type", "code")
             .append_pair("client_id", client_id)

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -14,6 +14,16 @@ where
     f(&mut **store)
 }
 
+/// Parse a token's space-delimited scope claim and return scopes sorted
+/// alphabetically. The OAuth issuer returns scopes in non-deterministic
+/// order; sorting makes `pup auth list`/`pup auth status` output stable
+/// and easier to scan or diff between invocations.
+fn sorted_scopes(scope_claim: &str) -> Vec<&str> {
+    let mut scopes: Vec<&str> = scope_claim.split_whitespace().collect();
+    scopes.sort();
+    scopes
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 pub async fn login(
     cfg: &Config,
@@ -48,10 +58,12 @@ pub async fn login(
             scopes.len()
         );
     } else {
+        let mut display_scopes = scopes.clone();
+        display_scopes.sort();
         eprintln!(
             "🔑 Requesting {} scope(s): {}",
             scopes.len(),
-            scopes.join(", ")
+            display_scopes.join(", ")
         );
     }
 
@@ -237,11 +249,7 @@ pub fn status(cfg: &Config) -> Result<()> {
                     .map(|dt| dt.with_timezone(&chrono::Local).to_rfc3339())
                     .unwrap_or_default();
 
-                let scopes: Vec<&str> = tokens
-                    .scope
-                    .split_whitespace()
-                    .filter(|s| !s.is_empty())
-                    .collect();
+                let scopes = sorted_scopes(&tokens.scope);
 
                 let json = serde_json::json!({
                     "authenticated": true,
@@ -361,16 +369,11 @@ pub fn list(cfg: &Config) -> Result<()> {
                     let expires_at = chrono::DateTime::from_timestamp(expires_at_ts, 0)
                         .map(|dt| dt.with_timezone(&chrono::Local).to_rfc3339())
                         .unwrap_or_default();
-                    let scopes: Vec<&str> = t
-                        .scope
-                        .split_whitespace()
-                        .filter(|s| !s.is_empty())
-                        .collect();
                     serde_json::json!({
                         "expires_at": expires_at,
                         "has_refresh": !t.refresh_token.is_empty(),
                         "org": s.org,
-                        "scopes": scopes,
+                        "scopes": sorted_scopes(&t.scope),
                         "site": s.site,
                         "status": status,
                     })
@@ -440,6 +443,22 @@ mod tests {
             agent_mode: false,
             read_only: false,
         }
+    }
+
+    // ------------------------------------------------------------------
+    // sorted_scopes — pure helper, no env / storage state.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn sorted_scopes_alphabetises_the_claim() {
+        let got = sorted_scopes("monitors_read apm_read dashboards_read");
+        assert_eq!(got, vec!["apm_read", "dashboards_read", "monitors_read"]);
+    }
+
+    #[test]
+    fn sorted_scopes_handles_empty_and_whitespace_input() {
+        assert!(sorted_scopes("").is_empty());
+        assert!(sorted_scopes("   ").is_empty());
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Scopes arrive from the OAuth issuer in non-deterministic order, which makes pup's various scope-display surfaces unstable across invocations and hard to scan or diff. Sort them alphabetically at every display point.

## Surfaces touched

- `pup auth login` pre-launch print (the `🔑 Requesting N scope(s): ...` line when scope count is small enough to be inlined).
- `pup auth list` JSON output: each session's `scopes` array is now sorted.
- `pup auth status` JSON output: same.
- `dcr::build_authorization_url`: the printed authorize URL's `scope=` parameter is sorted too. OAuth treats scope as an unordered set so this is a no-op for the issuer; for users it makes the URL stable enough to grep or diff across runs.

A small `sorted_scopes(scope_claim: &str) -> Vec<&str>` helper deduplicates the parse-and-sort step shared by `list` and `status`.

## Schema

The JSON output schema is **unchanged** (`scopes` stays a `Vec<String>` array). Only the order changes, so existing snapshot fixtures at `tests/snapshots/auth_list__{human,agent}.json` continue to pass.

## Test plan

- [x] `cargo test --bin pup` — 67 auth-related tests pass, 2 new for `sorted_scopes`.
- [x] `cargo clippy --bin pup --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] Local E2E with synthetic `sessions.json` + tokens via `PUP_CONFIG_DIR` and `DD_TOKEN_STORAGE=file`: `pup auth list` and `pup auth status` both emit alphabetised arrays.