### PR TITLE
Add OAuth support to workflows commands

### DIFF
--- a/src/auth/types.rs
+++ b/src/auth/types.rs
@@ -228,6 +228,7 @@ pub fn default_scopes() -> Vec<&'static str> {
         "user_access_read",
         // Workflows
         "workflows_read",
+        "workflows_run",
         "workflows_write",
     ]
 }
@@ -275,7 +276,7 @@ mod tests {
     #[test]
     fn test_default_scopes() {
         let scopes = default_scopes();
-        assert_eq!(scopes.len(), 87);
+        assert_eq!(scopes.len(), 88);
         assert!(scopes.contains(&"dashboards_read"));
         assert!(scopes.contains(&"monitors_read"));
         assert!(scopes.contains(&"logs_read_data"));
@@ -296,6 +297,7 @@ mod tests {
         assert!(scopes.contains(&"gcp_configuration_read"));
         // Workflows
         assert!(scopes.contains(&"workflows_read"));
+        assert!(scopes.contains(&"workflows_run"));
         assert!(scopes.contains(&"workflows_write"));
     }
 

--- a/src/auth/types.rs
+++ b/src/auth/types.rs
@@ -96,6 +96,7 @@ pub fn read_only_scopes() -> Vec<&'static str> {
         "timeseries_query",
         "usage_read",
         "user_access_read",
+        "workflows_read",
     ]
 }
 
@@ -225,6 +226,9 @@ pub fn default_scopes() -> Vec<&'static str> {
         "usage_read",
         // Users
         "user_access_read",
+        // Workflows
+        "workflows_read",
+        "workflows_write",
     ]
 }
 
