### PR TITLE
Allow OAuth on pup security restriction-policies

### DIFF
--- a/src/commands/security.rs
+++ b/src/commands/security.rs
@@ -645,7 +645,7 @@ pub async fn asm_exclusions_delete(cfg: &Config, exclusion_filter_id: &str) -> R
 // ---- Restriction Policies ----
 
 pub async fn restriction_policy_get(cfg: &Config, resource_id: &str) -> Result<()> {
-    let api = crate::make_api_no_auth!(RestrictionPoliciesAPI, cfg);
+    let api = crate::make_api!(RestrictionPoliciesAPI, cfg);
     let resp = api
         .get_restriction_policy(resource_id.to_string())
         .await
@@ -655,7 +655,7 @@ pub async fn restriction_policy_get(cfg: &Config, resource_id: &str) -> Result<(
 
 pub async fn restriction_policy_update(cfg: &Config, resource_id: &str, file: &str) -> Result<()> {
     let body: RestrictionPolicyUpdateRequest = util::read_json_file(file)?;
-    let api = crate::make_api_no_auth!(RestrictionPoliciesAPI, cfg);
+    let api = crate::make_api!(RestrictionPoliciesAPI, cfg);
     let resp = api
         .update_restriction_policy(
             resource_id.to_string(),
@@ -668,7 +668,7 @@ pub async fn restriction_policy_update(cfg: &Config, resource_id: &str, file: &s
 }
 
 pub async fn restriction_policy_delete(cfg: &Config, resource_id: &str) -> Result<()> {
-    let api = crate::make_api_no_auth!(RestrictionPoliciesAPI, cfg);
+    let api = crate::make_api!(RestrictionPoliciesAPI, cfg);
     api.delete_restriction_policy(resource_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete restriction policy: {e:?}"))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4566,7 +4566,26 @@ enum SecurityActions {
         action: AsmExclusionActions,
     },
     /// Manage resource restriction policies
-    #[command(name = "restriction-policies")]
+    ///
+    /// Restriction policies live at `/api/v2/restriction_policy/{resource}`
+    /// where `{resource}` is `<type>:<id>` (ex: `dashboard:abc-123`,
+    /// `monitor:12345`). The server accepts OAuth2 or DD_API_KEY +
+    /// DD_APP_KEY.
+    ///
+    /// The required OAuth scope depends on the resource type embedded in
+    /// the resource ID. The server enforces the same permission a user would
+    /// need to view/edit the underlying resource (ex: `dashboards_read` for
+    /// a `dashboard:*` GET, `monitors_write` for a `monitor:*` POST).
+    ///
+    /// Common types covered by pup's default OAuth scopes today: dashboard,
+    /// monitor, slo, workflow, notebook, security-rule, logs-archive,
+    /// rum-application, reference-table, case-management-project,
+    /// on-call-*, status-page, integration-*. Other resource types (ex:
+    /// connection, app-builder-app, obs-pipelines-*, spreadsheet,
+    /// feature-flag, agent-builder-agent, product-analytics-*) require
+    /// scopes pup does not yet request; for those, use DD_API_KEY +
+    /// DD_APP_KEY.
+    #[command(name = "restriction-policies", verbatim_doc_comment)]
     RestrictionPolicies {
         #[command(subcommand)]
         action: RestrictionPolicyActions,


### PR DESCRIPTION
## Summary

`pup security restriction-policies {get,update,delete}` fails with `401 Unauthorized` for users who authenticated via `pup auth login` and don't have `DD_API_KEY` + `DD_APP_KEY` exported. The Datadog API behind these commands already accepts OAuth bearer tokens server-side -- this is purely a pup-side gap. The three callsites use `make_api_no_auth!`, which skips bearer attachment, so the request goes out with no credentials at all.

Fix: flip the three callsites in `src/commands/security.rs` from `make_api_no_auth!` to `make_api!`.

## Scope coverage

A restriction policy URL is `/api/v2/restriction_policy/{type}:{id}`. The server enforces the same permission a caller would need to view/edit the underlying resource, which auto-derives into the matching OAuth scope.

Common resource types (dashboard, monitor, slo, workflow, notebook, security-rule, on-call-*, logs-archive, status-page, integration*, and a handful more) are covered by pup's default OAuth scopes today and will Just Work after this change. Niche types (connection, app-builder-app, obs-pipelines-*, feature-flag, agent-builder-agent, product-analytics-*, and others) require scopes pup doesn't request by default and will still 403 under OAuth -- callers fall back to DD_API_KEY + DD_APP_KEY. See `pup security restriction-policies --help` for the full breakdown.

Getting every type working under OAuth would mean adding ~30 new scopes to `default_scopes()`. Not doing that here: would bloat the consent page and broaden the power of every pup access token for a niche case. Plan is to add incrementally as users ask.

## End-to-end validation (prod, OAuth-only token)

Real HTTP probes against `api.datadoghq.com` with a fresh `pup auth login` token, no `DD_API_KEY` / `DD_APP_KEY` exported:

| Probe | HTTP | What it proves |
|---|---|---|
| `get dashboard:hap-e47-uv7` (real entry) | 200 with 13 team-editor + org-viewer bindings | Bearer attaches; covered type -> success |
| `get monitor:bogus-no-policy` (no entry) | 200 empty bindings | Same -- different covered type |
| `get {connection,app-builder-app,feature-flag}:bogus` (3 uncovered types) | 403 with explicit message: "needs one of the following permissions: [<scope>]" | Server admits OAuth, per-type permission check fires as expected |
| `get no-colon-here` (malformed) | 400 "Invalid resource: ... is not in a valid format" | Format validation healthy |

Before this PR, every probe returned 401 (no bearer attached, no API key in env). `update` and `delete` not probed against the real dashboard to avoid mutating it; their write-scope family is exercised elsewhere in pup.

`cargo build`, `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test restriction_policy` all clean.

Tracking: https://datadoghq.atlassian.net/browse/DAL-708