### PR TITLE
feat(skills): ship dd-apm sub-skills via agent-skills submodule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
@@ -64,6 +66,8 @@ jobs:
       RUSTFLAGS: "-C target-feature=+crt-static"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
       - name: Install Rust
         run: |
           rustup toolchain install stable --profile minimal
@@ -107,6 +111,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
@@ -152,6 +158,8 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
@@ -183,6 +191,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          submodules: recursive
 
       - name: Check for changes since last tag
         id: check
@@ -67,6 +68,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          submodules: recursive
 
       - name: Compute next version
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          submodules: recursive
       - name: Fetch all tags
         run: git fetch --force --tags
       - name: Install Rust
@@ -70,6 +71,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          submodules: recursive
       - name: Fetch all tags
         run: git fetch --force --tags
       - name: Install Rust
@@ -116,6 +118,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          submodules: recursive
       - name: Install Rust
         run: |
           rustup toolchain install stable --profile minimal
@@ -163,6 +166,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          submodules: recursive
       - name: Enable long paths
         run: git config --global core.longpaths true
       - name: Install NASM
@@ -216,6 +220,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          submodules: recursive
 
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "agent-skills"]
+	path = agent-skills
+	url = https://github.com/datadog-labs/agent-skills.git

--- a/src/commands/skills.rs
+++ b/src/commands/skills.rs
@@ -66,6 +66,22 @@ pub fn install(
         let content = skills::format_content(entry, &fmt);
         std::fs::write(&path, &content)?;
         installed += 1;
+
+        // Write any nested sub-skill files under the parent skill's directory.
+        // Only applies when the parent installs as a skill directory
+        // (`<skills_dir>/<name>/SKILL.md`), not as a single subagent .md file.
+        if fmt == skills::InstallFormat::SkillMd {
+            if let Some(parent_dir) = path.parent() {
+                for sub in skills::SUB_SKILLS.iter().filter(|s| s.parent == entry.name) {
+                    let sub_path = parent_dir.join(sub.rel_path);
+                    if let Some(sub_parent) = sub_path.parent() {
+                        std::fs::create_dir_all(sub_parent)?;
+                    }
+                    std::fs::write(&sub_path, sub.content)?;
+                    installed += 1;
+                }
+            }
+        }
     }
 
     if cfg.agent_mode {

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -31,7 +31,7 @@ pub static SKILLS: &[SkillEntry] = &[
         name: "dd-apm",
         description: "APM - traces, services, dependencies, performance analysis.",
         entry_type: "skill",
-        content: include_str!("../skills/dd-apm/SKILL.md"),
+        content: include_str!("../agent-skills/dd-apm/SKILL.md"),
     },
     SkillEntry {
         name: "dd-debugger",
@@ -351,6 +351,73 @@ pub static SKILLS: &[SkillEntry] = &[
         description: "Manage workflow automations.",
         entry_type: "agent",
         content: include_str!("../agents/workflows.md"),
+    },
+];
+
+/// A nested file belonging to a parent skill (e.g. a sub-skill SKILL.md
+/// under `dd-apm/service-remapping/`). Written verbatim under the parent
+/// skill's install directory at the given relative path.
+pub struct SubSkillFile {
+    pub parent: &'static str,
+    pub rel_path: &'static str,
+    pub content: &'static str,
+}
+
+pub static SUB_SKILLS: &[SubSkillFile] = &[
+    SubSkillFile {
+        parent: "dd-apm",
+        rel_path: "service-remapping/SKILL.md",
+        content: include_str!("../agent-skills/dd-apm/service-remapping/SKILL.md"),
+    },
+    SubSkillFile {
+        parent: "dd-apm",
+        rel_path: "k8s-ssi/agent-install/SKILL.md",
+        content: include_str!("../agent-skills/dd-apm/k8s-ssi/agent-install/SKILL.md"),
+    },
+    SubSkillFile {
+        parent: "dd-apm",
+        rel_path: "k8s-ssi/enable-ssi/SKILL.md",
+        content: include_str!("../agent-skills/dd-apm/k8s-ssi/enable-ssi/SKILL.md"),
+    },
+    SubSkillFile {
+        parent: "dd-apm",
+        rel_path: "k8s-ssi/verify-ssi/SKILL.md",
+        content: include_str!("../agent-skills/dd-apm/k8s-ssi/verify-ssi/SKILL.md"),
+    },
+    SubSkillFile {
+        parent: "dd-apm",
+        rel_path: "k8s-ssi/troubleshoot-ssi/SKILL.md",
+        content: include_str!("../agent-skills/dd-apm/k8s-ssi/troubleshoot-ssi/SKILL.md"),
+    },
+    SubSkillFile {
+        parent: "dd-apm",
+        rel_path: "k8s-ssi/onboarding-summary/SKILL.md",
+        content: include_str!("../agent-skills/dd-apm/k8s-ssi/onboarding-summary/SKILL.md"),
+    },
+    SubSkillFile {
+        parent: "dd-apm",
+        rel_path: "linux-ssi/agent-install/SKILL.md",
+        content: include_str!("../agent-skills/dd-apm/linux-ssi/agent-install/SKILL.md"),
+    },
+    SubSkillFile {
+        parent: "dd-apm",
+        rel_path: "linux-ssi/enable-ssi/SKILL.md",
+        content: include_str!("../agent-skills/dd-apm/linux-ssi/enable-ssi/SKILL.md"),
+    },
+    SubSkillFile {
+        parent: "dd-apm",
+        rel_path: "linux-ssi/verify-ssi/SKILL.md",
+        content: include_str!("../agent-skills/dd-apm/linux-ssi/verify-ssi/SKILL.md"),
+    },
+    SubSkillFile {
+        parent: "dd-apm",
+        rel_path: "linux-ssi/troubleshoot-ssi/SKILL.md",
+        content: include_str!("../agent-skills/dd-apm/linux-ssi/troubleshoot-ssi/SKILL.md"),
+    },
+    SubSkillFile {
+        parent: "dd-apm",
+        rel_path: "linux-ssi/onboarding-summary/SKILL.md",
+        content: include_str!("../agent-skills/dd-apm/linux-ssi/onboarding-summary/SKILL.md"),
     },
 ];
 


### PR DESCRIPTION
Pull dd-apm's SKILL.md and all 11 nested sub-skill files (service-remapping, k8s-ssi/*, linux-ssi/*) from the datadog-labs/agent-skills repo via a git submodule, instead of the standalone pup/skills/dd-apm/SKILL.md that previously had no sub-skills attached.

- Add agent-skills as a submodule at pup/agent-skills
- Point dd-apm's include_str! at the submodule's router SKILL.md
- Add SubSkillFile struct + SUB_SKILLS array embedding the 11 nested SKILL.md files at compile time
- Extend skills install to write sub-skills under the parent skill's install directory (gated on InstallFormat::SkillMd)

pup skills install dd-apm now writes 12 files (1 root + 11 sub-skills) instead of just the root. Refreshing sub-skills is a git submodule update + rebuild; no manual copies.

## What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

## Motivation

<!-- What inspired you to submit this pull request? -->

## Additional Notes

<!-- Anything else we should know when reviewing? -->

## Checklist

- [ ] The code change follows the project conventions (see [CONTRIBUTING.md](../docs/CONTRIBUTING.md))
- [ ] Tests have been added/updated (if applicable)
- [ ] Documentation has been updated (if applicable)
- [ ] All CI checks pass
- [ ] Code coverage is maintained or improved

## Related Issues

<!-- Link related issues here. Use "Closes #123" to automatically close issues when the PR is merged. -->
