### PR TITLE
feat(alias): implement alias execution and builtin name protection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,7 @@ Rust-based CLI wrapper for Datadog APIs. Provides OAuth2 + API key authenticatio
 
 ## Documentation Index
 
+- **[ALIASES.md](docs/ALIASES.md)** - Alias management (storage, commands, expansion)
 - **[COMMANDS.md](docs/COMMANDS.md)** - Complete command reference
 - **[CONTRIBUTING.md](docs/CONTRIBUTING.md)** - Git workflow, PR process, commit format
 - **[TESTING.md](docs/TESTING.md)** - Test strategy, coverage requirements, CI/CD

--- a/docs/ALIASES.md
+++ b/docs/ALIASES.md
@@ -1,0 +1,124 @@
+# Aliases
+
+## Overview
+
+Aliases let you define short names for any `pup` command. Once set, an alias
+can be used exactly like a built-in command — with the same global flags and
+any extra arguments appended after the alias name.
+
+```bash
+pup alias set infra-list "infrastructure hosts list"
+pup infra-list                            # same as: pup infrastructure hosts list
+pup infra-list --filter env:production    # extra args are appended to the expansion
+pup --output json infra-list             # global flags before the alias still work
+```
+
+## Managing Aliases
+
+```bash
+# Create or update an alias
+pup alias set infra-list "infrastructure hosts list"
+pup alias set prod-errors "logs search --query='status:error' --tag='env:prod'"
+
+# List all configured aliases
+pup alias list
+pup --output json alias list
+
+# Delete one or more aliases
+pup alias delete infra-list
+pup alias delete infra-list prod-errors
+
+# Bulk-import from a YAML or JSON file
+pup alias import my-aliases.yaml
+pup alias import my-aliases.json
+```
+
+### Import file format
+
+YAML:
+
+```yaml
+infra-list: infrastructure hosts list
+prod-errors: logs search --query='status:error' --tag='env:prod'
+```
+
+JSON:
+
+```json
+{
+  "infra-list": "infrastructure hosts list",
+  "prod-errors": "logs search --query='status:error' --tag='env:prod'"
+}
+```
+
+## Storage
+
+Aliases are stored in a YAML file named `aliases.yaml` inside pup's config
+directory. The location depends on your platform:
+
+| Operating System | Path |
+|------------------|------|
+| macOS | `~/Library/Application Support/pup/aliases.yaml` |
+| Linux | `~/.config/pup/aliases.yaml` (or `$XDG_CONFIG_HOME/pup/aliases.yaml`) |
+| Windows | `%APPDATA%\pup\aliases.yaml` |
+
+The file is created automatically on the first `pup alias set`. It is a plain
+key/value map and can be edited directly in any text editor. Importing merges
+into the existing file — aliases not present in the import file are left
+untouched.
+
+## How Expansion Works
+
+When `pup` starts it reads `~/.config/pup/aliases.yaml` and checks whether the
+first positional argument (the subcommand) matches a known alias. If it does,
+the alias token is replaced with the stored command tokens **before** the
+argument list is handed to the command parser.
+
+This means:
+
+- **Global flags before the alias are preserved.** `pup --output json infra-list`
+  expands to `pup --output json infrastructure hosts list`.
+- **Extra arguments after the alias are appended.** `pup infra-list --filter env:prod`
+  expands to `pup infrastructure hosts list --filter env:prod`.
+- **Extensions take priority over aliases.** If a pup extension binary matches
+  the alias name, the extension is dispatched instead.
+- **Built-in commands cannot be aliased over.** An alias named `monitors` or
+  `logs` will never shadow the built-in of the same name.
+
+## Implementation
+
+| File | Role |
+|------|------|
+| `src/commands/alias.rs` | CRUD commands (`list`, `set`, `delete`, `import`) and expansion logic (`expand`, `apply_expansion`) |
+| `src/main.rs` | Calls `commands::alias::expand` on startup, before clap parses the argument list |
+
+The core expansion function (`apply_expansion`) operates on an in-memory alias
+map, making it straightforward to unit-test without filesystem access. The
+public `expand` function wraps it with a disk read from `aliases.yaml`.
+
+## Examples
+
+```bash
+# Shorten a frequently used infrastructure command
+pup alias set infra-list "infrastructure hosts list"
+pup infra-list
+pup infra-list --filter env:production --count 50
+
+# Bookmark a common log search
+pup alias set prod-errors "logs search --query='status:error' --tag='env:prod'"
+pup prod-errors
+pup prod-errors --from 30m   # append extra flags on the fly
+
+# Snapshot a metrics query
+pup alias set cpu "metrics query --query='avg:system.cpu.user{*}' --from=1h"
+pup cpu
+
+# Review all aliases
+pup alias list
+
+# Remove an alias you no longer need
+pup alias delete cpu
+
+# Share a set of aliases with your team via a checked-in file
+pup alias import team-aliases.yaml
+```

