### PR TITLE
feat(rum): add --user-email filter to rum aggregate

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5669,6 +5669,11 @@ enum RumActions {
             help = "RUM query filter (e.g. '@type:error @application.name:\"My App\"')"
         )]
         query: Option<String>,
+        #[arg(
+            long,
+            help = "Filter to a specific user by email — prepends @usr.email:<value> to the query"
+        )]
+        user_email: Option<String>,
         #[arg(long, default_value = "1h", help = "Start time")]
         from: String,
         #[arg(long, default_value = "now", help = "End time")]
@@ -12066,16 +12071,29 @@ async fn main_inner() -> anyhow::Result<()> {
                 },
                 RumActions::Aggregate {
                     query,
+                    user_email,
                     from,
                     to,
                     compute,
                     group_by,
                     limit,
                 } => {
+                    let base_query = query.unwrap_or_default();
+                    let effective_query = match user_email {
+                        Some(email) => {
+                            let email_filter = format!("@usr.email:{email}");
+                            if base_query.is_empty() {
+                                email_filter
+                            } else {
+                                format!("{email_filter} {base_query}")
+                            }
+                        }
+                        None => base_query,
+                    };
                     commands::rum::aggregate(
                         &cfg,
                         commands::rum::RumAggregateArgs {
-                            query: query.unwrap_or_default(),
+                            query: effective_query,
                             from,
                             to,
                             compute: commands::rum::split_rum_compute_args(&compute),


### PR DESCRIPTION
## Why this is needed

This flag is required to ship the **`/eval-session-classify`** and **`/llm-obs-session-classify`** skills on top of pup.

Those skills classify whether a user's intent was satisfied in a Datadog assistant (CMD+I) session by combining LLMObs trace data with behavioral signals from web RUM. Specifically, they query RUM events filtered to a specific user by email to see what the user did before and after the assistant session — whether they navigated to the suggested pages, triggered the recommended actions, or abandoned the session.

When the skills run through pup instead of the MCP server, they need `pup rum aggregate` with a user-scoped filter. The existing command already supports `--query` for free-form filtering, but the `@usr.email:` syntax is non-obvious and error-prone. Without a dedicated flag, every call to `pup rum aggregate` for session classification requires the user to know and correctly quote the RUM field name.

### Skills that break without this

**`/eval-session-classify` and `/llm-obs-session-classify`** — Steps 4 and 5 of the session classification workflow pull two RUM event streams for the user:

- **Page view timeline** — `@usr.email:<user_handle>` filter on view events, to understand which pages the user navigated to around the assistant session (showing whether they followed up on the assistant's response)
- **Custom actions** — `@action.type:custom @usr.email:<user_handle>` filter on action events, to catch assistant-specific in-app actions (e.g. `ai-suggestion-accepted`, `ai-feedback-submitted`)

Without user-email filtering, the skill cannot isolate signals for the specific user being classified and falls back to trace-only classification, losing the behavioral validation layer entirely. This makes the satisfied/unsatisfied label significantly less reliable for sessions where the user acted silently after the conversation ended.

## Summary

Adds `--user-email <email>` to `pup rum aggregate` as a convenience shorthand for filtering by user. Prepends `@usr.email:<value>` to the query, composing cleanly with any `--query` value already set.

## Changes

- `src/main.rs` — `user_email: Option<String>` arg on `RumActions::Aggregate`, routing builds the effective query

## Usage

```bash
# Session count per session ID for a specific user over the last 30 minutes
pup rum aggregate \
  --user-email alice@example.com \
  --from 30m \
  --compute count \
  --group-by @session.id

# Combine with an additional query filter
pup rum aggregate \
  --user-email alice@example.com \
  --query "@type:error" \
  --from 1h \
  --compute count
```

When both `--user-email` and `--query` are set, the effective filter is `@usr.email:<email> <query>`. When only `--user-email` is set, it is used as the sole filter.

## Testing

### Automated
- `cargo test` — passing
- `cargo clippy -- -D warnings` — clean
- `cargo fmt --check` — clean

### Manual smoke test

```bash
# happy: returns session counts for a real user
pup rum aggregate \
  --user-email <your-email@datadoghq.com> \
  --from 1d \
  --compute count \
  --group-by @session.id \
  --limit 5

# sad: nonexistent email returns empty buckets (exit 0 — API behavior)
pup rum aggregate \
  --user-email nobody@notadomain.invalid \
  --from 1h \
  --compute count
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)