### PR TITLE
feat(skills): add dd-unblock-pr and dd-triage-flaky-test workflow skills

### DIFF
--- a/skills/dd-pup/SKILL.md
+++ b/skills/dd-pup/SKILL.md
@@ -31,11 +31,6 @@ Pup CLI for Datadog API operations. Supports OAuth2 and API key auth.
 | Find probe-able methods | `pup symdb search --service my-svc --query MyController --view probe-locations` |
 | Check auth | `pup auth status` |
 | Refresh token | `pup auth refresh` |
-| Search failing CI jobs | `pup cicd events search --query "@ci.status:error" --level job --from 24h` |
-| Count CI failures per branch | `pup cicd events aggregate --query "@ci.status:error" --compute count --group-by "@git.branch" --from 24h` |
-| List active flaky tests | `pup cicd flaky-tests search --query "flaky_test_state:active" --sort "-pipelines_duration_lost"` |
-| Quarantine a flaky test | `pup test-optimization flaky-tests update --file body.json` |
-| Get test optimization settings | `pup test-optimization settings get --file body.json` |
 
 ## Prerequisites
 

--- a/skills/dd-triage-flaky-test/SKILL.md
+++ b/skills/dd-triage-flaky-test/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: dd-triage-flaky-test
+description: Load when investigating a specific flaky test. Gets history, failure pattern, and category, then recommends fix, quarantine, or escalate.
+metadata:
+  version: "1.0.0"
+  author: datadog-labs
+  repository: https://github.com/datadog-labs/agent-skills
+  tags: datadog,ci,cicd,flaky,flaky-tests,test-optimization
+  alwaysApply: "false"
+---
+
+# Triage Flaky Test
+
+One-line summary: Investigate a specific flaky test — get history, failure pattern, and category, then recommend fix, quarantine, or escalate.
+
+Requires: `dd-pup` skill (pup CLI installed and authenticated).
+
+---
+
+## Input
+
+| Parameter | Description |
+|---|---|
+| Test name | Fully qualified test name (e.g. `TestMyFunc` or `com.example.MyTest`) |
+| Repository | Lowercase, no-schema URL (e.g. `github.com/org/repo`). Derive from `git remote get-url origin` if not provided. |
+
+---
+
+## Workflow
+
+### STEP 0 — Parse Input
+
+Derive repository ID from git if not provided:
+```bash
+git remote get-url origin
+# Strip protocol and trailing .git, then lowercase the result
+# e.g. https://github.com/DataDog/my-repo.git → github.com/datadog/my-repo
+```
+
+**Validation fallback:** If STEP 1 returns no results, confirm the correct repository by searching without a repo filter:
+```bash
+pup cicd tests search \
+  --query "@test.name:\"<test-name>\"" \
+  --from 30d \
+  --limit 5
+```
+Extract `@git.repository.id_v2` from results and retry STEP 1 with the confirmed value.
+
+### STEP 1 — Get Flaky Test Details
+
+**Preferred — use `fingerprint_fqn` if known** (`fingerprint_fqn` is a valid CI Visibility search facet, distinct from `flaky_state`):
+```bash
+pup cicd flaky-tests search \
+  --query "fingerprint_fqn:<fqn>" \
+  --sort="-last_flaked" \
+  --limit 5
+```
+
+**Fallback — use name + suite + repo:**
+```bash
+pup cicd flaky-tests search \
+  --query "@test.name:\"<test-name>\" @test.suite:\"<suite>\" @git.repository.id_v2:\"<repo>\"" \
+  --sort="-last_flaked" \
+  --limit 10
+```
+Omit `@test.suite` if unknown; if the same test name appears in multiple suites, pick the entry whose suite matches the failing test.
+
+Do not filter by `flaky_test_state` — return the test regardless of state.
+
+Note: the query filter facet is `flaky_test_state`; the returned response attribute is `flaky_state` — these are different names for the same concept; do not use `flaky_state:active` as a query filter.
+
+Extract from results:
+- `fingerprint_fqn` — unique test identifier; used as the `id` in STEP 5 write call. **If absent, do not proceed to quarantine — see STEP 5.**
+- `flaky_state` — current state (active / quarantined / disabled / fixed)
+- `test_stats.failure_rate_pct` — percentage of runs that fail
+- `flaky_category` — root cause category
+- `codeowners` — owning team
+- `pipeline_stats.total_lost_time_ms` — total CI time lost
+
+### STEP 2 — Get Recent Failure History
+
+```bash
+pup cicd tests search \
+  --query "@test.name:\"<test-name>\" @test.suite:\"<suite>\" @test.status:fail @git.repository.id_v2:\"<repo>\"" \
+  --from 7d \
+  --limit 20
+```
+
+Extract:
+- Error messages and stack traces (`@error.message`, `@error.stack`)
+- Failing branches (`@git.branch`) — branch-specific vs. widespread
+- Frequency pattern — random timing or specific conditions
+- Unique `@ci.pipeline.id` values for blast radius (STEP 3)
+
+### STEP 3 — Check Blast Radius
+
+Count distinct pipelines impacted using pipeline IDs from STEP 2:
+
+```bash
+pup cicd events aggregate \
+  --query "@ci.status:error @ci.pipeline.id:(<id1> OR <id2> OR ...) @git.repository.id_v2:\"<repo>\"" \
+  --compute count \
+  --group-by "@ci.pipeline.name" \
+  --from 7d
+```
+
+Use the first 10 pipeline IDs from STEP 2 (cap at 10; if more are available, run a second batch and merge results by summing counts per `@ci.pipeline.name` across batches). Report blast radius as: total number of unique pipelines impacted and whether failures are branch-specific or widespread.
+
+Note: a pipeline failure is not necessarily caused solely by this flaky test — treat blast radius as a signal, not a definitive count.
+
+### STEP 4 — Recommend Fix or Quarantine
+
+Use `flaky_category` from STEP 1 and error messages from STEP 2.
+
+**Root cause first:**
+- Read the full error trace from bottom to top — chained errors hide the real cause; the innermost error is the root cause, not the first line.
+- Identify the exact source of nondeterminism (race, ordering, stale state, timing).
+- If the root cause is a CI infrastructure problem (runner unavailable, Docker daemon failure, network outage) → do NOT propose a code fix; classify as `infra` and recommend retry instead.
+- If root cause is uncertain and cannot be confirmed from the stack trace → skip fix, go to quarantine.
+
+**Fix at the correct layer:**
+- Test issue → fix in test or test helper only.
+- Production bug exposed by the test → fix in production code.
+- Shared helper used by multiple tests → fix the helper AND update all call sites; never patch a single test when the root cause is in shared code.
+
+**Forbidden — do not propose these:**
+- Timing hacks: increasing timeouts, adding sleeps, widening time windows, adding retries. A fix that only reduces flake probability without eliminating the root cause is invalid.
+- Masking: relaxing assertions (e.g., exact match → at least 1), dropping validations.
+- Partial fixes: touching one call site when multiple share the root cause.
+
+**Fix patterns by category:**
+
+| Category | Approach |
+|---|---|
+| `timeout` | Identify the slow operation and make it synchronous or deterministic — do NOT simply raise the timeout constant |
+| `concurrency` | Add deterministic synchronization (barriers, channels, locks); remove shared mutable state between tests |
+| `network` | Mock or stub network calls at the boundary; if the test requires a real connection, isolate it with a test server |
+| `time` | Inject a controllable clock; replace wall-clock assertions with relative or event-driven checks |
+| `order_dependency` | Isolate test state with setup/teardown; eliminate dependencies on execution order or global state |
+| `environment_dependency` | Mock env variables and external config; use test-local fixtures, not shared directories or singletons |
+| `resource_leak` | Ensure every resource opened in a test is closed in teardown; use cleanup hooks that run even on failure |
+| `randomness` | Fix the random seed for the test run; use deterministic inputs instead of random generation |
+| `asynchronous_wait` | Replace fixed sleeps with condition polling or event/signal-driven waits with a hard timeout |
+| `io` | Use temp files/dirs cleaned up in teardown; mock or stub filesystem interactions |
+| `unknown` | Skip fix attempt → go to quarantine |
+
+**Before proposing code changes, verify all of the following — if any fails, skip fix and recommend quarantine:**
+- The root cause is the innermost error in the trace, not a surface-level symptom.
+- The failure is a code problem, not a CI infrastructure problem.
+- The fix eliminates the root cause (not just reduces flake probability).
+- The fix is at the correct layer (test vs. production vs. shared helper).
+- All call sites of any shared code are updated.
+- No timing hacks or relaxed assertions introduced.
+
+**Decision:**
+- If category is `unknown` OR verification above fails → skip fix, recommend quarantine
+- If category is known AND root cause is confirmed AND fix is valid → propose specific code change
+
+### STEP 5 — Produce Triage Brief and Act
+
+```
+Flaky Test Triage Brief
+=======================
+Test:           <fully qualified test name>
+Service:        <@test.service>
+Category:       <flaky_category>
+Failure Rate:   <test_stats.failure_rate_pct>%
+Duration Lost:  <pipeline_stats.total_lost_time_ms>ms
+Codeowners:     <codeowners>
+Blast Radius:   <N> pipelines (<branch-specific | widespread>) [approximate — other failures in the same pipeline runs may not be related]
+
+Evidence:
+  <1-2 key error message lines from STEP 2>
+
+Recommendation: <fix | quarantine | escalate>
+Confidence:     <high | medium | low>
+Action:         <specific next step>
+```
+
+**Decision thresholds:**
+- `failure_rate_pct > 10` OR blast radius > 5 pipelines → **quarantine**
+- `failure_rate_pct ≤ 10` AND known category AND clear fix → **fix**
+- `failure_rate_pct ≤ 10` AND category `unknown` → **escalate** to codeowners with triage brief
+
+**If recommending quarantine**, present and require explicit user approval before writing:
+
+```
+Proposed action: quarantine "<test-name>"
+  id (fingerprint_fqn): <fingerprint_fqn from STEP 1>
+  Effect: test still runs but failures are suppressed (CI will not be blocked)
+  Reversible: yes — update new_state to active to restore
+
+Approve? (yes/no)
+```
+
+**If `fingerprint_fqn` was not returned in STEP 1** (test not yet in FTM or query returned no results): do not attempt the write. Surface an error and ask the user to open the Flaky Test Management UI directly to quarantine manually.
+
+Only after explicit approval and a confirmed `fingerprint_fqn`, write the body file and run:
+```bash
+cat > /tmp/flaky-update.json <<'EOF'
+{
+  "data": {
+    "type": "UpdateFlakyTestsRequest",
+    "attributes": {
+      "tests": [{"id": "<fingerprint_fqn>", "new_state": "quarantined"}]
+    }
+  }
+}
+EOF
+pup test-optimization flaky-tests update --file /tmp/flaky-update.json
+```
+
+To undo: repeat with `"new_state": "active"`.

