### PR TITLE
feat(cost): add OCI configs and cost anomalies list commands

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -197,7 +197,7 @@ pup infrastructure hosts list
 
 ### Cost & Usage
 - **usage** - Usage and billing (summary, hourly)
-- **costs** - Cost management: `datadog` subgroup (projected, attribution, by-org, aws-config, azure-config, gcp-config) and `ccm` subgroup (custom-costs, tag-descriptions, tag-metadata, tags, tag-keys, budgets, commitments)
+- **costs** - Cost management: `datadog` subgroup (projected, attribution, by-org, aws-config, azure-config, gcp-config), `ccm` subgroup (custom-costs, tag-descriptions, tag-metadata, tags, tag-keys, budgets, commitments), `oci-configs` subgroup (list), and `anomalies` subgroup (list)
 
 ### Configuration & Data Management
 - **obs-pipelines** - Observability pipelines (list, get, create, update, delete, validate)

--- a/src/client.rs
+++ b/src/client.rs
@@ -414,6 +414,8 @@ static UNSTABLE_OPS: &[&str] = &[
     "v2.get_investigation",
     "v2.list_investigations",
     "v2.trigger_investigation",
+    // Cloud Cost Management — Anomalies (1)
+    "v2.list_cost_anomalies",
 ];
 
 // ---------------------------------------------------------------------------
@@ -636,7 +638,7 @@ static OAUTH_EXCLUDED_ENDPOINTS: &[EndpointRequirement] = &[
         path: "/api/v2/obs-pipelines/pipelines/validate",
         method: "POST",
     },
