### PR TITLE
feat(notebooks): add append-only edit command

### DIFF
--- a/src/commands/notebooks.rs
+++ b/src/commands/notebooks.rs
@@ -53,6 +53,50 @@ pub async fn update(cfg: &Config, notebook_id: i64, file: &str) -> Result<()> {
     formatter::output(cfg, &resp)
 }
 
+/// Append-only update: fetches the current notebook, appends cells from
+/// `file` (an array of cell objects), then writes the full modified notebook back.
+pub async fn edit(cfg: &Config, notebook_id: i64, file: &str) -> Result<()> {
+    let api = crate::make_api!(NotebooksAPI, cfg);
+
+    // Fetch current notebook so we can append without clobbering existing cells.
+    let current = api
+        .get_notebook(notebook_id)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to fetch notebook {notebook_id}: {e:?}"))?;
+
+    // Serialize current notebook to Value so we can manipulate cells generically.
+    let mut nb: serde_json::Value = serde_json::to_value(&current)
+        .map_err(|e| anyhow::anyhow!("failed to serialize notebook: {e:?}"))?;
+
+    // Read the new cells to append from the file (expected: array of cell objects).
+    let new_cells: serde_json::Value = util::read_json_file(file)?;
+    let new_cells_arr = new_cells
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("--file must contain a JSON array of cell objects"))?;
+
+    // Append new cells to the existing cells array.
+    let cells = nb
+        .pointer_mut("/data/attributes/cells")
+        .and_then(|v| v.as_array_mut())
+        .ok_or_else(|| anyhow::anyhow!("could not locate cells array in notebook response"))?;
+    cells.extend(new_cells_arr.iter().cloned());
+
+    // Write back via the typed update endpoint.
+    let update_body: NotebookUpdateRequest = serde_json::from_value(
+        nb.get("data")
+            .cloned()
+            .map(|data| serde_json::json!({ "data": data }))
+            .unwrap_or(nb.clone()),
+    )
+    .map_err(|e| anyhow::anyhow!("failed to build update request: {e:?}"))?;
+
+    let resp = api
+        .update_notebook(notebook_id, update_body)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to edit notebook: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5644,10 +5644,19 @@ enum NotebookActions {
         #[arg(long, help = "JSON file with notebook data (required)")]
         file: String,
     },
-    /// Update a notebook
+    /// Update a notebook (full replace)
     Update {
         notebook_id: i64,
         #[arg(long, help = "JSON file with notebook data (required)")]
+        file: String,
+    },
+    /// Append cells to an existing notebook (reads current notebook first, then appends)
+    Edit {
+        notebook_id: i64,
+        #[arg(
+            long,
+            help = "JSON file containing an array of cell objects to append (required)"
+        )]
         file: String,
     },
     /// Delete a notebook
@@ -12040,6 +12049,9 @@ async fn main_inner() -> anyhow::Result<()> {
                 }
                 NotebookActions::Update { notebook_id, file } => {
                     commands::notebooks::update(&cfg, notebook_id, &file).await?;
+                }
+                NotebookActions::Edit { notebook_id, file } => {
+                    commands::notebooks::edit(&cfg, notebook_id, &file).await?;
                 }
                 NotebookActions::Delete { notebook_id } => {
                     commands::notebooks::delete(&cfg, notebook_id).await?;


### PR DESCRIPTION
## Why this is needed

This command is required to ship the **LLMObs skills** (`/eval-trace-rca`, `/eval-bootstrap`, `/experiment-analyzer`) on top of pup.

Those skills currently call Datadog MCP notebook tools (`create_datadog_notebook`, `edit_datadog_notebook`) to write persistent analysis artifacts. When the skills run through pup instead of the MCP server, they need an equivalent pup command. `notebooks create` already exists; this PR adds the missing append-only variant.

### Skills that break without this

**`/eval-trace-rca` and `/llm-obs-trace-rca`** — Phase 6 exports the root cause analysis report as a formatted Datadog notebook. Without `notebooks edit`, the skill produces console-only output with no shareable artifact. It also breaks the downstream chaining workflow described below.

**`/eval-bootstrap`** — After bootstrapping an evaluator suite, the skill detects whether a prior RCA notebook was created in the same session (by matching the notebook URL) and **appends** the bootstrapped evaluator summary to that notebook rather than creating a new one. This is the append-only pattern: the skill calls `edit_datadog_notebook` with `append_only=true` to preserve the existing RCA content and add new cells alongside it. Without `notebooks edit`, this entire chained workflow — `/eval-trace-rca` → creates notebook → `/eval-bootstrap` → appends to same notebook — is broken at the second step.

**`/experiment-analyzer`** — Phase 5 optionally exports the analysis report to a Datadog notebook. Without `notebooks edit` (or `notebooks create`), the skill falls back to chat-only output with no persistent artifact.

### What breaks end-to-end

The most impactful breakage is the RCA → bootstrap chain:

```
/eval-trace-rca          # creates notebook with RCA findings
    ↓ notebook URL passed to next skill
/eval-bootstrap          # appends evaluator suite to same notebook
    ↓ broken without notebooks edit
```

Users lose the ability to produce a single unified notebook that documents both the root cause diagnosis and the evaluator suite that addresses it.

## Summary

Adds `pup notebooks edit <id> --file <cells.json>` as an append-only alternative to `notebooks update`. Instead of replacing the entire notebook, it fetches the current notebook, appends the provided cells, and writes back — preventing accidental clobber of existing content.

## Changes

- `src/commands/notebooks.rs` — new `edit()` function (read-modify-write via typed API)
- `src/main.rs` — `NotebookActions::Edit` variant and routing

## Interface

```bash
# --file contains a JSON array of cell objects to append (not the full notebook)
pup notebooks edit <notebook_id> --file cells.json
```

Example cells file:
```json
[
  {
    "attributes": {
      "definition": {
        "type": "markdown",
        "text": "## New Section\n\nContent here."
      }
    },
    "type": "notebook_cells"
  }
]
```

## Testing

### Automated
- `cargo test` — passing
- `cargo clippy -- -D warnings` — clean
- `cargo fmt --check` — clean

### Manual smoke tests

```bash
cat > /tmp/cells.json << 'BODY'
[{"attributes": {"definition": {"type": "markdown", "text": "## pup smoke test\n\nAppended by pup notebooks edit — safe to delete."}}, "type": "notebook_cells"}]
BODY
```

- [ ] `pup notebooks edit 13937752 --file /tmp/cells.json` — cell appended to notebook, returns updated notebook (exit 0)
- [ ] `pup notebooks edit 999999999 --file /tmp/cells.json` — 404 "Notebook not found" on the initial fetch (exit 1)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)