### PR TITLE
fix(ci): correct release-tag trust policy claims

### DIFF
--- a/.github/chainguard/release-tag.sts.yaml
+++ b/.github/chainguard/release-tag.sts.yaml
@@ -3,9 +3,11 @@ issuer: https://token.actions.githubusercontent.com
 subject: repo:DataDog/pup:pull_request
 
 claim_pattern:
+  base_ref: main
   event_name: pull_request
-  job_workflow_ref: DataDog/pup/\.github/workflows/release-tag\.yml@refs/pull/[0-9]+/merge
-  ref: refs/pull/[0-9]+/merge
+  head_ref: release/v[0-9]+\.[0-9]+\.[0-9]+
+  job_workflow_ref: DataDog/pup/\.github/workflows/release-tag\.yml@refs/heads/main
+  ref: refs/heads/main
   repository: DataDog/pup
 
 permissions:


### PR DESCRIPTION
For `pull_request: closed` events, GitHub OIDC uses the base-branch context, so the actual claims are `ref: refs/heads/main` and `job_workflow_ref: ...@refs/heads/main` — not `refs/pull/N/merge` as the initial policy assumed. Also tighten via `head_ref` regex and `base_ref` for defense in depth.

## What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

## Motivation

<!-- What inspired you to submit this pull request? -->

## Additional Notes

<!-- Anything else we should know when reviewing? -->

## Checklist

- [ ] The code change follows the project conventions (see [CONTRIBUTING.md](../docs/CONTRIBUTING.md))
- [ ] Tests have been added/updated (if applicable)
- [ ] Documentation has been updated (if applicable)
- [ ] All CI checks pass
- [ ] Code coverage is maintained or improved

## Related Issues

<!-- Link related issues here. Use "Closes #123" to automatically close issues when the PR is merged. -->