-    // Cost / Billing (9) — API key only, no OAuth support
+    // Cost / Billing (11) — API key only, no OAuth support
     EndpointRequirement {
         path: "/api/v2/usage/projected_cost",
         method: "GET",
@@ -697,6 +699,14 @@ static OAUTH_EXCLUDED_ENDPOINTS: &[EndpointRequirement] = &[
     EndpointRequirement {
         path: "/api/v2/cost/gcp_uc_config/",
         method: "DELETE",
+    },
+    EndpointRequirement {
+        path: "/api/v2/cost/oci_config",
+        method: "GET",
+    },
+    EndpointRequirement {
+        path: "/api/v2/cost/anomalies",
+        method: "GET",
     },
     // Profiling (4)
     // No OAuth scope is declared for Continuous Profiler endpoints; force API-key auth.
@@ -1273,12 +1283,12 @@ mod tests {
 
     #[test]
     fn test_unstable_ops_count() {
-        assert_eq!(UNSTABLE_OPS.len(), 162);
+        assert_eq!(UNSTABLE_OPS.len(), 163);
     }
 
     #[test]
     fn test_oauth_excluded_count() {
-        assert_eq!(OAUTH_EXCLUDED_ENDPOINTS.len(), 52);
+        assert_eq!(OAUTH_EXCLUDED_ENDPOINTS.len(), 54);
     }
 
     #[test]

--- a/src/commands/cost.rs
+++ b/src/commands/cost.rs
@@ -225,7 +225,11 @@ mod tests {
         let cfg = test_config(&server.url());
         let _mock = mock_any(&mut server, "GET", r#"{"data":[]}"#).await;
         let result = super::oci_configs_list(&cfg).await;
-        assert!(result.is_ok(), "oci_configs_list failed: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "oci_configs_list failed: {:?}",
+            result.err()
+        );
         cleanup_env();
     }
 

--- a/src/commands/cost.rs
+++ b/src/commands/cost.rs
@@ -1,5 +1,7 @@
 use anyhow::Result;
-use datadog_api_client::datadogV2::api_cloud_cost_management::CloudCostManagementAPI;
+use datadog_api_client::datadogV2::api_cloud_cost_management::{
+    CloudCostManagementAPI, ListCostAnomaliesOptionalParams,
+};
 use datadog_api_client::datadogV2::api_usage_metering::{
     GetCostByOrgOptionalParams, GetMonthlyCostAttributionOptionalParams,
     GetProjectedCostOptionalParams, UsageMeteringAPI as UsageMeteringV2API,
@@ -179,6 +181,28 @@ pub async fn gcp_config_delete(cfg: &Config, id: i64) -> Result<()> {
     Ok(())
 }
 
+// ---- Cloud Cost Management — OCI Configs ----
+
+pub async fn oci_configs_list(cfg: &Config) -> Result<()> {
+    let api = make_ccm_api(cfg);
+    let resp = api
+        .list_cost_oci_configs()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to list OCI configs: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+// ---- Cloud Cost Management — Anomalies ----
+
+pub async fn anomalies_list(cfg: &Config) -> Result<()> {
+    let api = make_ccm_api(cfg);
+    let resp = api
+        .list_cost_anomalies(ListCostAnomaliesOptionalParams::default())
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to list cost anomalies: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -191,6 +215,45 @@ mod tests {
         let cfg = test_config(&s.url());
         mock_all(&mut s, r#"{"data": []}"#).await;
         let _ = super::projected(&cfg).await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_oci_configs_list() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = mock_any(&mut server, "GET", r#"{"data":[]}"#).await;
+        let result = super::oci_configs_list(&cfg).await;
+        assert!(result.is_ok(), "oci_configs_list failed: {:?}", result.err());
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_oci_configs_list_error() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(403)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors":["Forbidden"]}"#)
+            .create_async()
+            .await;
+        let result = super::oci_configs_list(&cfg).await;
+        assert!(result.is_err(), "expected error for 403 response");
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_anomalies_list() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = mock_any(&mut server, "GET", r#"{"data":null}"#).await;
+        let result = super::anomalies_list(&cfg).await;
+        assert!(result.is_ok(), "anomalies_list failed: {:?}", result.err());
         cleanup_env();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7492,6 +7492,17 @@ enum CostActions {
         #[command(subcommand)]
         action: CostCcmActions,
     },
+    /// Manage OCI (Oracle Cloud Infrastructure) cost configs
+    #[command(name = "oci-configs")]
+    OciConfigs {
+        #[command(subcommand)]
+        action: CostOciConfigsActions,
+    },
+    /// Manage Cloud Cost Management anomalies
+    Anomalies {
+        #[command(subcommand)]
+        action: CostAnomaliesActions,
+    },
 }
 
 #[derive(Subcommand)]
@@ -7917,6 +7928,20 @@ enum CostCcmCommitmentsActions {
         #[arg(long, help = "Tag filter (key:value syntax)")]
         filter_by: Option<String>,
     },
+}
+
+// ---- Cost OCI Configs ----
+#[derive(Subcommand)]
+enum CostOciConfigsActions {
+    /// List OCI cost configs
+    List,
+}
+
+// ---- Cost Anomalies ----
+#[derive(Subcommand)]
+enum CostAnomaliesActions {
+    /// List detected cost anomalies
+    List,
 }
 
 // ---- Misc ----
@@ -13902,6 +13927,12 @@ async fn main_inner() -> anyhow::Result<()> {
                             .await?;
                         }
                     },
+                },
+                CostActions::OciConfigs { action } => match action {
+                    CostOciConfigsActions::List => commands::cost::oci_configs_list(&cfg).await?,
+                },
+                CostActions::Anomalies { action } => match action {
+                    CostAnomaliesActions::List => commands::cost::anomalies_list(&cfg).await?,
                 },
             }
         }


### PR DESCRIPTION
## Summary

Adds two new Cloud Cost Management commands surfacing endpoints picked up in the SDK upgrade (base branch `chore/upgrade-dd-sdk-to-master`, PR #539).

## Changes

- `src/commands/cost.rs` — `oci_configs_list` (ListCostOCIConfigs, SDK #1540) and `anomalies_list` (ListCostAnomalies, SDK #1588)
- `src/client.rs` — register `v2.list_cost_anomalies` as an unstable op (162 → 163); add the two API-key-only endpoints to `OAUTH_EXCLUDED_ENDPOINTS` (52 → 54)
- `src/main.rs` — `pup cost oci-configs list` and `pup cost anomalies list` subcommands + dispatch
- `docs/COMMANDS.md` — documented the new commands

## New commands

```bash
pup cost oci-configs list
pup cost anomalies list
```

## Testing

- `test_oci_configs_list` / `test_oci_configs_list_error` (happy + 403)
- `test_anomalies_list` (happy; `CostAnomaliesResponse.data` is an optional object)
- Validated locally against the pinned SDK rev: `cargo test` green, `cargo clippy` clean (no warnings in pup code).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MaHfvEkY66q99gwcPZi4Xc)_