@@ -271,7 +275,7 @@ mod tests {
     #[test]
     fn test_default_scopes() {
         let scopes = default_scopes();
-        assert_eq!(scopes.len(), 85);
+        assert_eq!(scopes.len(), 87);
         assert!(scopes.contains(&"dashboards_read"));
         assert!(scopes.contains(&"monitors_read"));
         assert!(scopes.contains(&"logs_read_data"));
@@ -290,6 +294,9 @@ mod tests {
         assert!(scopes.contains(&"on_call_write"));
         assert!(scopes.contains(&"aws_configuration_read"));
         assert!(scopes.contains(&"gcp_configuration_read"));
+        // Workflows
+        assert!(scopes.contains(&"workflows_read"));
+        assert!(scopes.contains(&"workflows_write"));
     }
 
     #[test]

--- a/src/auth/types.rs
+++ b/src/auth/types.rs
@@ -276,7 +276,6 @@ mod tests {
     #[test]
     fn test_default_scopes() {
         let scopes = default_scopes();
-        assert_eq!(scopes.len(), 88);
         assert!(scopes.contains(&"dashboards_read"));
         assert!(scopes.contains(&"monitors_read"));
         assert!(scopes.contains(&"logs_read_data"));

--- a/src/commands/workflows.rs
+++ b/src/commands/workflows.rs
@@ -63,7 +63,7 @@ pub async fn delete(cfg: &Config, workflow_id: &str) -> Result<()> {
 }
 
 // ---------------------------------------------------------------------------
-// Workflow execution (API trigger only — requires DD_API_KEY + DD_APP_KEY)
+// Workflow execution
 // ---------------------------------------------------------------------------
 
 pub async fn run(

--- a/src/commands/workflows.rs
+++ b/src/commands/workflows.rs
@@ -11,11 +11,11 @@ use crate::formatter::{self, Metadata};
 use crate::util;
 
 // ---------------------------------------------------------------------------
-// Helper: build a WorkflowAutomationAPI (API key auth only)
+// Helper: build a WorkflowAutomationAPI
 // ---------------------------------------------------------------------------
 
 fn make_api(cfg: &Config) -> WorkflowAutomationAPI {
-    crate::make_api_no_auth!(WorkflowAutomationAPI, cfg)
+    crate::make_api!(WorkflowAutomationAPI, cfg)
 }
 
 // ---------------------------------------------------------------------------
@@ -74,7 +74,7 @@ pub async fn run(
     wait: bool,
     timeout: &str,
 ) -> Result<()> {
-    let api = crate::make_api_no_auth!(WorkflowAutomationAPI, cfg);
+    let api = crate::make_api!(WorkflowAutomationAPI, cfg);
 
     let input_payload: Option<BTreeMap<String, serde_json::Value>> = match (&payload, &payload_file)
     {
@@ -132,7 +132,7 @@ pub async fn run(
 
         tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
-        let api = crate::make_api_no_auth!(WorkflowAutomationAPI, cfg);
+        let api = crate::make_api!(WorkflowAutomationAPI, cfg);
         let status = api
             .get_workflow_instance(workflow_id.to_string(), instance_id.clone())
             .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -2728,8 +2728,13 @@ enum Commands {
     ///   pup workflows instances cancel <workflow-id> <instance-id>
     ///
     /// AUTHENTICATION:
-    ///   All workflow commands require DD_API_KEY + DD_APP_KEY.
-    ///   OAuth2 bearer tokens are not supported for workflow operations at this time.
+    ///   Workflow CRUD (`workflows get/create/update/delete`) and
+    ///   workflow instance commands (`workflows instances *`) accept
+    ///   OAuth2 (`pup auth login`) or DD_API_KEY + DD_APP_KEY.
+    ///   `workflows run` is API-key-only: it triggers a workflow via
+    ///   the API trigger endpoint, which requires DD_API_KEY + DD_APP_KEY.
+    ///   `workflows connections *` is API-key-only at this time, pending
+    ///   server-side OAuth enablement on the action-connections API.
     #[command(verbatim_doc_comment)]
     Workflows {
         #[command(subcommand)]
@@ -14414,13 +14419,6 @@ async fn main_inner() -> anyhow::Result<()> {
         },
         // --- Workflows ---
         Commands::Workflows { action } => {
-            cfg.validate_api_and_app_keys().map_err(|_| {
-                anyhow::anyhow!(
-                    "workflow commands require DD_API_KEY and DD_APP_KEY with workflow_* scopes\n\
-                     OAuth2 bearer tokens are not supported for workflow operations.\n\
-                     See: https://docs.datadoghq.com/api/latest/workflow-automation"
-                )
-            })?;
             match action {
                 WorkflowActions::Get { workflow_id } => {
                     commands::workflows::get(&cfg, &workflow_id).await?;
@@ -14441,6 +14439,13 @@ async fn main_inner() -> anyhow::Result<()> {
                     wait,
                     timeout,
                 } => {
+                    cfg.validate_api_and_app_keys().map_err(|_| {
+                        anyhow::anyhow!(
+                            "`workflows run` triggers a workflow via the API trigger \
+                             endpoint, which requires DD_API_KEY + DD_APP_KEY.\n\
+                             See: https://docs.datadoghq.com/api/latest/workflow-automation"
+                        )
+                    })?;
                     commands::workflows::run(
                         &cfg,
                         &workflow_id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -14418,79 +14418,68 @@ async fn main_inner() -> anyhow::Result<()> {
             AuthActions::Test => commands::test::run(&cfg)?,
         },
         // --- Workflows ---
-        Commands::Workflows { action } => {
-            match action {
-                WorkflowActions::Get { workflow_id } => {
-                    commands::workflows::get(&cfg, &workflow_id).await?;
-                }
-                WorkflowActions::Create { file } => {
-                    commands::workflows::create(&cfg, &file).await?;
-                }
-                WorkflowActions::Update { workflow_id, file } => {
-                    commands::workflows::update(&cfg, &workflow_id, &file).await?;
-                }
-                WorkflowActions::Delete { workflow_id } => {
-                    commands::workflows::delete(&cfg, &workflow_id).await?;
-                }
-                WorkflowActions::Run {
-                    workflow_id,
-                    payload,
-                    payload_file,
-                    wait,
-                    timeout,
-                } => {
-                    commands::workflows::run(
-                        &cfg,
-                        &workflow_id,
-                        payload,
-                        payload_file,
-                        wait,
-                        &timeout,
-                    )
-                    .await?;
-                }
-                WorkflowActions::Instances { action } => match action {
-                    WorkflowInstanceActions::List {
-                        workflow_id,
-                        limit,
-                        page,
-                    } => {
-                        commands::workflows::instance_list(&cfg, &workflow_id, limit, page).await?;
-                    }
-                    WorkflowInstanceActions::Get {
-                        workflow_id,
-                        instance_id,
-                    } => {
-                        commands::workflows::instance_get(&cfg, &workflow_id, &instance_id).await?;
-                    }
-                    WorkflowInstanceActions::Cancel {
-                        workflow_id,
-                        instance_id,
-                    } => {
-                        commands::workflows::instance_cancel(&cfg, &workflow_id, &instance_id)
-                            .await?;
-                    }
-                },
-                WorkflowActions::Connections { action } => match action {
-                    WorkflowConnectionActions::Get { connection_id } => {
-                        commands::workflows::connections_get(&cfg, &connection_id).await?;
-                    }
-                    WorkflowConnectionActions::Create { file } => {
-                        commands::workflows::connections_create(&cfg, &file).await?;
-                    }
-                    WorkflowConnectionActions::Update {
-                        connection_id,
-                        file,
-                    } => {
-                        commands::workflows::connections_update(&cfg, &connection_id, &file)
-                            .await?;
-                    }
-                    WorkflowConnectionActions::Delete { connection_id } => {
-                        commands::workflows::connections_delete(&cfg, &connection_id).await?;
-                    }
-                },
+        Commands::Workflows { action } => match action {
+            WorkflowActions::Get { workflow_id } => {
+                commands::workflows::get(&cfg, &workflow_id).await?;
             }
-        }
+            WorkflowActions::Create { file } => {
+                commands::workflows::create(&cfg, &file).await?;
+            }
+            WorkflowActions::Update { workflow_id, file } => {
+                commands::workflows::update(&cfg, &workflow_id, &file).await?;
+            }
+            WorkflowActions::Delete { workflow_id } => {
+                commands::workflows::delete(&cfg, &workflow_id).await?;
+            }
+            WorkflowActions::Run {
+                workflow_id,
+                payload,
+                payload_file,
+                wait,
+                timeout,
+            } => {
+                commands::workflows::run(&cfg, &workflow_id, payload, payload_file, wait, &timeout)
+                    .await?;
+            }
+            WorkflowActions::Instances { action } => match action {
+                WorkflowInstanceActions::List {
+                    workflow_id,
+                    limit,
+                    page,
+                } => {
+                    commands::workflows::instance_list(&cfg, &workflow_id, limit, page).await?;
+                }
+                WorkflowInstanceActions::Get {
+                    workflow_id,
+                    instance_id,
+                } => {
+                    commands::workflows::instance_get(&cfg, &workflow_id, &instance_id).await?;
+                }
+                WorkflowInstanceActions::Cancel {
+                    workflow_id,
+                    instance_id,
+                } => {
+                    commands::workflows::instance_cancel(&cfg, &workflow_id, &instance_id).await?;
+                }
+            },
+            WorkflowActions::Connections { action } => match action {
+                WorkflowConnectionActions::Get { connection_id } => {
+                    commands::workflows::connections_get(&cfg, &connection_id).await?;
+                }
+                WorkflowConnectionActions::Create { file } => {
+                    commands::workflows::connections_create(&cfg, &file).await?;
+                }
+                WorkflowConnectionActions::Update {
+                    connection_id,
+                    file,
+                } => {
+                    commands::workflows::connections_update(&cfg, &connection_id, &file).await?;
+                }
+                WorkflowConnectionActions::Delete { connection_id } => {
+                    commands::workflows::connections_delete(&cfg, &connection_id).await?;
+                }
+            },
+        },
         // --- LLM Observability ---
         Commands::LlmObs { action } => {
             cfg.validate_auth()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2708,7 +2708,7 @@ enum Commands {
     /// CAPABILITIES:
     ///   • Get workflow details
     ///   • Create, update, and delete workflows
-    ///   • Execute workflows via API trigger (requires DD_API_KEY + DD_APP_KEY)
+    ///   • Execute workflows via API trigger
     ///   • List, inspect, and cancel workflow instances (executions)
     ///
     /// EXAMPLES:
@@ -2728,13 +2728,12 @@ enum Commands {
     ///   pup workflows instances cancel <workflow-id> <instance-id>
     ///
     /// AUTHENTICATION:
-    ///   Workflow CRUD (`workflows get/create/update/delete`) and
-    ///   workflow instance commands (`workflows instances *`) accept
-    ///   OAuth2 (`pup auth login`) or DD_API_KEY + DD_APP_KEY.
-    ///   `workflows run` is API-key-only: it triggers a workflow via
-    ///   the API trigger endpoint, which requires DD_API_KEY + DD_APP_KEY.
-    ///   `workflows connections *` is API-key-only at this time, pending
-    ///   server-side OAuth enablement on the action-connections API.
+    ///   Workflow CRUD (`workflows get/create/update/delete`),
+    ///   `workflows run`, and `workflows instances *` accept OAuth2
+    ///   (`pup auth login`) or DD_API_KEY + DD_APP_KEY.
+    ///   `workflows connections *` requires DD_API_KEY + DD_APP_KEY
+    ///   pending server-side OAuth enablement on the action-connections
+    ///   API.
     #[command(verbatim_doc_comment)]
     Workflows {
         #[command(subcommand)]
@@ -4264,10 +4263,11 @@ enum WorkflowActions {
     },
     /// Delete a workflow
     Delete { workflow_id: String },
-    /// Execute a workflow via API trigger (requires DD_API_KEY + DD_APP_KEY)
+    /// Execute a workflow via API trigger
     ///
-    /// The workflow must have an API trigger configured.
-    /// OAuth tokens are not supported — this command requires API key authentication.
+    /// The workflow must have an API trigger configured. Accepts OAuth2
+    /// (`pup auth login`, requires the `workflows_run` scope) or
+    /// DD_API_KEY + DD_APP_KEY.
     #[command(verbatim_doc_comment)]
     Run {
         workflow_id: String,
@@ -14439,13 +14439,6 @@ async fn main_inner() -> anyhow::Result<()> {
                     wait,
                     timeout,
                 } => {
-                    cfg.validate_api_and_app_keys().map_err(|_| {
-                        anyhow::anyhow!(
-                            "`workflows run` triggers a workflow via the API trigger \
-                             endpoint, which requires DD_API_KEY + DD_APP_KEY.\n\
-                             See: https://docs.datadoghq.com/api/latest/workflow-automation"
-                        )
-                    })?;
                     commands::workflows::run(
                         &cfg,
                         &workflow_id,


### PR DESCRIPTION
## Summary

Pup's workflow commands now use OAuth bearer when available, falling back to `DD_API_KEY` + `DD_APP_KEY`. The Datadog Workflow Automation API has accepted OAuth on the public workflow routes for a while; the pup-side helpers and pre-flight guards were the only thing still treating workflows as API-key-only.

## Changes

- `src/commands/workflows.rs`: workflow CRUD and instance call sites flipped to `make_api!` (OAuth-with-fallback). The action-connections helper stays on `make_api_no_auth!` for now -- see "What's not in scope".
- `src/main.rs`: drop the top-level "API keys required" pre-flight for the Workflows subcommand and the matching guard on `Run`. Update the AUTHENTICATION doc-comments to reflect what works via OAuth.
- `src/auth/types.rs`: add `workflows_read`, `workflows_run`, `workflows_write` to `default_scopes()` and `workflows_read` to `read_only_scopes()`.

## What's not in scope

`pup workflows connections *` (the action-connections API) stays API-key-only. That surface still only accepts API+App key auth server-side; a separate server-side change to add OAuth there is in flight but out of scope here.

## End-to-end validation (prod)

Real HTTP probes against `api.datadoghq.com` with an OAuth-only token carrying `workflows_read`, `workflows_run`, `workflows_write`:

| Probe | Required perm | HTTP | What it proves |
|---|---|---|---|
| `workflows get <bogus>` | workflows_read | 404 "workflow not found" | OAuth admit + perm check pass |
| `workflows instances list <bogus>` | workflows_read | 200 (empty data) | full successful round-trip via OAuth |
| `workflows instances get <bogus> <bogus>` | workflows_read | 404 "instance not found" | OAuth healthy |
| `workflows instances cancel <bogus> <bogus>` | workflows_run | 404 "instance not found" | Run scope works via OAuth |
| `workflows delete <bogus>` | workflows_write | 404 "workflow not found" | Write scope works via OAuth |
| `workflows connections get <bogus>` | (connections API) | 401 Unauthorized | as expected -- the documented non-OAuth surface |

`workflows run` and `workflows {create,update}` weren't probed because they would trigger or mutate real workflows; their underlying scopes (`workflows_run` and `workflows_write`) are validated by cancel and delete respectively.

## Test plan

- [x] \`cargo build --release --bin pup\` -- clean
- [x] \`cargo test --bin pup auth::types::\` -- 9/9 pass
- [x] End-to-end probe matrix above



https://datadoghq.atlassian.net/browse/DAL-551