--- a/skills/dd-unblock-pr/SKILL.md
+++ b/skills/dd-unblock-pr/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: dd-unblock-pr
+description: Load when investigating a failing PR CI pipeline or checking PR health. Attributes each CI failure as flaky, infra, or regression, proposes a targeted action, and reports code coverage.
+metadata:
+  version: "1.1.0"
+  author: datadog-labs
+  repository: https://github.com/datadog-labs/agent-skills
+  tags: datadog,ci,cicd,flaky,flaky-tests,pipeline
+  alwaysApply: "false"
+---
+
+# Unblock PR
+
+One-line summary: Investigate a failing PR CI pipeline — attribute each failure as flaky, infra, or regression and propose a targeted action.
+
+Requires: `dd-pup` skill (pup CLI installed and authenticated), `dd-triage-flaky-test` skill (for flaky failure deep investigation).
+
+---
+
+## Input
+
+| Parameter | Description |
+|---|---|
+| PR branch | The branch under investigation (e.g. `my-feature-branch`) |
+| Repository | Lowercase, no-schema URL (e.g. `github.com/org/repo`). Derive from `git remote get-url origin` if not provided. |
+
+---
+
+## Workflow
+
+### STEP 0 — Parse Input
+
+Derive repository ID and default branch from git if not provided:
+
+```bash
+# Repository ID: fully lowercase, no-schema URL (the API rejects mixed-case)
+git remote get-url origin
+# Strip protocol and trailing .git, then lowercase the result
+# e.g. https://github.com/DataDog/my-repo.git → github.com/datadog/my-repo
+
+# Default branch
+git symbolic-ref refs/remotes/origin/HEAD
+# Strip refs/remotes/origin/ prefix — fall back to main if unset
+```
+
+### STEP 1 — Get PR CI Summary (run both in parallel)
+
+**Pipeline failures (job level):**
+```bash
+pup cicd events search \
+  --query "@ci.status:error @git.branch:<branch> @git.repository.id_v2:\"<repo>\"" \
+  --level job \
+  --from 24h \
+  --limit 50
+```
+
+**Test failures:**
+```bash
+pup cicd tests search \
+  --query "@test.status:fail @git.branch:<branch> @git.repository.id_v2:\"<repo>\"" \
+  --from 24h \
+  --limit 50
+```
+
+Run both queries in parallel. Collect all distinct `@test.service` values from test event results. If more than one distinct service is found, note each separately in the triage brief — do not collapse them into a single service filter. If pipeline results contain only infrastructure job types (build, lint, deploy) with no test-runner output, discard test search results and skip to STEP 3.
+
+### STEP 1.5 — Fetch Code Coverage (run in parallel with STEP 1)
+
+This step runs unconditionally — coverage context is valuable whether CI is red or green.
+
+The `--repo` value must be fully lowercase (the API rejects mixed-case). Normalize before calling:
+```bash
+repo_lower=$(echo "<repo>" | tr '[:upper:]' '[:lower:]')
+pup code-coverage branch-summary \
+  --repo "$repo_lower" \
+  --branch "<branch>"
+```
+
+If the command returns no data or exits with an error, report "No data available" for Coverage in the PR Health section.
+
+Note: Code quality and security violation counts are not available in pup — those lines always show "No data available".
+
+### STEP 2 — Blame Guard per Failing Job
+
+First check whether `@error_classification.domain` / `@error_classification.type` are present on job events from STEP 1 — if populated, use them as primary classification signals.
+
+For each failing job where classification is still needed, run both checks in parallel:
+
+**Default branch check** — was this job already failing before this PR?
+```bash
+pup cicd events aggregate \
+  --query "@ci.status:error @ci.job.name:\"<job>\" @git.branch:<default-branch> @git.repository.id_v2:\"<repo>\"" \
+  --compute count \
+  --from 24h
+```
+
+**Blast radius check** — is this job failing on other branches too?
+```bash
+pup cicd events aggregate \
+  --query "@ci.status:error @ci.job.name:\"<job>\" @git.repository.id_v2:\"<repo>\"" \
+  --compute count \
+  --group-by "@git.branch" \
+  --from 24h
+```
+
+Performance fallback: if the blast radius query is slow or times out, skip it and rely on the default branch check alone.
+
+### STEP 3 — Classify Each Failure
+
+**Priority order:**
+1. If `@error_classification.domain` / `@error_classification.type` present → use as primary signal
+2. If test failure AND test appears in flaky tests with `flaky_test_state:active`:
+   ```bash
+   pup cicd flaky-tests search \
+     --query "flaky_test_state:active @test.name:\"<test-name>\" @git.repository.id_v2:\"<repo>\""
+   ```
+   → **flaky**
+3. Use blame guard results:
+
+| Failing on default branch? | Failing on ≥3 other branches? | Classification |
+|---|---|---|
+| Yes | Yes | **infra** (pre-existing, widespread) |
+| Yes | No | **infra** (pre-existing on default branch) |
+| No | No | **regression** (introduced by this PR) |
+| No | Yes | **flaky** (intermittent, cross-branch) |
+| Insufficient data | — | **unknown** |
+
+### STEP 4 — Produce Triage Brief
+
+One entry per failing job:
+
+```
+PR CI Triage Brief
+==================
+Branch:   <branch>
+Repo:     <repo>
+
+Job: <job-name>
+  Classification:  <flaky | infra | regression | unknown>
+  Evidence:        <1 key data point — error message, pipeline count, or test result>
+  Confidence:      <high | medium | low>
+  Recommended:     <action>
+
+[repeat for each failing job]
+
+Overall: <N> failures — <e.g. "1 regression, 1 flaky, 1 infra">
+
+PR Health
+=========
+Coverage:   <X>% on <branch> | No data available
+Quality:    No data available
+Security:   No data available
+```
+
+All three lines always appear.
+
+### STEP 5 — Propose Actions
+
+**regression** → Prompt user to investigate their code changes. No write action available.
+
+**flaky** → Load `dd-triage-flaky-test` skill for deep investigation. That skill will:
+- Attempt an agent-native fix using `flaky_category` + stack trace
+- Propose quarantine via `pup test-optimization flaky-tests update` if a quick fix isn't possible
+
+**infra** → Before proposing a retry, assess whether the failure is transient:
+- Check `@error_classification.type` and error message for signals like `timeout`, `runner unavailable`, `network error`, `quota exceeded` — these indicate transient failures where a retry is likely to help
+- If the error is deterministic (build misconfiguration, missing secret, explicit test assertion failure), a retry is unlikely to help — note this and suggest investigating the root cause
+- If the failure is pre-existing on the default branch, inform the user — a retry will likely fail again; await the upstream fix instead
+
+If transient and GitHub Actions: extract the run ID from `@ci.pipeline.url` (e.g. `https://github.com/org/repo/actions/runs/<run_id>`):
+```bash
+gh run rerun <run_id> --failed
+```
+For other providers, share `@ci.pipeline.url` and direct to the provider UI for retry.
+
+**unknown** → Suggest checking raw job logs via the CI provider UI or `@ci.pipeline.url` from the pipeline event.

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -108,6 +108,22 @@ pub static SKILLS: &[SkillEntry] = &[
         platform: "",
         files: &[],
     },
