### PR TITLE
fix(cicd): fix aggregate commands, add --level to events search

### DIFF
--- a/agents/cicd.md
+++ b/agents/cicd.md
@@ -75,43 +75,89 @@ pup cicd tests aggregate \
   --from="7d"
 ```
 
-#### List Flaky Tests
+#### Search Flaky Tests
 ```bash
-pup cicd tests flaky \
-  --service="my-service"
+pup cicd flaky-tests search \
+  --query="flaky_test_state:active @test.service:my-service" \
+  --sort="-pipelines_duration_lost"
+```
+
+#### Update Flaky Test States
+```bash
+# Quarantine a flaky test (suppress CI failures while a fix is prepared)
+# body.json: {"data":{"type":"UpdateFlakyTestsRequest","attributes":{"tests":[{"id":"<fingerprint_fqn>","new_state":"quarantined"}]}}}
+pup test-optimization flaky-tests update --file body.json
+```
+
+States: `quarantined` (suppress failures), `disabled` (skip test), `fixed` (mark resolved), `active` (restore).
+All state changes are reversible — set `new_state: active` to undo.
+
+### Test Optimization Settings
+
+#### Get Service Settings
+Returns enabled/disabled state for ITR, EFD, ATR, Code Coverage, etc. per service.
+
+```bash
+# body.json: {"data":{"type":"test_optimization_get_service_settings_request","attributes":{"service":"my-service","env":"production"}}}
+pup test-optimization settings get --file body.json
+```
+
+#### Update Service Settings
+```bash
+# body.json: {"data":{"type":"test_optimization_update_service_settings_request","attributes":{"service":"my-service","env":"production","itr_enabled":true,"flaky_test_management_enabled":true}}}
+pup test-optimization settings update --file body.json
+```
+
+#### Get Flaky Test Management Policies
+Returns FTM policy rules (auto-quarantine thresholds, quarantine duration) for a repository.
+
+```bash
+# body.json: {"data":{"type":"test_optimization_get_flaky_tests_management_policies_request","attributes":{"repository_id":"github.com/org/repo"}}}
+pup test-optimization flaky-tests policies get --file body.json
 ```
 
 ### Pipeline Visibility
 
 #### Search Pipeline Events
+Use `pup cicd events search` to query pipeline events. Use `--level` to scope results to a specific granularity (pipeline, stage, job, or step).
+
 ```bash
-# Search all pipeline events
-pup cicd pipelines search \
+# Search all pipeline-level events in the last hour
+pup cicd events search \
   --query="*" \
   --from="1h" \
   --to="now"
 ```
 
-Search failed pipelines:
+Search failed job-level events on a branch:
 ```bash
-pup cicd pipelines search \
-  --query="@ci.status:error" \
+pup cicd events search \
+  --query="@ci.status:error @git.branch:my-feature" \
+  --level="job" \
   --from="24h"
 ```
 
-Search pipelines for specific repository:
+Search pipeline events for a specific repository:
 ```bash
-pup cicd pipelines search \
-  --query="@git.repository.name:my-repo" \
+pup cicd events search \
+  --query="@git.repository.id_v2:\"github.com/org/repo\"" \
   --from="7d"
 ```
 
 #### Aggregate Pipeline Analytics
 ```bash
-# Get pipeline success rate by branch
-pup cicd pipelines aggregate \
+# Count failed pipelines grouped by branch
+pup cicd events aggregate \
+  --query="@ci.status:error" \
   --compute="count" \
   --group-by="@git.branch" \
+  --from="7d"
+
+# P95 pipeline duration by pipeline name
+pup cicd events aggregate \
+  --query="*" \
+  --compute="percentile(@duration, 95)" \
+  --group-by="@ci.pipeline.name" \
   --from="7d"
 ```
 
@@ -307,14 +353,15 @@ pup cicd dora metrics \
 
 ### "Show me flaky tests for my-service"
 ```bash
-pup cicd tests flaky \
-  --service="my-service"
+pup cicd flaky-tests search \
+  --query="flaky_test_state:active @test.service:my-service" \
+  --sort="-pipelines_duration_lost"
 ```
 
 ### "List all failed pipeline runs for main branch"
 ```bash
