### PR TITLE
Re-add APM service remapping CRUD commands

### DIFF
--- a/src/auth/types.rs
+++ b/src/auth/types.rs
@@ -105,6 +105,7 @@ pub fn default_scopes() -> Vec<&'static str> {
         // APM
         "apm_read",
         "apm_service_catalog_read",
+        "apm_service_renaming_write",
         // Audit
         "audit_logs_read",
         // AWS
@@ -270,7 +271,7 @@ mod tests {
     #[test]
     fn test_default_scopes() {
         let scopes = default_scopes();
-        assert_eq!(scopes.len(), 84);
+        assert_eq!(scopes.len(), 85);
         assert!(scopes.contains(&"dashboards_read"));
         assert!(scopes.contains(&"monitors_read"));
         assert!(scopes.contains(&"logs_read_data"));
@@ -283,6 +284,7 @@ mod tests {
         assert!(scopes.contains(&"ci_visibility_read"));
         assert!(scopes.contains(&"teams_read"));
         assert!(scopes.contains(&"apm_service_catalog_read"));
+        assert!(scopes.contains(&"apm_service_renaming_write"));
         assert!(scopes.contains(&"status_pages_settings_read"));
         assert!(scopes.contains(&"on_call_read"));
         assert!(scopes.contains(&"on_call_write"));

--- a/src/client.rs
+++ b/src/client.rs
@@ -1009,6 +1009,33 @@ pub async fn raw_post_jsonapi(
     parse_response_json(resp).await
 }
 
+pub async fn raw_put(
+    cfg: &Config,
+    path: &str,
+    body: serde_json::Value,
+) -> anyhow::Result<serde_json::Value> {
+    let url = format!("{}{}", cfg.api_base_url(), path);
+    let client = reqwest::Client::new();
+    let req = client.put(&url);
+    let req = apply_auth(req, cfg, "PUT", path)?;
+    let resp = req
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .header("User-Agent", useragent::get())
+        .json(&body)
+        .send()
+        .await?;
+    if resp.status() == reqwest::StatusCode::NO_CONTENT {
+        return Ok(serde_json::Value::Null);
+    }
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("PUT {url} failed (HTTP {status}): {body}");
+    }
+    Ok(resp.json().await?)
+}
+
 /// Like `raw_post`, but returns the parsed JSON body even on non-2xx responses.
 /// Callers are responsible for inspecting the body for errors.
 pub async fn raw_post_lenient(

--- a/src/client.rs
+++ b/src/client.rs
@@ -1033,7 +1033,7 @@ pub async fn raw_put(
         let body = resp.text().await.unwrap_or_default();
         anyhow::bail!("PUT {url} failed (HTTP {status}): {body}");
     }
-    Ok(resp.json().await?)
+    parse_response_json(resp).await
 }
 
 /// Like `raw_post`, but returns the parsed JSON body even on non-2xx responses.

--- a/src/commands/apm.rs
+++ b/src/commands/apm.rs
@@ -100,6 +100,67 @@ pub async fn troubleshooting_list(
     formatter::output(cfg, &data)
 }
 
+pub async fn service_remapping_list(cfg: &Config) -> Result<()> {
+    let data = client::raw_get(cfg, "/api/v2/service-naming-rules", &[]).await?;
+    formatter::output(cfg, &data)
+}
+
+pub async fn service_remapping_create(
+    cfg: &Config,
+    name: String,
+    filter: String,
+    rule_type: i64,
+    value: String,
+) -> Result<()> {
+    let body = serde_json::json!({
+        "data": {
+            "type": "rule",
+            "attributes": {
+                "name": name,
+                "filter": filter,
+                "rule_type": rule_type,
+                "rewrite_tag_rules": [{"destination_tag_name": "service", "value": value}]
+            }
+        }
+    });
+    let data = client::raw_post(cfg, "/api/v2/service-naming-rules", body).await?;
+    formatter::output(cfg, &data)
+}
+
+pub async fn service_remapping_get(cfg: &Config, id: String) -> Result<()> {
+    let data = client::raw_get(cfg, &format!("/api/v2/service-naming-rules/{id}"), &[]).await?;
+    formatter::output(cfg, &data)
+}
+
+pub async fn service_remapping_update(
+    cfg: &Config,
+    id: String,
+    name: String,
+    filter: String,
+    rule_type: i64,
+    value: String,
+    version: i64,
+) -> Result<()> {
+    let body = serde_json::json!({
+        "data": {
+            "type": "rule",
+            "attributes": {
+                "name": name,
+                "filter": filter,
+                "rule_type": rule_type,
+                "rewrite_tag_rules": [{"destination_tag_name": "service", "value": value}],
+                "version": version
+            }
+        }
+    });
+    let data = client::raw_put(cfg, &format!("/api/v2/service-naming-rules/{id}"), body).await?;
+    formatter::output(cfg, &data)
+}
+
+pub async fn service_remapping_delete(cfg: &Config, id: String, version: i64) -> Result<()> {
+    client::raw_delete(cfg, &format!("/api/v2/service-naming-rules/{id}/{version}")).await
+}
+
 pub async fn service_config_get(
     cfg: &Config,
     service_name: String,
@@ -379,6 +440,282 @@ mod tests {
         assert!(
             result.is_ok(),
             "service_library_config_get with filters failed: {:?}",
+            result.err()
+        );
+        mock.assert_async().await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_service_remapping_list() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        let mock = server
+            .mock("GET", "/api/v2/service-naming-rules")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data": []}"#)
+            .create_async()
+            .await;
+
+        let result = super::service_remapping_list(&cfg).await;
+        assert!(
+            result.is_ok(),
+            "service_remapping_list failed: {:?}",
+            result.err()
+        );
+        mock.assert_async().await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_service_remapping_list_api_error() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        server
+            .mock("GET", "/api/v2/service-naming-rules")
+            .with_status(403)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors": ["Forbidden"]}"#)
+            .create_async()
+            .await;
+
+        let result = super::service_remapping_list(&cfg).await;
+        assert!(result.is_err(), "expected error on 403");
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_service_remapping_create() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        let mock = server
+            .mock("POST", "/api/v2/service-naming-rules")
+            .with_status(201)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data": {"id": "abc123"}}"#)
+            .create_async()
+            .await;
+
+        let result = super::service_remapping_create(
+            &cfg,
+            "my-rule".into(),
+            "service:my-svc".into(),
+            0,
+            "new-name".into(),
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "service_remapping_create failed: {:?}",
+            result.err()
+        );
+        mock.assert_async().await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_service_remapping_create_api_error() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        server
+            .mock("POST", "/api/v2/service-naming-rules")
+            .with_status(422)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors": ["Invalid rule_type"]}"#)
+            .create_async()
+            .await;
+
+        let result = super::service_remapping_create(
+            &cfg,
+            "my-rule".into(),
+            "service:my-svc".into(),
+            99,
+            "new-name".into(),
+        )
+        .await;
+        assert!(result.is_err(), "expected error on 422");
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_service_remapping_get() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        let mock = server
+            .mock("GET", "/api/v2/service-naming-rules/abc123")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data": {"id": "abc123"}}"#)
+            .create_async()
+            .await;
+
+        let result = super::service_remapping_get(&cfg, "abc123".into()).await;
+        assert!(
+            result.is_ok(),
+            "service_remapping_get failed: {:?}",
+            result.err()
+        );
+        mock.assert_async().await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_service_remapping_get_not_found() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        server
+            .mock("GET", "/api/v2/service-naming-rules/missing")
+            .with_status(404)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors": ["Not found"]}"#)
+            .create_async()
+            .await;
+
+        let result = super::service_remapping_get(&cfg, "missing".into()).await;
+        assert!(result.is_err(), "expected error on 404");
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_service_remapping_update() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        let mock = server
+            .mock("PUT", "/api/v2/service-naming-rules/abc123")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data": {"id": "abc123"}}"#)
+            .create_async()
+            .await;
+
+        let result = super::service_remapping_update(
+            &cfg,
+            "abc123".into(),
+            "updated-rule".into(),
+            "service:my-svc".into(),
+            0,
+            "new-name".into(),
+            2,
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "service_remapping_update failed: {:?}",
+            result.err()
+        );
+        mock.assert_async().await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_service_remapping_update_conflict() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        server
+            .mock("PUT", "/api/v2/service-naming-rules/abc123")
+            .with_status(409)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors": ["Conflict: stale version"]}"#)
+            .create_async()
+            .await;
+
+        let result = super::service_remapping_update(
+            &cfg,
+            "abc123".into(),
+            "updated-rule".into(),
+            "service:my-svc".into(),
+            0,
+            "new-name".into(),
+            1,
+        )
+        .await;
+        assert!(result.is_err(), "expected error on 409");
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_service_remapping_delete() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        let mock = server
+            .mock("DELETE", "/api/v2/service-naming-rules/abc123/2")
+            .with_status(204)
+            .create_async()
+            .await;
+
+        let result = super::service_remapping_delete(&cfg, "abc123".into(), 2).await;
+        assert!(
+            result.is_ok(),
+            "service_remapping_delete failed: {:?}",
+            result.err()
+        );
+        mock.assert_async().await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_service_remapping_delete_not_found() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        server
+            .mock("DELETE", "/api/v2/service-naming-rules/missing/1")
+            .with_status(404)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors": ["Not found"]}"#)
+            .create_async()
+            .await;
+
+        let result = super::service_remapping_delete(&cfg, "missing".into(), 1).await;
+        assert!(result.is_err(), "expected error on 404");
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_service_remapping_update_204_no_content() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        let mock = server
+            .mock("PUT", "/api/v2/service-naming-rules/abc123")
+            .with_status(204)
+            .create_async()
+            .await;
+
+        let result = super::service_remapping_update(
+            &cfg,
+            "abc123".into(),
+            "updated-rule".into(),
+            "service:my-svc".into(),
+            0,
+            "new-name".into(),
+            2,
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "204 No Content should not be an error: {:?}",
             result.err()
         );
         mock.assert_async().await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7866,6 +7866,12 @@ enum ApmActions {
         #[command(subcommand)]
         action: ApmTroubleshootingActions,
     },
+    /// Manage APM service remapping rules
+    #[command(name = "service-remapping")]
+    ServiceRemapping {
+        #[command(subcommand)]
+        action: ApmServiceRemappingActions,
+    },
     /// View APM service instance configuration
     #[command(name = "service-config")]
     ServiceConfig {
@@ -7984,6 +7990,70 @@ enum ApmTroubleshootingActions {
         hostname: String,
         #[arg(long, help = "Time window (e.g. 4h, 24h, 1h30m)")]
         timeframe: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+enum ApmServiceRemappingActions {
+    /// List all service remapping rules
+    List,
+    /// Create a service remapping rule
+    Create {
+        #[arg(long, help = "Rule name")]
+        name: String,
+        #[arg(
+            long,
+            help = "Filter query (e.g. 'service:my-svc', 'peer.service:*.shopify.com')"
+        )]
+        filter: String,
+        #[arg(
+            long,
+            value_name = "TYPE",
+            help = "Entity type: 0 = instrumented service, 1 = inferred entity (from outbound calls)"
+        )]
+        rule_type: i64,
+        #[arg(
+            long,
+            help = "New service name — static string or template (e.g. 'new-name', '{{service|^(.+?)\\..*$}}')"
+        )]
+        value: String,
+    },
+    /// Get a service remapping rule by ID
+    Get {
+        #[arg(help = "Rule ID")]
+        id: String,
+    },
+    /// Update a service remapping rule
+    Update {
+        #[arg(help = "Rule ID")]
+        id: String,
+        #[arg(long, help = "Rule name")]
+        name: String,
+        #[arg(
+            long,
+            help = "Filter query (e.g. 'service:my-svc', 'peer.service:*.shopify.com')"
+        )]
+        filter: String,
+        #[arg(
+            long,
+            value_name = "TYPE",
+            help = "Entity type: 0 = instrumented service, 1 = inferred entity"
+        )]
+        rule_type: i64,
+        #[arg(
+            long,
+            help = "New service name — static string or template (e.g. 'new-name', '{{service|^(.+?)\\..*$}}')"
+        )]
+        value: String,
+        #[arg(long, help = "Current rule version (from list/get output)")]
+        version: i64,
+    },
+    /// Delete a service remapping rule
+    Delete {
+        #[arg(help = "Rule ID")]
+        id: String,
+        #[arg(help = "Rule version (from list output)")]
+        version: i64,
     },
 }
 
