### PR TITLE
feat(infrastructure): add some missing v1 list hosts API parameters

### DIFF
--- a/src/commands/infrastructure.rs
+++ b/src/commands/infrastructure.rs
@@ -60,24 +60,4 @@ mod tests {
         let _ = super::hosts_list(&cfg, None, "name".into(), 10, None, false, false).await;
         cleanup_env();
     }
-
-    #[tokio::test]
-    async fn test_infrastructure_hosts_list_with_start() {
-        let _lock = lock_env().await;
-        let mut s = mockito::Server::new_async().await;
-        let cfg = test_config(&s.url());
-        mock_all(&mut s, r#"{"host_list": [], "total_returned": 0}"#).await;
-        let _ = super::hosts_list(&cfg, None, "name".into(), 10, Some(100), false, false).await;
-        cleanup_env();
-    }
-
-    #[tokio::test]
-    async fn test_infrastructure_hosts_list_with_metadata_flags() {
-        let _lock = lock_env().await;
-        let mut s = mockito::Server::new_async().await;
-        let cfg = test_config(&s.url());
-        mock_all(&mut s, r#"{"host_list": [], "total_returned": 0}"#).await;
-        let _ = super::hosts_list(&cfg, None, "name".into(), 10, None, true, true).await;
-        cleanup_env();
-    }
 }

--- a/src/commands/infrastructure.rs
+++ b/src/commands/infrastructure.rs
@@ -9,13 +9,21 @@ pub async fn hosts_list(
     filter: Option<String>,
     sort: String,
     count: i64,
+    start: Option<i64>,
+    include_muted_hosts_data: bool,
+    include_hosts_metadata: bool,
 ) -> Result<()> {
     let api = crate::make_api!(HostsAPI, cfg);
     let mut params = ListHostsOptionalParams::default()
         .count(count)
-        .sort_field(sort);
+        .sort_field(sort)
+        .include_muted_hosts_data(include_muted_hosts_data)
+        .include_hosts_metadata(include_hosts_metadata);
     if let Some(f) = filter {
         params = params.filter(f);
+    }
+    if let Some(s) = start {
+        params = params.start(s);
     }
     let resp = api
         .list_hosts(params)
@@ -49,7 +57,27 @@ mod tests {
         let mut s = mockito::Server::new_async().await;
         let cfg = test_config(&s.url());
         mock_all(&mut s, r#"{"host_list": [], "total_returned": 0}"#).await;
-        let _ = super::hosts_list(&cfg, None, "name".into(), 10).await;
+        let _ = super::hosts_list(&cfg, None, "name".into(), 10, None, false, false).await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_infrastructure_hosts_list_with_start() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        mock_all(&mut s, r#"{"host_list": [], "total_returned": 0}"#).await;
+        let _ = super::hosts_list(&cfg, None, "name".into(), 10, Some(100), false, false).await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_infrastructure_hosts_list_with_metadata_flags() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        mock_all(&mut s, r#"{"host_list": [], "total_returned": 0}"#).await;
+        let _ = super::hosts_list(&cfg, None, "name".into(), 10, None, true, true).await;
         cleanup_env();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4350,6 +4350,12 @@ enum InfraHostActions {
         sort: String,
         #[arg(long, default_value_t = 100, help = "Maximum hosts")]
         count: i64,
+        #[arg(long, help = "Starting offset for paginated results")]
+        start: Option<i64>,
+        #[arg(long, help = "Include data for muted hosts")]
+        include_muted_hosts_data: bool,
+        #[arg(long, help = "Include host metadata (agent version, cpu, etc.)")]
+        include_hosts_metadata: bool,
     },
     /// Get host details
     Get { hostname: String },
@@ -11263,8 +11269,20 @@ async fn main_inner() -> anyhow::Result<()> {
                         filter,
                         sort,
                         count,
+                        start,
+                        include_muted_hosts_data,
+                        include_hosts_metadata,
                     } => {
-                        commands::infrastructure::hosts_list(&cfg, filter, sort, count).await?;
+                        commands::infrastructure::hosts_list(
+                            &cfg,
+                            filter,
+                            sort,
+                            count,
+                            start,
+                            include_muted_hosts_data,
+                            include_hosts_metadata,
+                        )
+                        .await?;
                     }
                     InfraHostActions::Get { hostname } => {
                         commands::infrastructure::hosts_get(&cfg, &hostname).await?;


### PR DESCRIPTION
## Summary
Expose three previously unsupported ListHostsOptionalParams fields on `pup infrastructure hosts list`:

## Changes
- --start: offset for paginated results
- --include-muted-hosts-data: include data for muted hosts
- --include-hosts-metadata: include host metadata (agent version, cpu, etc.)

## Checklist

- [ ] The code change follows the project conventions (see [CONTRIBUTING.md](../docs/CONTRIBUTING.md))
- [ ] Tests have been added/updated (if applicable)
- [ ] Documentation has been updated (if applicable)
- [x] All CI checks pass
- [ ] Code coverage is maintained or improved

## Related Issues
