### PR TITLE
fix(incidents): enable v2.list_incident_attachments unstable op

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -232,6 +232,7 @@ static UNSTABLE_OPS: &[&str] = &[
     "v2.create_incident",
     "v2.update_incident",
     "v2.delete_incident",
+    "v2.list_incident_attachments",
     "v2.create_global_incident_handle",
     "v2.delete_global_incident_handle",
     "v2.get_global_incident_settings",
@@ -1278,7 +1279,7 @@ mod tests {
 
     #[test]
     fn test_unstable_ops_count() {
-        assert_eq!(UNSTABLE_OPS.len(), 166);
+        assert_eq!(UNSTABLE_OPS.len(), 167);
     }
 
     #[test]

--- a/src/commands/incidents.rs
+++ b/src/commands/incidents.rs
@@ -441,6 +441,75 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_incidents_attachments_list() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        mock_all(&mut s, r#"{"data": []}"#).await;
+        let result = super::attachments_list(&cfg, "inc1").await;
+        assert!(
+            result.is_ok(),
+            "attachments_list should succeed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_incidents_attachments_list_error() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        let _mock = s
+            .mock("GET", mockito::Matcher::Any)
+            .match_query(mockito::Matcher::Any)
+            .with_status(404)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors":["Not Found"]}"#)
+            .create_async()
+            .await;
+        let result = super::attachments_list(&cfg, "missing").await;
+        assert!(result.is_err(), "attachments_list should fail on 404");
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_incidents_attachments_delete() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        let _mock = s
+            .mock("DELETE", "/api/v2/incidents/inc1/attachments/att1")
+            .with_status(204)
+            .create_async()
+            .await;
+        let result = super::attachments_delete(&cfg, "inc1", "att1").await;
+        assert!(
+            result.is_ok(),
+            "attachments_delete should succeed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_incidents_attachments_delete_error() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        let _mock = s
+            .mock("DELETE", "/api/v2/incidents/inc1/attachments/missing")
+            .with_status(404)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors":["Not Found"]}"#)
+            .create_async()
+            .await;
+        let result = super::attachments_delete(&cfg, "inc1", "missing").await;
+        assert!(result.is_err(), "attachments_delete should fail on 404");
+        cleanup_env();
+    }
+
+    #[tokio::test]
     async fn test_incidents_settings_get() {
         let _lock = lock_env().await;
         let mut s = mockito::Server::new_async().await;


### PR DESCRIPTION
## What does this PR do?

Enables the `v2.list_incident_attachments` unstable operation in the DD API client so `pup incidents attachments list` actually works instead of failing with `UnstableOperationDisabledError`.

## Motivation

The command was unusable:

```
Error: failed to list incident attachments:
UnstableOperationDisabledError(... msg: "Operation 'v2.list_incident_attachments' is not enabled" ...)
```

## Additional Notes

- Adds the op to `UNSTABLE_OPS` in `src/client.rs` and bumps the count-assertion test (166 → 167).
- Adds tests for the attachments commands (happy + error paths for both `attachments_list` and `attachments_delete`) — these paths previously had no coverage.

## Checklist

- [x] The code change follows the project conventions
- [x] Tests have been added/updated
- [ ] Documentation has been updated (n/a)
- [x] All CI checks pass
- [x] Code coverage is maintained or improved