@@ -13403,6 +13473,41 @@ async fn main_inner() -> anyhow::Result<()> {
                         timeframe,
                     } => {
                         commands::apm::troubleshooting_list(&cfg, hostname, timeframe).await?;
+                    }
+                },
+                ApmActions::ServiceRemapping { action } => match action {
+                    ApmServiceRemappingActions::List => {
+                        commands::apm::service_remapping_list(&cfg).await?;
+                    }
+                    ApmServiceRemappingActions::Create {
+                        name,
+                        filter,
+                        rule_type,
+                        value,
+                    } => {
+                        commands::apm::service_remapping_create(
+                            &cfg, name, filter, rule_type, value,
+                        )
+                        .await?;
+                    }
+                    ApmServiceRemappingActions::Get { id } => {
+                        commands::apm::service_remapping_get(&cfg, id).await?;
+                    }
+                    ApmServiceRemappingActions::Update {
+                        id,
+                        name,
+                        filter,
+                        rule_type,
+                        value,
+                        version,
+                    } => {
+                        commands::apm::service_remapping_update(
+                            &cfg, id, name, filter, rule_type, value, version,
+                        )
+                        .await?;
+                    }
+                    ApmServiceRemappingActions::Delete { id, version } => {
+                        commands::apm::service_remapping_delete(&cfg, id, version).await?;
                     }
                 },
                 ApmActions::ServiceConfig { action } => match action {


### PR DESCRIPTION
## Context

Resurrects #439, which was reverted in #454 because `pup auth login` failed with `invalid_scope` once the new scope was requested. The server-side DCR client allowlist is now in place, so the original failure mode is resolved.

Requested by @rachelyangdog

## Summary

Restores the four files removed by the revert, with one updated test assertion to match current `main`:

- `pup apm service-remapping {list,create,get,update,delete}` (new commands wired in `src/main.rs`, implementation in `src/commands/apm.rs`)
- `apm_service_renaming_write` added to `default_scopes()` in `src/auth/types.rs`
- `raw_put` helper added to `src/client.rs` to support the `update` (PUT) endpoint
- `test_default_scopes` length assertion 84 -> 85

No exclusion-list changes: the original PR briefly added then removed three `/api/v2/service-naming-rules` entries from `OAUTH_EXCLUDED_ENDPOINTS`; net effect was zero. Current `main` has no such entries, so OAuth is used for these routes by default -- which is what we want.

## Test plan

- [x] `cargo build`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --bin pup auth::types` (9 passed)
- [x] `cargo test --bin pup -- --test-threads=1 commands::apm` (19 passed, including 11 new `service_remapping_*` tests)
- [x] End-to-end against both `datad0g.com` (staging) and `datadoghq.com` (prod): login issues a token containing `apm_service_renaming_write`, `service-remapping list` returns real rules, and `service-remapping delete <bogus-uuid> 1` reaches the service (404 in staging, 403 RBAC in prod) -- proving the scope is honored end-to-end. Transcripts in a comment below.