### PR TITLE
fix(help): mark mutating commands as read_only: false in schema output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9891,6 +9891,7 @@ pub(crate) fn is_write_command_name(name: &str) -> bool {
         || name == "remove"
         || name == "install"
         || name == "assign"
+        || name == "unassign"
         || name == "archive"
         || name == "unarchive"
         || name == "activate"
@@ -9902,6 +9903,7 @@ pub(crate) fn is_write_command_name(name: &str) -> bool {
         || name == "upgrade"
         || name.starts_with("update-")
         || name.starts_with("create-")
+        || name.ends_with("-create")
         || name == "submit"
         || name == "send"
         || name == "import"
@@ -9910,6 +9912,20 @@ pub(crate) fn is_write_command_name(name: &str) -> bool {
         || name.contains("delete")
         || name == "patch"
         || name.starts_with("patch-")
+        || name == "run"
+        || name == "enable"
+        || name == "disable"
+        || name == "edit"
+        || name == "upsert"
+        || name == "upload"
+        || name == "publish"
+        || name == "unpublish"
+        || name == "comment"
+        || name == "start"
+        || name == "stop"
+        || name == "pause"
+        || name == "resume"
+        || name == "generate"
 }
 
 fn build_command_schema(cmd: &clap::Command, parent_path: &str) -> serde_json::Value {

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -30,6 +30,23 @@ fn test_is_write_command_name_writes() {
     assert!(crate::is_write_command_name("create-page"));
     assert!(crate::is_write_command_name("patch"));
     assert!(crate::is_write_command_name("patch-deployment"));
+    // Mutation verbs added to fix issue #528
+    assert!(crate::is_write_command_name("run"));
+    assert!(crate::is_write_command_name("enable"));
+    assert!(crate::is_write_command_name("disable"));
+    assert!(crate::is_write_command_name("edit"));
+    assert!(crate::is_write_command_name("upsert"));
+    assert!(crate::is_write_command_name("upload"));
+    assert!(crate::is_write_command_name("publish"));
+    assert!(crate::is_write_command_name("unpublish"));
+    assert!(crate::is_write_command_name("comment"));
+    assert!(crate::is_write_command_name("start"));
+    assert!(crate::is_write_command_name("stop"));
+    assert!(crate::is_write_command_name("pause"));
+    assert!(crate::is_write_command_name("resume"));
+    assert!(crate::is_write_command_name("generate"));
+    assert!(crate::is_write_command_name("unassign"));
+    assert!(crate::is_write_command_name("batch-create"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Several subcommands were reporting `read_only: true` in `pup --help` JSON output despite performing server-side mutations. The root cause was that `is_write_command_name()` in `src/main.rs` was missing the verbs used by those commands.

## Changes

- `src/main.rs`: Added 14 mutation verbs and one pattern to `is_write_command_name()` (src/main.rs:9883):
  - `run`, `enable`, `disable`, `edit`, `upsert`, `upload`, `publish`, `unpublish`, `comment`, `start`, `stop`, `pause`, `resume`, `generate`, `unassign`
  - `name.ends_with("-create")` pattern to cover `batch-create`
- `src/test_commands.rs`: Added assertions for all newly added verbs in `test_is_write_command_name_writes()`

## Commands fixed

| Command | Verb |
|---|---|
| `pup cases comment` | `comment` |
| `pup workflows run` | `run` |
| `pup runbooks run` | `run` |
| `pup synthetics tests run` | `run` |
| `pup feature-flags enable` | `enable` |
| `pup feature-flags disable` | `disable` |
| `pup feature-flags exposure start` | `start` |
| `pup feature-flags exposure stop` | `stop` |
| `pup feature-flags exposure pause` | `pause` |
| `pup feature-flags exposure resume` | `resume` |
| `pup notebooks edit` | `edit` |
| `pup software-catalog entities upsert` | `upsert` |
| `pup software-catalog kinds upsert` | `upsert` |
| `pup costs ccm budgets upsert` | `upsert` |
| `pup costs ccm custom-costs upload` | `upload` |
| `pup costs ccm tag-descriptions upsert` | `upsert` |
| `pup costs ccm tag-descriptions generate` | `generate` |
| `pup app-builder publish` | `publish` |
| `pup app-builder unpublish` | `unpublish` |
| `pup users seats users unassign` | `unassign` |
| `pup scorecards outcomes batch-create` | `batch-create` (via `ends_with("-create")`) |

## Testing

- Added 16 new `assert!` cases to `test_is_write_command_name_writes()` in `src/test_commands.rs`
- All existing tests for read commands and the read-only guard integration tests remain unchanged

## Related Issues

Closes #528

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019tj93JAKf3pg2YJJERLT6F)_