### PR TITLE
feat(annotations): add dashboard/notebook annotations commands

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -22,6 +22,7 @@ pup <domain> <subgroup> <action> [options] # Nested commands
 | Domain | Subcommands | File | Status |
 |--------|-------------|------|--------|
 | acp | serve | src/commands/acp.rs | ✅ |
+| annotations | list, get-page, create, update, delete | src/commands/annotations.rs | ✅ (unstable) |
 | auth | login, logout, status, refresh | src/commands/auth.rs | ✅ |
 | metrics | query, list, get, search | src/commands/metrics.rs | ✅ |
 | logs | search, list, aggregate | src/commands/logs.rs | ✅ |

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -22,13 +22,12 @@ pup <domain> <subgroup> <action> [options] # Nested commands
 | Domain | Subcommands | File | Status |
 |--------|-------------|------|--------|
 | acp | serve | src/commands/acp.rs | ✅ |
-| annotations | list, get-page, create, update, delete | src/commands/annotations.rs | ✅ (unstable) |
 | auth | login, logout, status, refresh | src/commands/auth.rs | ✅ |
 | metrics | query, list, get, search | src/commands/metrics.rs | ✅ |
 | logs | search, list, aggregate | src/commands/logs.rs | ✅ |
 | traces | metrics (list, get, create, update, delete) | src/commands/traces.rs | ✅ |
 | monitors | list, get, delete, search | src/commands/monitors.rs | ✅ |
-| dashboards | list, get, delete, url | src/commands/dashboards.rs | ✅ |
+| dashboards | list, get, delete, url, annotations (list, get-page, create, update, delete) | src/commands/dashboards.rs, src/commands/annotations.rs | ✅ |
 | dbm | samples (search) | src/commands/dbm.rs | ✅ |
 | ddsql | table, time-series, spec, schema (tables, columns) | src/commands/ddsql.rs | ✅ |
 | debugger | probes (list, get, create, delete, watch) | src/commands/debugger.rs | ✅ |
@@ -50,7 +49,7 @@ pup <domain> <subgroup> <action> [options] # Nested commands
 | logs-restriction | list, get, create, update, delete, roles (list, add) | src/commands/logs_restriction.rs | ✅ |
 | processes | list | src/commands/processes.rs | ✅ |
 | users | list, get, roles, service-accounts (create, app-keys CRUD) | src/commands/users.rs | ✅ |
-| notebooks | list, get, delete | src/commands/notebooks.rs | ✅ |
+| notebooks | list, get, delete, annotations (list, get-page, create, update, delete) | src/commands/notebooks.rs, src/commands/annotations.rs | ✅ |
 | security | rules, signals, findings, content-packs, risk-scores | src/commands/security.rs | ✅ |
 | organizations | get, list | src/commands/organizations.rs | ✅ |
 | service-catalog | list, get | src/commands/service_catalog.rs | ✅ |