+    SkillEntry {
+        name: "dd-unblock-pr",
+        description: "Investigate a failing PR CI pipeline — attribute failures as flaky, infra, or regression and propose a targeted action.",
+        entry_type: "skill",
+        content: include_str!("../skills/dd-unblock-pr/SKILL.md"),
+        platform: "",
+        files: &[],
+    },
+    SkillEntry {
+        name: "dd-triage-flaky-test",
+        description: "Investigate a specific flaky test — get history, category, and recommend fix or quarantine.",
+        entry_type: "skill",
+        content: include_str!("../skills/dd-triage-flaky-test/SKILL.md"),
+        platform: "",
+        files: &[],
+    },
     // --- Domain Agents (from datadog-api-claude-plugin) ---
     SkillEntry {
         name: "agentless-scanning",
@@ -1057,7 +1073,7 @@ mod tests {
     #[test]
     fn test_skill_count() {
         let skills: Vec<_> = SKILLS.iter().filter(|e| e.entry_type == "skill").collect();
-        assert_eq!(skills.len(), 9, "expected 9 skills");
+        assert_eq!(skills.len(), 11, "expected 11 skills");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds two CI/CD workflow skill files to the pup skills directory, ported from `datadog-labs/agent-skills`. Also removes the CI/CD quick-reference rows that were inadvertently added to `skills/dd-pup/SKILL.md` in #526 — no other dd-* domain skills add entries there.

## Changes

- `skills/dd-unblock-pr/SKILL.md` — New skill. Searches job-level pipeline failures and test failures in parallel, runs per-job blame-guard aggregations (default-branch check + blast radius), classifies each failure as flaky/infra/regression/unknown, and proposes targeted actions including transience-aware retry for infra failures.
- `skills/dd-triage-flaky-test/SKILL.md` — New skill. Fetches pre-computed FTM stats, recent failure history, and blast radius. Recommends a category-specific code fix or quarantine. Requires explicit user approval before any write via `pup test-optimization flaky-tests update`.
- `skills/dd-pup/SKILL.md` — Reverts 5 CI/CD rows added in #526 for consistency with other domain skills.

## Testing

Workflows validated against pup CLI command signatures from #526. Skills reviewed through 3 rounds of automated code review.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)