--- a/src/commands/alias.rs
+++ b/src/commands/alias.rs
@@ -52,6 +52,9 @@ pub fn list(cfg: &crate::config::Config) -> Result<()> {
 }
 
 pub fn set(name: String, command: String) -> Result<()> {
+    if crate::extensions::is_builtin_command(&name) {
+        bail!("'{name}' is a built-in command and cannot be used as an alias name");
+    }
     let mut aliases = load_aliases()?;
     aliases.insert(name.clone(), command.clone());
     save_aliases(&aliases)?;
@@ -69,6 +72,38 @@ pub fn delete(names: Vec<String>) -> Result<()> {
     save_aliases(&aliases)?;
     println!("Deleted {} alias(es).", names.len());
     Ok(())
+}
+
+/// Core expansion logic, operating on an already-loaded alias map.
+/// Exposed separately so unit tests can exercise it without touching the
+/// filesystem.
+fn apply_expansion(args: &[String], name: &str, aliases: &BTreeMap<String, String>) -> Vec<String> {
+    // Built-in commands cannot be shadowed by aliases.
+    if crate::extensions::is_builtin_command(name) {
+        return args.to_vec();
+    }
+    let Some(expansion) = aliases.get(name) else {
+        return args.to_vec();
+    };
+    let expansion_tokens: Vec<String> = expansion.split_whitespace().map(String::from).collect();
+    let Some(idx) = args.iter().position(|a| a == name) else {
+        return args.to_vec();
+    };
+    let mut out = args[..idx].to_vec();
+    out.extend(expansion_tokens);
+    out.extend_from_slice(&args[idx + 1..]);
+    out
+}
+
+/// Rewrite `args` by replacing the `name` token with its stored alias expansion.
+/// Returns a clone of `args` unchanged if `name` is not a known alias or on
+/// any I/O error.
+pub fn expand(args: &[String], name: &str) -> Vec<String> {
+    let aliases = match load_aliases() {
+        Ok(m) => m,
+        Err(_) => return args.to_vec(),
+    };
+    apply_expansion(args, name, &aliases)
 }
 
 pub fn import(file: &str) -> Result<()> {
@@ -96,4 +131,69 @@ pub fn import(file: &str) -> Result<()> {
     save_aliases(&aliases)?;
     println!("Imported {count} alias(es) from {file}.");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(s: &str) -> Vec<String> {
+        s.split_whitespace().map(String::from).collect()
+    }
+
+    fn map(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn test_apply_expansion_no_match() {
+        let aliases = map(&[]);
+        let result = apply_expansion(&args("pup infra-list"), "infra-list", &aliases);
+        assert_eq!(result, args("pup infra-list"));
+    }
+
+    #[test]
+    fn test_apply_expansion_simple() {
+        let aliases = map(&[("infra-list", "infrastructure hosts list")]);
+        let result = apply_expansion(&args("pup infra-list"), "infra-list", &aliases);
+        assert_eq!(result, args("pup infrastructure hosts list"));
+    }
+
+    #[test]
+    fn test_apply_expansion_preserves_trailing_args() {
+        let aliases = map(&[("infra-list", "infrastructure hosts list")]);
+        let result = apply_expansion(
+            &args("pup infra-list --filter env:prod"),
+            "infra-list",
+            &aliases,
+        );
+        assert_eq!(
+            result,
+            args("pup infrastructure hosts list --filter env:prod")
+        );
+    }
+
+    #[test]
+    fn test_apply_expansion_preserves_leading_flags() {
+        let aliases = map(&[("infra-list", "infrastructure hosts list")]);
+        let result = apply_expansion(
+            &args("pup --output json infra-list"),
+            "infra-list",
+            &aliases,
+        );
+        assert_eq!(result, args("pup --output json infrastructure hosts list"));
+    }
+
+    #[test]
+    fn test_set_rejects_builtin_name() {
+        let result = super::set(
+            "infrastructure".to_string(),
+            "infrastructure hosts list".to_string(),
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("built-in command"));
+    }
 }

--- a/src/commands/alias.rs
+++ b/src/commands/alias.rs
@@ -52,6 +52,7 @@ pub fn list(cfg: &crate::config::Config) -> Result<()> {
 }
 
 pub fn set(name: String, command: String) -> Result<()> {
+    #[cfg(not(target_arch = "wasm32"))]
     if crate::extensions::is_builtin_command(&name) {
         bail!("'{name}' is a built-in command and cannot be used as an alias name");
     }
@@ -79,6 +80,7 @@ pub fn delete(names: Vec<String>) -> Result<()> {
 /// filesystem.
 fn apply_expansion(args: &[String], name: &str, aliases: &BTreeMap<String, String>) -> Vec<String> {
     // Built-in commands cannot be shadowed by aliases.
+    #[cfg(not(target_arch = "wasm32"))]
     if crate::extensions::is_builtin_command(name) {
         return args.to_vec();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10298,7 +10298,7 @@ mod resolve_callback_port_tests {
 
 async fn main_inner() -> anyhow::Result<()> {
     // In agent mode, intercept --help to return a JSON schema instead of plain text.
-    let mut args: Vec<String> = std::env::args().collect();
+    let args: Vec<String> = std::env::args().collect();
     let has_help = args.iter().any(|a| a == "--help" || a == "-h");
     let has_agent_flag = args.iter().any(|a| a == "--agent");
     let has_no_agent_flag = args.iter().any(|a| a == "--no-agent");
@@ -10346,12 +10346,14 @@ async fn main_inner() -> anyhow::Result<()> {
     // If the first positional arg matches a stored alias, rewrite args so
     // that clap sees the expanded command instead of the alias name.
     #[cfg(not(target_arch = "wasm32"))]
-    {
+    let args = {
         let parsed = extensions::parse_extension_args(&args);
         if let Some(ref candidate) = parsed.candidate {
-            args = commands::alias::expand(&args, candidate);
+            commands::alias::expand(&args, candidate)
+        } else {
+            args
         }
-    }
+    };
 
     // Build the clap Command and, when extensions are installed, append an
     // "EXTENSIONS:" section to the help output so they are visible in

--- a/src/main.rs
+++ b/src/main.rs
@@ -10298,7 +10298,7 @@ mod resolve_callback_port_tests {
 
 async fn main_inner() -> anyhow::Result<()> {
     // In agent mode, intercept --help to return a JSON schema instead of plain text.
-    let args: Vec<String> = std::env::args().collect();
+    let mut args: Vec<String> = std::env::args().collect();
     let has_help = args.iter().any(|a| a == "--help" || a == "-h");
     let has_agent_flag = args.iter().any(|a| a == "--agent");
     let has_no_agent_flag = args.iter().any(|a| a == "--no-agent");
@@ -10342,6 +10342,17 @@ async fn main_inner() -> anyhow::Result<()> {
         }
     }
 
+    // --- Alias expansion (before clap parsing) ---
+    // If the first positional arg matches a stored alias, rewrite args so
+    // that clap sees the expanded command instead of the alias name.
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let parsed = extensions::parse_extension_args(&args);
+        if let Some(ref candidate) = parsed.candidate {
+            args = commands::alias::expand(&args, candidate);
+        }
+    }
+
     // Build the clap Command and, when extensions are installed, append an
     // "EXTENSIONS:" section to the help output so they are visible in
     // `pup --help` / `pup help`, similar to how `gh` lists extensions.
@@ -10353,7 +10364,7 @@ async fn main_inner() -> anyhow::Result<()> {
             cmd = cmd.after_help(section);
         }
     }
-    let matches = cmd.get_matches();
+    let matches = cmd.get_matches_from(&args);
     let cli = Cli::from_arg_matches(&matches).unwrap_or_else(|e| e.exit());
 
     // Handle commands that do not require authentication before Config::from_env() so


### PR DESCRIPTION
## Summary
Implements runtime alias expansion so user-defined shorthand commands are resolved to their full pup command before clap parses the argument list, and adds builtin name protection to prevent aliases from shadowing built-in commands.

## Changes
- Added `apply_expansion` and `expand` functions to `src/commands/alias.rs` to rewrite args before clap sees them
- Updated `src/main.rs` to call `commands::alias::expand` after extension interception and switch `cmd.get_matches()` to `cmd.get_matches_from(&args)`
- Added builtin guard in `apply_expansion` (`src/commands/alias.rs:82`) and `set` (`src/commands/alias.rs:55`) to reject aliases that conflict with built-in commands
- Added `docs/ALIASES.md` covering storage locations, commands, expansion behavior, and examples
- Updated `CLAUDE.md` documentation index to reference `docs/ALIASES.md`

## Testing
- `test_apply_expansion_simple` — verifies basic alias token replacement
- `test_apply_expansion_preserves_trailing_args` — verifies extra args are appended after expansion
- `test_apply_expansion_preserves_leading_flags` — verifies global flags before alias are retained
- `test_apply_expansion_no_match` — verifies args are unchanged when no alias matches
- `test_set_rejects_builtin_name` — verifies `set` returns an error for builtin command names

## Related Issues
N/A

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)