--- a/src/client.rs
+++ b/src/client.rs
@@ -225,6 +225,12 @@ macro_rules! make_api_no_auth {
 
 /// All unstable operations (snake_case for the Rust DD client).
 static UNSTABLE_OPS: &[&str] = &[
+    // Annotations (5)
+    "v2.create_annotation",
+    "v2.delete_annotation",
+    "v2.get_page_annotations",
+    "v2.list_annotations",
+    "v2.update_annotation",
     // Incidents (26)
     "v2.list_incidents",
     "v2.search_incidents",
@@ -1273,7 +1279,7 @@ mod tests {
 
     #[test]
     fn test_unstable_ops_count() {
-        assert_eq!(UNSTABLE_OPS.len(), 162);
+        assert_eq!(UNSTABLE_OPS.len(), 167);
     }
 
     #[test]

--- a/src/commands/annotations.rs
+++ b/src/commands/annotations.rs
@@ -1,0 +1,238 @@
+use anyhow::Result;
+use datadog_api_client::datadogV2::api_annotations::{
+    AnnotationsAPI, ListAnnotationsOptionalParams,
+};
+use datadog_api_client::datadogV2::model::{AnnotationCreateRequest, AnnotationUpdateRequest};
+
+use crate::config::Config;
+use crate::formatter;
+use crate::util;
+
+pub async fn list(
+    cfg: &Config,
+    page_id: &str,
+    start_time: i64,
+    end_time: i64,
+    widget_id: Option<String>,
+) -> Result<()> {
+    let api = crate::make_api!(AnnotationsAPI, cfg);
+    let params = if let Some(wid) = widget_id {
+        ListAnnotationsOptionalParams::default().widget_id(wid)
+    } else {
+        ListAnnotationsOptionalParams::default()
+    };
+    let resp = api
+        .list_annotations(page_id.to_string(), start_time, end_time, params)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to list annotations: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn get_page(cfg: &Config, page_id: &str, start_time: i64, end_time: i64) -> Result<()> {
+    let api = crate::make_api!(AnnotationsAPI, cfg);
+    let resp = api
+        .get_page_annotations(page_id.to_string(), start_time, end_time)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to get page annotations: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn create(cfg: &Config, file: &str) -> Result<()> {
+    let api = crate::make_api!(AnnotationsAPI, cfg);
+    let body: AnnotationCreateRequest = util::read_json_file(file)?;
+    let resp = api
+        .create_annotation(body)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to create annotation: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn update(cfg: &Config, annotation_id: uuid::Uuid, file: &str) -> Result<()> {
+    let api = crate::make_api!(AnnotationsAPI, cfg);
+    let body: AnnotationUpdateRequest = util::read_json_file(file)?;
+    let resp = api
+        .update_annotation(annotation_id, body)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to update annotation: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn delete(cfg: &Config, annotation_id: uuid::Uuid) -> Result<()> {
+    let api = crate::make_api!(AnnotationsAPI, cfg);
+    api.delete_annotation(annotation_id)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to delete annotation: {e:?}"))?;
+    println!("Successfully deleted annotation {annotation_id}");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_support::*;
+
+    #[tokio::test]
+    async fn test_annotations_list() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        mock_all(&mut s, r#"{"data":[]}"#).await;
+        let result = super::list(&cfg, "test-page", 0, 3600, None).await;
+        assert!(
+            result.is_ok(),
+            "annotations list failed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_annotations_list_error() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        s.mock("GET", mockito::Matcher::Any)
+            .with_status(403)
+            .with_body("forbidden")
+            .create_async()
+            .await;
+        let result = super::list(&cfg, "test-page", 0, 3600, None).await;
+        assert!(result.is_err());
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_annotations_get_page() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        mock_all(
+            &mut s,
+            r#"{"data":{"id":"p1","type":"page_annotations","attributes":{"annotations":{},"global_annotations":[],"widget_mapping":{}}}}"#,
+        )
+        .await;
+        let result = super::get_page(&cfg, "test-page", 0, 3600).await;
+        assert!(
+            result.is_ok(),
+            "get page annotations failed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_annotations_get_page_error() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        s.mock("GET", mockito::Matcher::Any)
+            .with_status(404)
+            .with_body(r#"{"errors":["not found"]}"#)
+            .create_async()
+            .await;
+        let result = super::get_page(&cfg, "missing-page", 0, 3600).await;
+        assert!(result.is_err());
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_annotations_create() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        mock_all(
+            &mut s,
+            r#"{"data":{"id":"00000000-0000-0000-0000-000000000001","type":"annotation","attributes":{"author_id":"u1","color":"blue","created_at":0,"description":"x","end_time":0,"modified_at":0,"page_id":"p1","start_time":0,"type":"pointInTime"}}}"#,
+        )
+        .await;
+        let tmp = write_temp_json(
+            "annotation_create.json",
+            r#"{"data":{"type":"annotation","attributes":{"color":"blue","description":"deploy","page_id":"p1","start_time":0,"type":"pointInTime"}}}"#,
+        );
+        let result = super::create(&cfg, tmp.to_str().unwrap()).await;
+        assert!(
+            result.is_ok(),
+            "annotation create failed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_annotations_create_bad_file() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        mock_all(&mut s, "{}").await;
+        let result = super::create(&cfg, "/nonexistent/file.json").await;
+        assert!(result.is_err());
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_annotations_update() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        mock_all(
+            &mut s,
+            r#"{"data":{"id":"00000000-0000-0000-0000-000000000001","type":"annotation","attributes":{"author_id":"u1","color":"blue","created_at":0,"description":"x","end_time":0,"modified_at":0,"page_id":"p1","start_time":0,"type":"pointInTime"}}}"#,
+        )
+        .await;
+        let tmp = write_temp_json(
+            "annotation_update.json",
+            r#"{"data":{"type":"annotation","attributes":{"color":"green","description":"rollback","page_id":"p1","start_time":1000,"type":"pointInTime"}}}"#,
+        );
+        let id = uuid::Uuid::nil();
+        let result = super::update(&cfg, id, tmp.to_str().unwrap()).await;
+        assert!(
+            result.is_ok(),
+            "annotation update failed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_annotations_update_bad_file() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        mock_all(&mut s, "{}").await;
+        let id = uuid::Uuid::nil();
+        let result = super::update(&cfg, id, "/nonexistent/file.json").await;
+        assert!(result.is_err());
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_annotations_delete() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        mock_all(&mut s, "").await;
+        let id = uuid::Uuid::nil();
+        let result = super::delete(&cfg, id).await;
+        assert!(
+            result.is_ok(),
+            "annotation delete failed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_annotations_delete_error() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        s.mock("DELETE", mockito::Matcher::Any)
+            .with_status(404)
+            .with_body(r#"{"errors":["not found"]}"#)
+            .create_async()
+            .await;
+        let id = uuid::Uuid::nil();
+        let result = super::delete(&cfg, id).await;
+        assert!(result.is_err());
+        cleanup_env();
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod acp;
 pub mod agent;
 pub mod agentless_scanning;
 pub mod alias;
+pub mod annotations;
 pub mod api;
 pub mod api_keys;
 pub mod apm;

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,33 +160,6 @@ enum Commands {
         #[command(subcommand)]
         action: AgentlessScanningActions,
     },
-    /// Manage Datadog annotations
-    ///
-    /// Create, list, update, and delete annotations on dashboards and notebook pages.
-    /// Annotations mark events such as deployments, incidents, or other notable moments in time.
-    ///
-    /// COMMANDS:
-    ///   list         List annotations for a page within a time window
-    ///   get-page     Get all annotations on a page grouped by widget
-    ///   create       Create a new annotation from JSON
-    ///   update       Update an existing annotation
-    ///   delete       Delete an annotation by ID
-    ///
-    /// EXAMPLES:
-    ///   pup annotations list --page-id my-page --start 0 --end 3600
-    ///   pup annotations get-page --page-id my-page --start 0 --end 3600
-    ///   pup annotations create --file annotation.json
-    ///   pup annotations update <uuid> --file updated.json
-    ///   pup annotations delete <uuid>
-    ///
-    /// AUTHENTICATION:
-    ///   Requires OAuth2 (via 'pup auth login') or DD_API_KEY + DD_APP_KEY.
-    ///   Note: Annotations API is currently in unstable/preview status.
-    #[command(verbatim_doc_comment)]
-    Annotations {
-        #[command(subcommand)]
-        action: AnnotationsActions,
-    },
     /// Create shortcuts for pup commands
     ///
     /// Aliases can be used to make shortcuts for pup commands or to compose multiple commands.
@@ -3252,6 +3225,11 @@ enum DashboardActions {
         #[command(subcommand)]
         action: WidgetActions,
     },
+    /// Manage annotations on dashboard pages
+    Annotations {
+        #[command(subcommand)]
+        action: AnnotationsActions,
+    },
 }
 
 // ---- Debugger ----
@@ -5740,6 +5718,11 @@ enum NotebookActions {
     },
     /// Delete a notebook
     Delete { notebook_id: i64 },
+    /// Manage annotations on notebook pages
+    Annotations {
+        #[command(subcommand)]
+        action: AnnotationsActions,
+    },
 }
 
 // ---- RUM ----
@@ -9217,6 +9200,33 @@ enum AnnotationsActions {
     },
 }
 
+/// Shared dispatch for annotation subcommands. Annotations attach to a page
+/// (`dashboard:<id>` or `notebook:<id>`), so the same actions are exposed under
+/// both `pup dashboards annotations` and `pup notebooks annotations`.
+async fn run_annotations(cfg: &config::Config, action: AnnotationsActions) -> anyhow::Result<()> {
+    match action {
+        AnnotationsActions::List {
+            page_id,
+            start,
+            end,
+            widget_id,
+        } => commands::annotations::list(cfg, &page_id, start, end, widget_id).await,
+        AnnotationsActions::GetPage {
+            page_id,
+            start,
+            end,
+        } => commands::annotations::get_page(cfg, &page_id, start, end).await,
+        AnnotationsActions::Create { file } => commands::annotations::create(cfg, &file).await,
+        AnnotationsActions::Update {
+            annotation_id,
+            file,
+        } => commands::annotations::update(cfg, annotation_id, &file).await,
+        AnnotationsActions::Delete { annotation_id } => {
+            commands::annotations::delete(cfg, annotation_id).await
+        }
+    }
+}
+
 // ---- Skills ----
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Subcommand)]
@@ -11059,6 +11069,7 @@ async fn main_inner() -> anyhow::Result<()> {
         Commands::Dashboards { action } => {
             cfg.validate_auth()?;
             match action {
+                DashboardActions::Annotations { action } => run_annotations(&cfg, action).await?,
                 DashboardActions::List => commands::dashboards::list(&cfg).await?,
                 DashboardActions::Get { id } => commands::dashboards::get(&cfg, &id).await?,
                 DashboardActions::Url {
@@ -12456,6 +12467,7 @@ async fn main_inner() -> anyhow::Result<()> {
         Commands::Notebooks { action } => {
             cfg.validate_auth()?;
             match action {
+                NotebookActions::Annotations { action } => run_annotations(&cfg, action).await?,
                 NotebookActions::List => commands::notebooks::list(&cfg).await?,
                 NotebookActions::Get { notebook_id } => {
                     commands::notebooks::get(&cfg, notebook_id).await?;
@@ -14375,39 +14387,6 @@ async fn main_inner() -> anyhow::Result<()> {
             AliasActions::Delete { names } => commands::alias::delete(names)?,
             AliasActions::Import { file } => commands::alias::import(&file)?,
         },
-        // --- Annotations ---
-        Commands::Annotations { action } => {
-            cfg.validate_auth()?;
-            match action {
-                AnnotationsActions::List {
-                    page_id,
-                    start,
-                    end,
-                    widget_id,
-                } => {
-                    commands::annotations::list(&cfg, &page_id, start, end, widget_id).await?;
-                }
-                AnnotationsActions::GetPage {
-                    page_id,
-                    start,
-                    end,
-                } => {
-                    commands::annotations::get_page(&cfg, &page_id, start, end).await?;
-                }
-                AnnotationsActions::Create { file } => {
-                    commands::annotations::create(&cfg, &file).await?;
-                }
-                AnnotationsActions::Update {
-                    annotation_id,
-                    file,
-                } => {
-                    commands::annotations::update(&cfg, annotation_id, &file).await?;
-                }
-                AnnotationsActions::Delete { annotation_id } => {
-                    commands::annotations::delete(&cfg, annotation_id).await?;
-                }
-            }
-        }
         // --- Api ---
         Commands::Api {
             endpoint,

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,6 +160,33 @@ enum Commands {
         #[command(subcommand)]
         action: AgentlessScanningActions,
     },
+    /// Manage Datadog annotations
+    ///
+    /// Create, list, update, and delete annotations on dashboards and notebook pages.
+    /// Annotations mark events such as deployments, incidents, or other notable moments in time.
+    ///
+    /// COMMANDS:
+    ///   list         List annotations for a page within a time window
+    ///   get-page     Get all annotations on a page grouped by widget
+    ///   create       Create a new annotation from JSON
+    ///   update       Update an existing annotation
+    ///   delete       Delete an annotation by ID
+    ///
+    /// EXAMPLES:
+    ///   pup annotations list --page-id my-page --start 0 --end 3600
+    ///   pup annotations get-page --page-id my-page --start 0 --end 3600
+    ///   pup annotations create --file annotation.json
+    ///   pup annotations update <uuid> --file updated.json
+    ///   pup annotations delete <uuid>
+    ///
+    /// AUTHENTICATION:
+    ///   Requires OAuth2 (via 'pup auth login') or DD_API_KEY + DD_APP_KEY.
+    ///   Note: Annotations API is currently in unstable/preview status.
+    #[command(verbatim_doc_comment)]
+    Annotations {
+        #[command(subcommand)]
+        action: AnnotationsActions,
+    },
     /// Create shortcuts for pup commands
     ///
     /// Aliases can be used to make shortcuts for pup commands or to compose multiple commands.
@@ -9148,6 +9175,48 @@ enum AliasActions {
     },
 }
 
+// ---- Annotations ----
+#[derive(Subcommand)]
+enum AnnotationsActions {
+    /// List annotations for a page within a time window
+    List {
+        #[arg(long, help = "Page ID (dashboard or notebook page)")]
+        page_id: String,
+        #[arg(long, help = "Start of time window (Unix epoch seconds)")]
+        start: i64,
+        #[arg(long, help = "End of time window (Unix epoch seconds)")]
+        end: i64,
+        #[arg(long, help = "Optional widget ID to filter results")]
+        widget_id: Option<String>,
+    },
+    /// Get all annotations on a page grouped by widget
+    GetPage {
+        #[arg(long, help = "Page ID (dashboard or notebook page)")]
+        page_id: String,
+        #[arg(long, help = "Start of time window (Unix epoch seconds)")]
+        start: i64,
+        #[arg(long, help = "End of time window (Unix epoch seconds)")]
+        end: i64,
+    },
+    /// Create a new annotation from a JSON file
+    Create {
+        #[arg(long, help = "JSON file with AnnotationCreateRequest body (required)")]
+        file: String,
+    },
+    /// Update an existing annotation
+    Update {
+        /// Annotation UUID
+        annotation_id: uuid::Uuid,
+        #[arg(long, help = "JSON file with AnnotationUpdateRequest body (required)")]
+        file: String,
+    },
+    /// Delete an annotation by ID
+    Delete {
+        /// Annotation UUID
+        annotation_id: uuid::Uuid,
+    },
+}
+
 // ---- Skills ----
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Subcommand)]
@@ -14306,6 +14375,39 @@ async fn main_inner() -> anyhow::Result<()> {
             AliasActions::Delete { names } => commands::alias::delete(names)?,
             AliasActions::Import { file } => commands::alias::import(&file)?,
         },
+        // --- Annotations ---
+        Commands::Annotations { action } => {
+            cfg.validate_auth()?;
+            match action {
+                AnnotationsActions::List {
+                    page_id,
+                    start,
+                    end,
+                    widget_id,
+                } => {
+                    commands::annotations::list(&cfg, &page_id, start, end, widget_id).await?;
+                }
+                AnnotationsActions::GetPage {
+                    page_id,
+                    start,
+                    end,
+                } => {
+                    commands::annotations::get_page(&cfg, &page_id, start, end).await?;
+                }
+                AnnotationsActions::Create { file } => {
+                    commands::annotations::create(&cfg, &file).await?;
+                }
+                AnnotationsActions::Update {
+                    annotation_id,
+                    file,
+                } => {
+                    commands::annotations::update(&cfg, annotation_id, &file).await?;
+                }
+                AnnotationsActions::Delete { annotation_id } => {
+                    commands::annotations::delete(&cfg, annotation_id).await?;
+                }
+            }
+        }
         // --- Api ---
         Commands::Api {
             endpoint,


### PR DESCRIPTION
## Summary

Adds the Annotations API v2 (SDK #1631) to pup. Annotations attach to a page — `dashboard:<id>` or `notebook:<id>` — and mark moments/regions in time on dashboard and notebook widgets, so the commands are nested under **both** `pup dashboards annotations` and `pup notebooks annotations` (sharing one module), rather than a top-level domain.

## Changes

- `src/commands/annotations.rs` — new module: `list`, `get_page`, `create`, `update`, `delete`
- `src/commands/mod.rs` — register the module
- `src/client.rs` — register the 5 annotation ops as unstable (`UNSTABLE_OPS` 162 → 167)
- `src/main.rs` — `Annotations` subcommand added to both `DashboardActions` and `NotebookActions`, dispatched through a shared `run_annotations` helper
- `docs/COMMANDS.md` — documented under the dashboards and notebooks rows

## New commands

```bash
pup dashboards annotations list --page-id dashboard:<id> --start <ts> --end <ts>
pup dashboards annotations create --file body.json
pup notebooks annotations list --page-id notebook:<id> --start <ts> --end <ts>
pup notebooks annotations get-page --page-id notebook:<id> --start <ts> --end <ts>
# update/delete also available under both
```

## Testing

- list / get-page / create / update / delete + error and bad-file paths
- Validated locally against the pinned SDK rev: `cargo test` green, `cargo fmt --check` clean, `cargo clippy` clean (no warnings in pup code). Top-level command alphabetical-order check passes (no new top-level command added).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)