-pup cicd pipelines search \
-  --query="@ci.status:error AND @git.branch:main" \
+pup cicd events search \
+  --query="@ci.status:error @git.branch:main" \
   --from="7d"
 ```
 

--- a/skills/dd-pup/SKILL.md
+++ b/skills/dd-pup/SKILL.md
@@ -31,6 +31,11 @@ Pup CLI for Datadog API operations. Supports OAuth2 and API key auth.
 | Find probe-able methods | `pup symdb search --service my-svc --query MyController --view probe-locations` |
 | Check auth | `pup auth status` |
 | Refresh token | `pup auth refresh` |
+| Search failing CI jobs | `pup cicd events search --query "@ci.status:error" --level job --from 24h` |
+| Count CI failures per branch | `pup cicd events aggregate --query "@ci.status:error" --compute count --group-by "@git.branch" --from 24h` |
+| List active flaky tests | `pup cicd flaky-tests search --query "flaky_test_state:active" --sort "-pipelines_duration_lost"` |
+| Quarantine a flaky test | `pup test-optimization flaky-tests update --file body.json` |
+| Get test optimization settings | `pup test-optimization settings get --file body.json` |
 
 ## Prerequisites
 

--- a/src/commands/cicd.rs
+++ b/src/commands/cicd.rs
@@ -10,9 +10,11 @@ use datadog_api_client::datadogV2::api_test_optimization::{
     SearchFlakyTestsOptionalParams, TestOptimizationAPI,
 };
 use datadog_api_client::datadogV2::model::{
-    CIAppPipelineEventsRequest, CIAppPipelinesQueryFilter, CIAppQueryPageOptions, CIAppSort,
-    CIAppTestEventsRequest, CIAppTestsQueryFilter, DORADeploymentPatchRequest,
-    FlakyTestsSearchRequest, UpdateFlakyTestsRequest,
+    CIAppAggregationFunction, CIAppCompute, CIAppPipelineEventsRequest,
+    CIAppPipelinesAggregateRequest, CIAppPipelinesGroupBy, CIAppPipelinesQueryFilter,
+    CIAppQueryPageOptions, CIAppSort, CIAppTestEventsRequest, CIAppTestsAggregateRequest,
+    CIAppTestsGroupBy, CIAppTestsQueryFilter, DORADeploymentPatchRequest, FlakyTestsSearchRequest,
+    UpdateFlakyTestsRequest,
 };
 
 use crate::config::Config;
@@ -30,14 +32,8 @@ pub async fn pipelines_list(
 ) -> Result<()> {
     let api = crate::make_api!(CIVisibilityPipelinesAPI, cfg);
 
-    let from_ms = util::parse_time_to_unix_millis(&from)?;
-    let to_ms = util::parse_time_to_unix_millis(&to)?;
-    let from_str = chrono::DateTime::from_timestamp_millis(from_ms)
-        .ok_or_else(|| anyhow::anyhow!("--from value {from_ms}ms is out of representable range"))?
-        .to_rfc3339();
-    let to_str = chrono::DateTime::from_timestamp_millis(to_ms)
-        .ok_or_else(|| anyhow::anyhow!("--to value {to_ms}ms is out of representable range"))?
-        .to_rfc3339();
+    let from_str = util::parse_time_to_datetime(&from)?.to_rfc3339();
+    let to_str = util::parse_time_to_datetime(&to)?.to_rfc3339();
 
     let mut query_parts: Vec<String> = Vec::new();
     if let Some(q) = query {
@@ -102,17 +98,12 @@ pub async fn events_search(
     to: String,
     limit: i32,
     sort: String,
+    level: String,
 ) -> Result<()> {
     let api = crate::make_api!(CIVisibilityPipelinesAPI, cfg);
 
-    let from_ms = util::parse_time_to_unix_millis(&from)?;
-    let to_ms = util::parse_time_to_unix_millis(&to)?;
-    let from_str = chrono::DateTime::from_timestamp_millis(from_ms)
-        .ok_or_else(|| anyhow::anyhow!("--from value {from_ms}ms is out of representable range"))?
-        .to_rfc3339();
-    let to_str = chrono::DateTime::from_timestamp_millis(to_ms)
-        .ok_or_else(|| anyhow::anyhow!("--to value {to_ms}ms is out of representable range"))?
-        .to_rfc3339();
+    let from_str = util::parse_time_to_datetime(&from)?.to_rfc3339();
+    let to_str = util::parse_time_to_datetime(&to)?.to_rfc3339();
 
     let sort_val = match sort.as_str() {
         "asc" | "timestamp" => CIAppSort::TIMESTAMP_ASCENDING,
@@ -122,10 +113,22 @@ pub async fn events_search(
         ),
     };
 
+    let level = level.to_lowercase();
+    let effective_query = match level.as_str() {
+        "pipeline" => query,
+        "stage" | "job" | "step" => match query.trim() {
+            "" => format!("@ci.level:{level}"),
+            q => format!("@ci.level:{level} {q}"),
+        },
+        other => anyhow::bail!(
+            "invalid --level value: {other:?}\nExpected: pipeline, stage, job, or step"
+        ),
+    };
+
     let filter = CIAppPipelinesQueryFilter::new()
         .from(from_str)
         .to(to_str)
-        .query(query);
+        .query(effective_query);
 
     let body = CIAppPipelineEventsRequest::new()
         .filter(filter)
@@ -140,28 +143,36 @@ pub async fn events_search(
     formatter::output(cfg, &resp)
 }
 
-pub async fn events_aggregate(cfg: &Config, query: String, from: String, to: String) -> Result<()> {
+pub async fn events_aggregate(
+    cfg: &Config,
+    query: String,
+    from: String,
+    to: String,
+    compute: String,
+    group_by: Option<String>,
+    limit: i64,
+) -> Result<()> {
     let api = crate::make_api!(CIVisibilityPipelinesAPI, cfg);
 
-    let from_ms = util::parse_time_to_unix_millis(&from)?;
-    let to_ms = util::parse_time_to_unix_millis(&to)?;
-    let from_str = chrono::DateTime::from_timestamp_millis(from_ms)
-        .ok_or_else(|| anyhow::anyhow!("--from value {from_ms}ms is out of representable range"))?
-        .to_rfc3339();
-    let to_str = chrono::DateTime::from_timestamp_millis(to_ms)
-        .ok_or_else(|| anyhow::anyhow!("--to value {to_ms}ms is out of representable range"))?
-        .to_rfc3339();
+    let from_str = util::parse_time_to_datetime(&from)?.to_rfc3339();
+    let to_str = util::parse_time_to_datetime(&to)?.to_rfc3339();
+    let compute_spec = build_ci_compute_spec(&compute)?;
 
     let filter = CIAppPipelinesQueryFilter::new()
         .from(from_str)
         .to(to_str)
         .query(query);
 
-    let body = CIAppPipelineEventsRequest::new().filter(filter);
+    let mut body = CIAppPipelinesAggregateRequest::new()
+        .compute(vec![compute_spec])
+        .filter(filter);
 
-    let params = SearchCIAppPipelineEventsOptionalParams::default().body(body);
+    if let Some(gb) = group_by {
+        body = body.group_by(vec![CIAppPipelinesGroupBy::new(gb).limit(limit)]);
+    }
+
     let resp = api
-        .search_ci_app_pipeline_events(params)
+        .aggregate_ci_app_pipeline_events(body)
         .await
         .map_err(|e| anyhow::anyhow!("failed to aggregate pipeline events: {e:?}"))?;
     formatter::output(cfg, &resp)
@@ -176,14 +187,8 @@ pub async fn tests_search(
 ) -> Result<()> {
     let api = crate::make_api!(CIVisibilityTestsAPI, cfg);
 
-    let from_ms = util::parse_time_to_unix_millis(&from)?;
-    let to_ms = util::parse_time_to_unix_millis(&to)?;
-    let from_str = chrono::DateTime::from_timestamp_millis(from_ms)
-        .ok_or_else(|| anyhow::anyhow!("--from value {from_ms}ms is out of representable range"))?
-        .to_rfc3339();
-    let to_str = chrono::DateTime::from_timestamp_millis(to_ms)
-        .ok_or_else(|| anyhow::anyhow!("--to value {to_ms}ms is out of representable range"))?
-        .to_rfc3339();
+    let from_str = util::parse_time_to_datetime(&from)?.to_rfc3339();
+    let to_str = util::parse_time_to_datetime(&to)?.to_rfc3339();
 
     let filter = CIAppTestsQueryFilter::new()
         .from(from_str)
@@ -203,28 +208,36 @@ pub async fn tests_search(
     formatter::output(cfg, &resp)
 }
 
-pub async fn tests_aggregate(cfg: &Config, query: String, from: String, to: String) -> Result<()> {
+pub async fn tests_aggregate(
+    cfg: &Config,
+    query: String,
+    from: String,
+    to: String,
+    compute: String,
+    group_by: Option<String>,
+    limit: i64,
+) -> Result<()> {
     let api = crate::make_api!(CIVisibilityTestsAPI, cfg);
 
-    let from_ms = util::parse_time_to_unix_millis(&from)?;
-    let to_ms = util::parse_time_to_unix_millis(&to)?;
-    let from_str = chrono::DateTime::from_timestamp_millis(from_ms)
-        .ok_or_else(|| anyhow::anyhow!("--from value {from_ms}ms is out of representable range"))?
-        .to_rfc3339();
-    let to_str = chrono::DateTime::from_timestamp_millis(to_ms)
-        .ok_or_else(|| anyhow::anyhow!("--to value {to_ms}ms is out of representable range"))?
-        .to_rfc3339();
+    let from_str = util::parse_time_to_datetime(&from)?.to_rfc3339();
+    let to_str = util::parse_time_to_datetime(&to)?.to_rfc3339();
+    let compute_spec = build_ci_compute_spec(&compute)?;
 
     let filter = CIAppTestsQueryFilter::new()
         .from(from_str)
         .to(to_str)
         .query(query);
 
-    let body = CIAppTestEventsRequest::new().filter(filter);
+    let mut body = CIAppTestsAggregateRequest::new()
+        .compute(vec![compute_spec])
+        .filter(filter);
 
-    let params = SearchCIAppTestEventsOptionalParams::default().body(body);
+    if let Some(gb) = group_by {
+        body = body.group_by(vec![CIAppTestsGroupBy::new(gb).limit(limit)]);
+    }
+
     let resp = api
-        .search_ci_app_test_events(params)
+        .aggregate_ci_app_test_events(body)
         .await
         .map_err(|e| anyhow::anyhow!("failed to aggregate test events: {e:?}"))?;
     formatter::output(cfg, &resp)
@@ -325,6 +338,35 @@ pub async fn flaky_tests_update(cfg: &Config, file: &str) -> Result<()> {
     formatter::output(cfg, &resp)
 }
 
+fn parse_ci_agg(compute: &str) -> Result<(CIAppAggregationFunction, Option<String>)> {
+    let (func, metric) = util::parse_compute_raw(compute)?;
+    let agg = match func.as_str() {
+        "count" => CIAppAggregationFunction::COUNT,
+        "avg" => CIAppAggregationFunction::AVG,
+        "sum" => CIAppAggregationFunction::SUM,
+        "min" => CIAppAggregationFunction::MIN,
+        "max" => CIAppAggregationFunction::MAX,
+        "median" => CIAppAggregationFunction::MEDIAN,
+        "cardinality" => CIAppAggregationFunction::CARDINALITY,
+        "pc75" => CIAppAggregationFunction::PERCENTILE_75,
+        "pc90" => CIAppAggregationFunction::PERCENTILE_90,
+        "pc95" => CIAppAggregationFunction::PERCENTILE_95,
+        "pc98" => CIAppAggregationFunction::PERCENTILE_98,
+        "pc99" => CIAppAggregationFunction::PERCENTILE_99,
+        _ => anyhow::bail!("unknown aggregation function: {func}"),
+    };
+    Ok((agg, metric))
+}
+
+fn build_ci_compute_spec(compute: &str) -> Result<CIAppCompute> {
+    let (agg_fn, metric) = parse_ci_agg(compute)?;
+    let mut spec = CIAppCompute::new(agg_fn);
+    if let Some(m) = metric {
+        spec = spec.metric(m);
+    }
+    Ok(spec)
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -391,6 +433,7 @@ mod tests {
             "now".into(),
             10,
             "bogus".into(),
+            "pipeline".into(),
         )
         .await;
         assert!(result.is_err());
@@ -398,5 +441,113 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("invalid --sort value"));
+    }
+
+    #[tokio::test]
+    async fn test_cicd_events_search_invalid_level() {
+        let cfg = test_config("http://unused.local");
+        let result = super::events_search(
+            &cfg,
+            "*".into(),
+            "1h".into(),
+            "now".into(),
+            10,
+            "desc".into(),
+            "bogus".into(),
+        )
+        .await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("invalid --level value"));
+    }
+
+    #[tokio::test]
+    async fn test_parse_ci_agg_invalid() {
+        let result = super::parse_ci_agg("bogus");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("invalid --compute format"));
+    }
+
+    #[tokio::test]
+    async fn test_cicd_events_aggregate() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        mock_all(&mut s, r#"{"data": {"buckets": []}}"#).await;
+        let _ = super::events_aggregate(
+            &cfg,
+            "@ci.status:error".into(),
+            "1h".into(),
+            "now".into(),
+            "count".into(),
+            Some("@git.branch".into()),
+            10,
+        )
+        .await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_cicd_events_aggregate_invalid_compute() {
+        let cfg = test_config("http://unused.local");
+        let result = super::events_aggregate(
+            &cfg,
+            "*".into(),
+            "1h".into(),
+            "now".into(),
+            "bogus".into(),
+            None,
+            10,
+        )
+        .await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("invalid --compute format"));
+    }
+
+    #[tokio::test]
+    async fn test_cicd_tests_aggregate() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        mock_all(&mut s, r#"{"data": {"buckets": []}}"#).await;
+        let _ = super::tests_aggregate(
+            &cfg,
+            "@test.status:fail".into(),
+            "1h".into(),
+            "now".into(),
+            "count".into(),
+            Some("@test.service".into()),
+            10,
+        )
+        .await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_cicd_tests_aggregate_invalid_compute() {
+        let cfg = test_config("http://unused.local");
+        let result = super::tests_aggregate(
+            &cfg,
+            "*".into(),
+            "1h".into(),
+            "now".into(),
+            "bogus".into(),
+            None,
+            10,
+        )
+        .await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("invalid --compute format"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6031,12 +6031,16 @@ enum CicdTestActions {
         from: String,
         #[arg(long, default_value = "now", help = "End time")]
         to: String,
-        #[arg(long, default_value = "count", help = "Aggregation function")]
+        #[arg(
+            long,
+            default_value = "count",
+            help = "Aggregation function: count, avg(@duration), sum(@duration), percentile(@duration, 95), etc."
+        )]
         compute: String,
-        #[arg(long, help = "Group by field(s)")]
+        #[arg(long, help = "Group by field (e.g. @test.service)")]
         group_by: Option<String>,
         #[arg(long, default_value_t = 10, help = "Maximum groups")]
-        limit: i32,
+        limit: i64,
     },
 }
 
@@ -6054,6 +6058,12 @@ enum CicdEventActions {
         limit: i32,
         #[arg(long, default_value = "desc", help = "Sort order: asc or desc")]
         sort: String,
+        #[arg(
+            long,
+            default_value = "pipeline",
+            help = "CI event granularity: pipeline, stage, job, or step"
+        )]
+        level: String,
     },
     /// Aggregate CI/CD events
     Aggregate {
@@ -6063,12 +6073,16 @@ enum CicdEventActions {
         from: String,
         #[arg(long, default_value = "now", help = "End time")]
         to: String,
-        #[arg(long, default_value = "count", help = "Aggregation function")]
+        #[arg(
+            long,
+            default_value = "count",
+            help = "Aggregation function: count, avg(@duration), sum(@duration), percentile(@duration, 95), etc."
+        )]
         compute: String,
-        #[arg(long, help = "Group by field(s)")]
+        #[arg(long, help = "Group by field (e.g. @git.branch)")]
         group_by: Option<String>,
         #[arg(long, default_value_t = 10, help = "Maximum groups")]
-        limit: i32,
+        limit: i64,
     },
 }
 
@@ -12594,9 +12608,17 @@ async fn main_inner() -> anyhow::Result<()> {
                         commands::cicd::tests_search(&cfg, query, from, to, limit).await?;
                     }
                     CicdTestActions::Aggregate {
-                        query, from, to, ..
+                        query,
+                        from,
+                        to,
+                        compute,
+                        group_by,
+                        limit,
                     } => {
-                        commands::cicd::tests_aggregate(&cfg, query, from, to).await?;
+                        commands::cicd::tests_aggregate(
+                            &cfg, query, from, to, compute, group_by, limit,
+                        )
+                        .await?;
                     }
                 },
                 CicdActions::Events { action } => match action {
@@ -12606,13 +12628,23 @@ async fn main_inner() -> anyhow::Result<()> {
                         to,
                         limit,
                         sort,
+                        level,
                     } => {
-                        commands::cicd::events_search(&cfg, query, from, to, limit, sort).await?;
+                        commands::cicd::events_search(&cfg, query, from, to, limit, sort, level)
+                            .await?;
                     }
                     CicdEventActions::Aggregate {
-                        query, from, to, ..
+                        query,
+                        from,
+                        to,
+                        compute,
+                        group_by,
+                        limit,
                     } => {
-                        commands::cicd::events_aggregate(&cfg, query, from, to).await?;
+                        commands::cicd::events_aggregate(
+                            &cfg, query, from, to, compute, group_by, limit,
+                        )
+                        .await?;
                     }
                 },
                 CicdActions::Dora { action } => match action {


### PR DESCRIPTION
## Summary

Fixes two silent bugs where `pup cicd events aggregate` and `pup cicd tests aggregate` called the search API instead of the aggregate API, making those commands return search hits rather than bucketed counts/averages. Also adds `--level` to `pup cicd events search` for job/stage/step granularity filtering.

## Changes

- `src/commands/cicd.rs`: Fix `events_aggregate` and `tests_aggregate` to call `aggregate_ci_app_pipeline_events` / `aggregate_ci_app_test_events` — previously both called the search API silently
- `src/commands/cicd.rs`: Wire `compute`, `group_by`, `limit` args that were previously dropped with `..` in both aggregate match arms (`src/main.rs`)
- `src/commands/cicd.rs`: Add `--level` param to `events_search` (pipeline/stage/job/step); injects `@ci.level:<value>` filter into query
- `src/commands/cicd.rs`: Replace hand-rolled aggregation function parser with `util::parse_compute_raw` pattern from `traces.rs`; compute now uses `avg(@duration)` / `percentile(@duration, 95)` syntax — removes the need for a separate `--metric` flag
- `src/commands/cicd.rs`: Simplify 6-line time-parsing boilerplate in 4 functions → `util::parse_time_to_datetime().to_rfc3339()` (already used in `tests_list`)
- `src/commands/cicd.rs`: Extract `build_ci_compute_spec` shared helper used by both aggregate functions
- `src/main.rs`: Change aggregate `limit` from `i32` to `i64` to match the API type directly
- `agents/cicd.md`: Fix `pup cicd tests flaky` → `pup cicd flaky-tests search`; fix pipeline search/aggregate → `pup cicd events search/aggregate`; add test-optimization settings/policies/flaky-test-update commands
- `skills/dd-pup/SKILL.md`: Add CI/CD quick-reference rows

## Testing

- All existing tests pass
- New tests: `test_cicd_events_aggregate`, `test_cicd_tests_aggregate`, `test_cicd_events_search_invalid_level`, `test_cicd_events_aggregate_invalid_compute`, `test_cicd_tests_aggregate_invalid_compute`
- `cargo clippy -- -D warnings` clean
- `cargo fmt --check` clean

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)