### PR TITLE
Enable Observability Pipelines via OAuth

### DIFF
--- a/src/auth/types.rs
+++ b/src/auth/types.rs
@@ -78,6 +78,7 @@ pub fn read_only_scopes() -> Vec<&'static str> {
         "metrics_read",
         "monitors_read",
         "notebooks_read",
+        "observability_pipelines_read",
         "oci_configuration_read",
         "on_call_read",
         "reference_tables_read",
@@ -180,6 +181,10 @@ pub fn default_scopes() -> Vec<&'static str> {
         // Notebooks
         "notebooks_read",
         "notebooks_write",
+        // Observability Pipelines
+        "observability_pipelines_read",
+        "observability_pipelines_deploy",
+        "observability_pipelines_delete",
         // OCI
         "oci_configuration_edit",
         "oci_configuration_read",
@@ -298,6 +303,10 @@ mod tests {
         assert!(scopes.contains(&"workflows_read"));
         assert!(scopes.contains(&"workflows_run"));
         assert!(scopes.contains(&"workflows_write"));
+        // Observability Pipelines
+        assert!(scopes.contains(&"observability_pipelines_read"));
+        assert!(scopes.contains(&"observability_pipelines_deploy"));
+        assert!(scopes.contains(&"observability_pipelines_delete"));
     }
 
     #[test]

--- a/src/commands/obs_pipelines.rs
+++ b/src/commands/obs_pipelines.rs
@@ -9,8 +9,7 @@ use crate::formatter;
 use crate::util;
 
 fn make_api(cfg: &Config) -> ObservabilityPipelinesAPI {
-    // Observability Pipelines does not support OAuth — API key auth only.
-    crate::make_api_no_auth!(ObservabilityPipelinesAPI, cfg)
+    crate::make_api!(ObservabilityPipelinesAPI, cfg)
 }
 
 pub async fn list(cfg: &Config, limit: i64) -> Result<()> {


### PR DESCRIPTION
Closes #521.

## Summary

Two changes that, together with in-flight server-side work, will make `pup obs-pipelines` work via OAuth instead of requiring `DD_API_KEY` + `DD_APP_KEY`:

1. **`src/commands/obs_pipelines.rs`** — switch the OP commands from `make_api_no_auth!` to `make_api!`, so the OAuth bearer token is sent when one is available (falling back to API-key headers otherwise). Same pattern as PR #342, expressed via the macro that subsumed the old `make_bearer_client` helper.
2. **`src/auth/types.rs`** — add `observability_pipelines_read`, `observability_pipelines_deploy`, and `observability_pipelines_delete` to `default_scopes()`, and `observability_pipelines_read` to `read_only_scopes()`, so `pup auth login` requests them on the consent screen. Updated `test_default_scopes()` count (85 → 88) and added containment assertions.

## Why this was needed

Today `pup obs-pipelines list` (and every other OP subcommand) returns **401 Unauthorized** for OAuth-authenticated users. Two reasons:

- `make_api_no_auth!` was suppressing the bearer header on every OP call (the comment said _"Observability Pipelines does not support OAuth — API key auth only"_). API-key headers were the only auth ever sent.
- Even if the bearer header had been sent, the OAuth consent screen never requested `observability_pipelines_*` scopes, so the token wouldn't have carried them anyway.

`agents/observability-pipelines.md` documents `observability_pipelines_{read,deploy,delete}` as required for these endpoints, but none of those scope names appeared anywhere in `src/auth/types.rs`. This PR closes both halves of that gap.

## Test plan

- [x] `cargo check --bin pup` passes
- [x] `cargo test --bin pup auth::types::` — all 9 tests pass with updated assertions
- [x] Built release binary locally; existing token store loads cleanly
- [x] Verified: with the patched binary + unchanged server side, OAuth login fails with `invalid_scope` (confirming the unsupported-scope hypothesis)
- [x] After server-side OAuth enablement deploys, and after pup's OAuth client gets the OP scopes: re-authenticate with this PR's binary and confirm `pup obs-pipelines list` returns pipelines instead of 401