### PR TITLE
fix(agents): remove hardcoded Project Location from all agent files

### DIFF
--- a/agents/_templates/README.md
+++ b/agents/_templates/README.md
@@ -74,8 +74,6 @@ Agents reference these templates in their "Important Context" and "Permission Mo
 ```markdown
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/_templates/pup-context.md
+++ b/agents/_templates/pup-context.md
@@ -1,7 +1,5 @@
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/api-management.md
+++ b/agents/api-management.md
@@ -21,8 +21,6 @@ You are a specialized agent for interacting with Datadog's Key Management API. Y
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/apm-configuration.md
+++ b/agents/apm-configuration.md
@@ -28,8 +28,6 @@ You are a specialized agent for managing Datadog APM (Application Performance Mo
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/app-builder.md
+++ b/agents/app-builder.md
@@ -22,8 +22,6 @@ You are a specialized agent for interacting with Datadog's App Builder APIs. You
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/application-security.md
+++ b/agents/application-security.md
@@ -17,8 +17,6 @@ You are a specialized agent for interacting with Datadog's Application Security 
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/audience-management.md
+++ b/agents/audience-management.md
@@ -24,8 +24,6 @@ You are a specialized agent for interacting with Datadog's RUM Audience Manageme
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **API Version**: v2 (Preview/Unstable - subject to changes)
 
 **Environment Variables Required**:

--- a/agents/audit-logs.md
+++ b/agents/audit-logs.md
@@ -18,8 +18,6 @@ You are a specialized agent for interacting with Datadog's Audit Trail API. Your
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/aws-integration.md
+++ b/agents/aws-integration.md
@@ -59,8 +59,6 @@ You are a specialized agent for managing Datadog's AWS integration. Your role is
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/azure-integration.md
+++ b/agents/azure-integration.md
@@ -28,8 +28,6 @@ You are a specialized agent for managing Datadog's Microsoft Azure integration. 
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/cicd.md
+++ b/agents/cicd.md
@@ -30,8 +30,6 @@ You are a specialized agent for interacting with Datadog's CI/CD Visibility APIs
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/cloud-cost.md
+++ b/agents/cloud-cost.md
@@ -33,8 +33,6 @@ You are a specialized agent for interacting with Datadog's Cloud Cost Management
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/cloud-workload-security.md
+++ b/agents/cloud-workload-security.md
@@ -17,8 +17,6 @@ You are a specialized agent for interacting with Datadog's Cloud Security Manage
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/container-monitoring.md
+++ b/agents/container-monitoring.md
@@ -29,8 +29,6 @@ Use the Container Monitoring agent when you need to:
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/dashboards.md
+++ b/agents/dashboards.md
@@ -17,8 +17,6 @@ You are a specialized agent for interacting with Datadog's Dashboards API. Your 
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/database-monitoring.md
+++ b/agents/database-monitoring.md
@@ -16,8 +16,6 @@ You are a specialized agent for interacting with Datadog's Database Monitoring (
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/events.md
+++ b/agents/events.md
@@ -31,8 +31,6 @@ You are a specialized agent for interacting with Datadog's Events API. Your role
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/fleet-automation.md
+++ b/agents/fleet-automation.md
@@ -30,8 +30,6 @@ You are a specialized agent for interacting with Datadog's Fleet Automation API.
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/gcp-integration.md
+++ b/agents/gcp-integration.md
@@ -39,8 +39,6 @@ You are a specialized agent for managing Datadog's Google Cloud Platform (GCP) i
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/incident-response.md
+++ b/agents/incident-response.md
@@ -91,8 +91,6 @@ standalone case work, route the user to `case-management` directly.
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/infrastructure.md
+++ b/agents/infrastructure.md
@@ -26,8 +26,6 @@ Use the Infrastructure agent when you need to:
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/log-configuration.md
+++ b/agents/log-configuration.md
@@ -42,8 +42,6 @@ You are a specialized agent for managing Datadog log configuration. Your role is
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/logs.md
+++ b/agents/logs.md
@@ -15,8 +15,6 @@ You are a specialized agent for interacting with Datadog's Logs API. Your role i
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/metrics.md
+++ b/agents/metrics.md
@@ -15,8 +15,6 @@ You are a specialized agent for interacting with Datadog's Metrics API. Your rol
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/monitoring-alerting.md
+++ b/agents/monitoring-alerting.md
@@ -57,8 +57,6 @@ This agent covers the entire monitoring and alerting ecosystem in Datadog.
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/network-performance.md
+++ b/agents/network-performance.md
@@ -26,8 +26,6 @@ You are a specialized agent for interacting with Datadog's Network Performance M
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/notebooks.md
+++ b/agents/notebooks.md
@@ -31,8 +31,6 @@ You are a specialized agent for interacting with Datadog's Notebooks API. Your r
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/organization-management.md
+++ b/agents/organization-management.md
@@ -43,8 +43,6 @@ You are a specialized agent for interacting with Datadog's Organization Manageme
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/powerpacks.md
+++ b/agents/powerpacks.md
@@ -24,8 +24,6 @@ You are a specialized agent for interacting with Datadog's Powerpacks API. Your 
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/rum-metrics-retention.md
+++ b/agents/rum-metrics-retention.md
@@ -25,8 +25,6 @@ You are a specialized agent for interacting with Datadog's RUM Metrics and RUM R
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/rum.md
+++ b/agents/rum.md
@@ -15,8 +15,6 @@ You are a specialized agent for interacting with Datadog's Real User Monitoring 
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/saml-configuration.md
+++ b/agents/saml-configuration.md
@@ -16,8 +16,6 @@ You are a specialized agent for configuring SAML Single Sign-On (SSO) in Datadog
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/scorecards.md
+++ b/agents/scorecards.md
@@ -27,8 +27,6 @@ You are a specialized agent for interacting with Datadog's Service Scorecards AP
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/security-posture-management.md
+++ b/agents/security-posture-management.md
@@ -18,8 +18,6 @@ You are a specialized agent for interacting with Datadog's Cloud Security Postur
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/security.md
+++ b/agents/security.md
@@ -15,8 +15,6 @@ You are a specialized agent for interacting with Datadog's Security Monitoring A
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/service-catalog.md
+++ b/agents/service-catalog.md
@@ -38,8 +38,6 @@ You are a specialized agent for interacting with Datadog's Service Catalog and S
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/slos.md
+++ b/agents/slos.md
@@ -15,8 +15,6 @@ You are a specialized agent for interacting with Datadog's Service Level Objecti
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/spark-pod-autosizing.md
+++ b/agents/spark-pod-autosizing.md
@@ -27,8 +27,6 @@ Use the Spark Pod Autosizing agent when you need to:
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/static-analysis.md
+++ b/agents/static-analysis.md
@@ -17,8 +17,6 @@ You are a specialized agent for interacting with Datadog's Code Security feature
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/synthetics.md
+++ b/agents/synthetics.md
@@ -15,8 +15,6 @@ You are a specialized agent for interacting with Datadog's Synthetic Monitoring 
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/third-party-integrations.md
+++ b/agents/third-party-integrations.md
@@ -74,8 +74,6 @@ You are a specialized agent for managing Datadog's third-party integration confi
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/traces.md
+++ b/agents/traces.md
@@ -15,8 +15,6 @@ You are a specialized agent for interacting with Datadog's APM (Application Perf
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/usage-metering.md
+++ b/agents/usage-metering.md
@@ -37,8 +37,6 @@ You are a specialized agent for interacting with Datadog's Usage Metering API. Y
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/user-access-management.md
+++ b/agents/user-access-management.md
@@ -80,8 +80,6 @@ You are a specialized agent for interacting with Datadog's User and Team Managem
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:

--- a/agents/workflows.md
+++ b/agents/workflows.md
@@ -35,8 +35,6 @@ You are a specialized agent for interacting with Datadog's Workflow Automation A
 
 ## Important Context
 
-**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
-
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 
 **Environment Variables Required**:


### PR DESCRIPTION
All 43 agent files and the pup-context template contained a hardcoded
"Project Location" line pointing to ~/go/src/github.com/DataDog/datadog-api-claude-plugin.
This path does not exist for Homebrew installs and points to an archived
repo (the active repo is DataDog/pup). Agents were getting confused and
trying to cd into the non-existent directory.

Remove the line entirely from all agent .md files and from the
_templates/pup-context.md template. The "Project Location" section
provides no value for end users — agents only need the pup CLI on PATH
and the three environment variables.

Closes #531

https://claude.ai/code/session_011XbWVouxGtmpK9CQVmZjJA