### PR TITLE
fix(ci): correct release trust policy for environment-scoped subject

### DIFF
--- a/.github/chainguard/release.sts.yaml
+++ b/.github/chainguard/release.sts.yaml
@@ -1,12 +1,12 @@
-# Policy for: .github/workflows/release-prepare.yml in datadog/pup
+# Policy for: .github/workflows/release-prepare.yml in DataDog/pup
 issuer: https://token.actions.githubusercontent.com
-subject: repo:datadog/pup:ref:refs/heads/main
+subject: repo:DataDog/pup:environment:release
 
 claim_pattern:
   event_name: schedule|workflow_dispatch
-  job_workflow_ref: datadog/pup/\.github/workflows/release-prepare\.yml@refs/heads/main
+  job_workflow_ref: DataDog/pup/\.github/workflows/release-prepare\.yml@refs/heads/main
   ref: refs/heads/main
-  repository: datadog/pup
+  repository: DataDog/pup
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

The `Prepare Release` workflow has been failing with `403 permission denied` during dd-octo-sts token exchange (e.g. [run 26134581691](https://github.com/DataDog/pup/actions/runs/26134581691/job/76953234078)). Two issues in `.github/chainguard/release.sts.yaml`:

1. **Subject mismatch.** The `release` job declares `environment: release`, which causes GitHub Actions to rewrite the OIDC `sub` claim to `repo:DataDog/pup:environment:release` instead of the ref-based form. The policy was matching on the ref-based subject.
2. **Case mismatch.** Claim regex matching is case-sensitive (Go RE2). The policy used lowercase `datadog/pup` but GitHub preserves `DataDog/pup` in claims like `repository` and `job_workflow_ref`.

## Changes

- `.github/chainguard/release.sts.yaml` — subject changed to `repo:DataDog/pup:environment:release`; fixed casing of `repository` and `job_workflow_ref` patterns.

## Security

The `contents: write` permission is now scoped to the `release` environment subject. That environment has a required-reviewer protection rule (verified via `gh api repos/DataDog/pup/environments/release`), so the privileged permission grant is gated by environment protection — consistent with dd-octo-sts guidance on restricting privileged permissions to protected refs/environments.

## Test plan

- [ ] Merge to `main` so dd-octo-sts can pick up the new policy (policies are read from the default branch).
- [ ] Wait ~5 min for the trust policy cache to refresh.
- [ ] Re-run the failed `Prepare Release` job (or wait for the next scheduled run) and confirm token exchange succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)