### PR TITLE
revert: remove site/subdomain commits pushed directly to main

### DIFF
--- a/docs/OAUTH2.md
+++ b/docs/OAUTH2.md
@@ -352,11 +352,10 @@ pup auth login --org staging-child
 # subsequent commands recall it from the session registry.
 pup auth login --site ap2.datadoghq.com --org ap2-prod
 
-# A SAML/SSO org with a vanity login page (e.g. acme.datadoghq.com).
-# Pass the full host via --site so the OAuth consent page routes to the
-# correct tenant. The literal host is used verbatim; --subdomain has been
-# removed.
-pup auth login --org acme-prod --site acme.datadoghq.com
+# A SAML/SSO org. --subdomain narrows the consent page to one org for
+# tenants with subdomain-routed SSO. It is only used during the browser
+# flow and is not persisted with the session.
+pup auth login --org acme-prod --subdomain acme
 
 # Pre-target a specific org by UUID (sent as `dd_oid`). Skips the org
 # switcher when the existing browser session matches, and pre-routes

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -559,25 +559,8 @@ pup <command>
 
 ### Override API Endpoint
 
-Set `DD_SITE` (or pass `--site`) to a literal hostname to route all API and OAuth traffic
-to a custom host — for example, an API gateway, proxy, or internal service:
-
+For testing or custom deployments:
 ```bash
-# Route all traffic through a custom gateway (HTTPS required)
-export DD_SITE=mygateway.example.com
-pup <command>
-
-# With a non-standard port
-export DD_SITE=mygateway.example.com:8443
+export DD_HOST=https://custom-api.example.com
 pup <command>
 ```
-
-For SAML/SSO vanity domain logins (replaces the removed `--subdomain` flag):
-
-```bash
-# Login via mycompany.datadoghq.com instead of app.datadoghq.com
-pup auth login --site mycompany.datadoghq.com
-```
-
-**Note:** `DD_HOST` is not recognized by pup. Use `DD_SITE` instead.
-For local test servers, use `PUP_MOCK_SERVER=http://127.0.0.1:PORT` (supports `http://`).

--- a/src/auth/dcr.rs
+++ b/src/auth/dcr.rs
@@ -28,14 +28,7 @@ pub fn get_redirect_uris() -> Vec<String> {
 #[cfg(not(target_arch = "wasm32"))]
 /// DCR + token exchange client.
 pub struct DcrClient {
-    /// Normalized site used as the token-storage key.
     site: String,
-    /// Host for API calls (register, token). Canonical sites → `api.{site}`;
-    /// literal hosts (vanity/gateway) → verbatim.
-    api_host: String,
-    /// Host for the OAuth authorize redirect. Canonical sites → `app.{site}`;
-    /// literal hosts → verbatim.
-    auth_host: String,
     http: reqwest::Client,
 }
 
@@ -71,8 +64,6 @@ struct TokenResponse {
 impl DcrClient {
     pub fn new(site: &str) -> Self {
         Self {
-            api_host: crate::config::api_host_for(site),
-            auth_host: crate::config::auth_host_for(site),
             site: site.to_string(),
             http: reqwest::Client::builder()
                 .timeout(std::time::Duration::from_secs(30))
@@ -87,7 +78,7 @@ impl DcrClient {
         redirect_uri: &str,
         _scopes: &[&str],
     ) -> Result<ClientCredentials> {
-        let url = format!("https://{}/api/v2/oauth2/register", self.api_host);
+        let url = format!("https://api.{}/api/v2/oauth2/register", self.site);
 
         let body = RegistrationRequest {
             client_name: DCR_CLIENT_NAME.to_string(),
@@ -159,7 +150,7 @@ impl DcrClient {
     }
 
     async fn request_tokens(&self, params: &[(&str, &str)], client_id: &str) -> Result<TokenSet> {
-        let url = format!("https://{}/oauth2/v1/token", self.api_host);
+        let url = format!("https://api.{}/oauth2/v1/token", self.site);
 
         // Filter out empty params
         let form_params: Vec<(&str, &str)> = params
@@ -201,10 +192,7 @@ impl DcrClient {
     /// Build the authorization URL for the browser. `org_uuid` is appended as
     /// `dd_oid` when set; callers should coerce empty strings to `None`
     /// upstream so this function doesn't have to second-guess them.
-    ///
-    /// The OAuth host is derived from `auth_host`: canonical sites use `app.{site}`;
-    /// literal hosts (vanity domain or gateway) are used verbatim. Pass the full
-    /// desired host via `--site` / `DD_SITE` — `--subdomain` has been removed.
+    #[allow(clippy::too_many_arguments)]
     pub fn build_authorization_url(
         &self,
         client_id: &str,
@@ -212,6 +200,7 @@ impl DcrClient {
         state: &str,
         challenge: &super::pkce::PkceChallenge,
         scopes: &[&str],
+        subdomain: Option<&str>,
         org_uuid: Option<&str>,
     ) -> String {
         // Sort scopes so the printed authorize URL has a deterministic
@@ -235,7 +224,18 @@ impl DcrClient {
         }
         let params = serializer.finish();
 
-        format!("https://{}/oauth2/v1/authorize?{params}", self.auth_host)
+        // Use custom subdomain for SAML/SSO auth, otherwise use standard app.{site}.
+        // The subdomain replaces the `app` prefix on whichever site is in play, so a
+        // staging login (--site datad0g.com --subdomain dd) routes to dd.datad0g.com
+        // rather than collapsing to dd.datadoghq.com (prod).
+        // An empty subdomain string (`Some("")`) is coerced to `None` rather than
+        // composing `https://.{site}/...` and producing a malformed URL the browser
+        // would surface as an opaque DNS error.
+        let auth_host = match subdomain.filter(|s| !s.is_empty()) {
+            Some(sub) => format!("{sub}.{}", self.site),
+            None => format!("app.{}", self.site),
+        };
+        format!("https://{auth_host}/oauth2/v1/authorize?{params}")
     }
 }
 
@@ -253,8 +253,7 @@ mod tests {
     }
 
     #[test]
-    fn build_authorization_url_uses_app_for_canonical_site() {
-        // Canonical sites → app.{site} as OAuth host.
+    fn build_authorization_url_defaults_to_app_subdomain() {
         let client = DcrClient::new("datadoghq.com");
         let url = client.build_authorization_url(
             "client123",
@@ -263,34 +262,19 @@ mod tests {
             &challenge(),
             &["dashboards_read"],
             None,
-        );
-        assert!(
-            url.starts_with("https://app.datadoghq.com/oauth2/v1/authorize?"),
-            "expected app.datadoghq.com host, got: {url}"
-        );
-    }
-
-    #[test]
-    fn build_authorization_url_uses_app_for_eu_canonical_site() {
-        let client = DcrClient::new("datadoghq.eu");
-        let url = client.build_authorization_url(
-            "client123",
-            "http://127.0.0.1:8000/oauth/callback",
-            "state",
-            &challenge(),
-            &["dashboards_read"],
             None,
         );
         assert!(
-            url.starts_with("https://app.datadoghq.eu/oauth2/v1/authorize?"),
-            "expected app.datadoghq.eu host, got: {url}"
+            url.starts_with("https://app.datadoghq.com/oauth2/v1/authorize?"),
+            "expected app.{{site}} prefix, got: {url}"
         );
     }
 
     #[test]
-    fn build_authorization_url_uses_app_for_staging_site() {
-        // datad0g.com is canonical (staging); pass --site dd.datad0g.com for
-        // a vanity-style staging login instead of using the removed --subdomain.
+    fn build_authorization_url_uses_subdomain_on_provided_site() {
+        // The bug: --subdomain used to hardcode .datadoghq.com regardless of --site,
+        // so a staging login (datad0g.com) silently redirected to prod. The fix
+        // composes the subdomain against the actual site.
         let client = DcrClient::new("datad0g.com");
         let url = client.build_authorization_url(
             "client123",
@@ -298,11 +282,12 @@ mod tests {
             "state",
             &challenge(),
             &["dashboards_read"],
+            Some("dd"),
             None,
         );
         assert!(
-            url.starts_with("https://app.datad0g.com/oauth2/v1/authorize?"),
-            "expected app.datad0g.com host, got: {url}"
+            url.starts_with("https://dd.datad0g.com/oauth2/v1/authorize?"),
+            "expected dd.datad0g.com host, got: {url}"
         );
         assert!(
             !url.contains("datadoghq.com"),
@@ -311,37 +296,42 @@ mod tests {
     }
 
     #[test]
-    fn build_authorization_url_uses_literal_host_verbatim() {
-        // Vanity/SAML host passed directly as --site: used verbatim (replaces --subdomain).
-        let client = DcrClient::new("mycompany.datadoghq.com");
+    fn build_authorization_url_uses_subdomain_on_eu_site() {
+        let client = DcrClient::new("datadoghq.eu");
         let url = client.build_authorization_url(
             "client123",
             "http://127.0.0.1:8000/oauth/callback",
             "state",
             &challenge(),
             &["dashboards_read"],
+            Some("acme"),
             None,
         );
         assert!(
-            url.starts_with("https://mycompany.datadoghq.com/oauth2/v1/authorize?"),
-            "expected literal host, got: {url}"
+            url.starts_with("https://acme.datadoghq.eu/oauth2/v1/authorize?"),
+            "expected acme.datadoghq.eu host, got: {url}"
         );
     }
 
     #[test]
-    fn build_authorization_url_uses_gateway_host_verbatim() {
-        let client = DcrClient::new("mygateway.example.com");
+    fn build_authorization_url_treats_empty_subdomain_as_unset() {
+        // An empty `--subdomain ""` previously composed to `https://.datadoghq.com/...`,
+        // a malformed URL whose browser-side failure was an opaque DNS error.
+        // The fix coerces empty to None so we fall back to app.{site} — same shape
+        // as omitting the flag.
+        let client = DcrClient::new("datadoghq.com");
         let url = client.build_authorization_url(
             "client123",
             "http://127.0.0.1:8000/oauth/callback",
             "state",
             &challenge(),
             &["dashboards_read"],
+            Some(""),
             None,
         );
         assert!(
-            url.starts_with("https://mygateway.example.com/oauth2/v1/authorize?"),
-            "expected gateway host, got: {url}"
+            url.starts_with("https://app.datadoghq.com/oauth2/v1/authorize?"),
+            "empty subdomain should fall back to app.{{site}}, got: {url}"
         );
     }
 
@@ -354,6 +344,7 @@ mod tests {
             "the-state",
             &challenge(),
             &["dashboards_read", "metrics_read"],
+            None,
             None,
         );
         assert!(url.contains("response_type=code"));
@@ -374,6 +365,7 @@ mod tests {
             "state",
             &challenge(),
             &["dashboards_read"],
+            None,
             Some("00000000-1111-2222-3333-444444444444"),
         );
         assert!(
@@ -392,35 +384,8 @@ mod tests {
             &challenge(),
             &["dashboards_read"],
             None,
+            None,
         );
         assert!(!url.contains("dd_oid"), "got: {url}");
-    }
-
-    /// Verify that DCR registration and token exchange target the literal host
-    /// verbatim for non-canonical sites (vanity domains, custom gateways).
-    /// These URLs are constructed at call time so there is no HTTP call here;
-    /// the test inspects `api_host` indirectly by verifying the fields set at
-    /// construction, which `register`/`request_tokens` use directly.
-    #[test]
-    fn dcr_client_api_host_for_literal_site() {
-        // Canonical site: register/token should hit api.datadoghq.com.
-        let canonical = DcrClient::new("datadoghq.com");
-        assert_eq!(canonical.api_host, "api.datadoghq.com");
-        assert_eq!(canonical.auth_host, "app.datadoghq.com");
-
-        // Vanity/SAML site (literal): must use the host verbatim without prepending api.
-        let vanity = DcrClient::new("mycompany.datadoghq.com");
-        assert_eq!(vanity.api_host, "mycompany.datadoghq.com");
-        assert_eq!(vanity.auth_host, "mycompany.datadoghq.com");
-
-        // Custom gateway (literal): same — no api. prefix.
-        let gateway = DcrClient::new("mygateway.example.com");
-        assert_eq!(gateway.api_host, "mygateway.example.com");
-        assert_eq!(gateway.auth_host, "mygateway.example.com");
-
-        // Staging canonical: api./app. prefixes apply.
-        let staging = DcrClient::new("datad0g.com");
-        assert_eq!(staging.api_host, "api.datad0g.com");
-        assert_eq!(staging.auth_host, "app.datad0g.com");
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -131,48 +131,29 @@ pub fn make_dd_config(cfg: &Config) -> datadog_api_client::datadog::Configuratio
             .server_variables
             .insert("protocol".into(), protocol.into());
         dd_cfg.server_variables.insert("name".into(), url.into());
-    } else if cfg.is_literal_host() {
-        // Literal host (vanity domain or custom gateway): route via the
-        // "{protocol}://{name}" template at index 1 so the SDK targets the host
-        // verbatim without prepending "api.". Both app. and api. hosts share the
-        // same Datadog infrastructure; the correct Accept header (already set by
-        // all pup request helpers) ensures JSON error semantics regardless.
-        //
-        // Remove "site" from server_variables: Configuration::new() populates it
-        // from the DD_SITE env var, but the index-2 template `https://api.{site}`
-        // must not bleed into the index-1 `{protocol}://{name}` path.
-        //
-        // If the SDK ever stops pre-populating this key, the routing here is still
-        // correct (`name` and `protocol` are set below), so there is no user-visible
-        // regression — the remove becomes a harmless no-op. The debug_assert is a
-        // maintenance canary: it fires in debug/CI builds when DD_SITE is set yet
-        // the key was absent, alerting maintainers that the comment has become stale.
-        // `test_make_dd_config_literal_host_dd_site_env_does_not_bleed` provides
-        // equivalent coverage in CI release builds via behavioral assertion.
-        let removed = dd_cfg.server_variables.remove("site");
-        debug_assert!(
-            removed.is_some() || std::env::var("DD_SITE").is_err(),
-            "expected SDK Configuration::new() to populate server_variables[\"site\"] \
-             when DD_SITE is set; check if the SDK version changed this behavior"
-        );
-        dd_cfg.server_index = 1;
-        dd_cfg
-            .server_variables
-            .insert("protocol".into(), "https".into());
-        dd_cfg
-            .server_variables
-            .insert("name".into(), cfg.api_host());
     } else {
-        // Canonical Datadog sites: use server index 2 (same `https://api.{site}`
-        // template as index 0 but with no enum restriction, so it works for all
-        // canonical sites including staging datad0g.com).
+        // Server index 0 only accepts production sites (datadoghq.com, us3, us5,
+        // ap1, ap2, eu, gov). Server index 2 uses the same URL template but with
+        // no enum restriction, so it works for any site including staging
+        // (datad0g.com). Use index 2 for non-standard sites.
         //
         // The SDK populates `server_variables["site"]` from the DD_SITE env var
         // at Configuration::default() time. We override it with `cfg.site` so
         // programmatic site resolution (e.g. `--org` picking up a saved site
         // from the session registry) reaches the SDK without requiring the
         // user to also set DD_SITE.
-        dd_cfg.server_index = 2;
+        static STANDARD_SITES: &[&str] = &[
+            "datadoghq.com",
+            "us3.datadoghq.com",
+            "us5.datadoghq.com",
+            "ap1.datadoghq.com",
+            "ap2.datadoghq.com",
+            "datadoghq.eu",
+            "ddog-gov.com",
+        ];
+        if !STANDARD_SITES.contains(&cfg.site.as_str()) {
+            dd_cfg.server_index = 2;
+        }
         dd_cfg
             .server_variables
             .insert("site".into(), cfg.site.clone());
@@ -1220,98 +1201,10 @@ mod tests {
 
         let dd_cfg = make_dd_config(&cfg);
 
-        // All canonical sites now use index 2 (same https://api.{site} template,
-        // no enum restriction) so staging and non-standard canonicals work too.
-        assert_eq!(dd_cfg.server_index, 2);
+        assert_eq!(dd_cfg.server_index, 0);
         assert_eq!(
             dd_cfg.server_variables.get("site").map(String::as_str),
             Some("datadoghq.eu")
-        );
-    }
-
-    #[test]
-    fn test_make_dd_config_literal_host_uses_server_index_1() {
-        let _guard = ENV_LOCK.blocking_lock();
-        std::env::remove_var("PUP_MOCK_SERVER");
-        std::env::remove_var("DD_SITE");
-
-        let mut cfg = test_cfg();
-        cfg.site = "mygateway.example.com".into(); // literal, not in KNOWN_SITES
-
-        let dd_cfg = make_dd_config(&cfg);
-
-        assert_eq!(dd_cfg.server_index, 1);
-        assert_eq!(
-            dd_cfg.server_variables.get("protocol").map(String::as_str),
-            Some("https")
-        );
-        assert_eq!(
-            dd_cfg.server_variables.get("name").map(String::as_str),
-            Some("mygateway.example.com")
-        );
-        // "site" must be absent: the index-2 template expands `https://api.{site}`,
-        // so a stale "site" variable would misroute if the SDK ever blends variables
-        // across server indices.
-        assert!(
-            dd_cfg.server_variables.get("site").is_none(),
-            "site variable must not be set for literal-host path"
-        );
-    }
-
-    #[test]
-    fn test_make_dd_config_vanity_subdomain_uses_literal() {
-        let _guard = ENV_LOCK.blocking_lock();
-        std::env::remove_var("PUP_MOCK_SERVER");
-        std::env::remove_var("DD_SITE");
-
-        let mut cfg = test_cfg();
-        cfg.site = "mycompany.datadoghq.com".into(); // vanity, not in KNOWN_SITES
-
-        let dd_cfg = make_dd_config(&cfg);
-
-        assert_eq!(dd_cfg.server_index, 1);
-        assert_eq!(
-            dd_cfg.server_variables.get("name").map(String::as_str),
-            Some("mycompany.datadoghq.com")
-        );
-        // "site" must be absent: the index-2 template expands `https://api.{site}`,
-        // so a stale "site" variable would misroute if the SDK ever blends variables
-        // across server indices.
-        assert!(
-            dd_cfg.server_variables.get("site").is_none(),
-            "site variable must not be set for literal-host path"
-        );
-    }
-
-    /// When DD_SITE is set in the user's environment, the SDK's
-    /// `Configuration::new()` pre-populates `server_variables["site"]`. The
-    /// literal-host branch must remove it so the `{protocol}://{name}` template
-    /// at server_index=1 is not contaminated by the index-2 `https://api.{site}`
-    /// expansion. This test exercises the actual bleed scenario.
-    #[test]
-    fn test_make_dd_config_literal_host_dd_site_env_does_not_bleed() {
-        let _guard = ENV_LOCK.blocking_lock();
-        std::env::remove_var("PUP_MOCK_SERVER");
-        // Simulate the user having DD_SITE set in their shell environment.
-        std::env::set_var("DD_SITE", "datadoghq.com");
-
-        let mut cfg = test_cfg();
-        cfg.site = "mygateway.example.com".into(); // literal, not in KNOWN_SITES
-
-        let dd_cfg = make_dd_config(&cfg);
-
-        std::env::remove_var("DD_SITE");
-
-        assert_eq!(dd_cfg.server_index, 1);
-        assert!(
-            dd_cfg.server_variables.get("site").is_none(),
-            "DD_SITE env var must not bleed into the literal-host server_variables; \
-             got: {:?}",
-            dd_cfg.server_variables.get("site")
-        );
-        assert_eq!(
-            dd_cfg.server_variables.get("name").map(String::as_str),
-            Some("mygateway.example.com")
         );
     }
 
@@ -1458,9 +1351,8 @@ mod tests {
         std::env::set_var("DD_APP_KEY", "test-app-key");
         std::env::remove_var("PUP_MOCK_SERVER");
         let dd_cfg = make_dd_config(&cfg);
-        // Canonical sites use server_index 2 (no enum restriction, same https://api.{site}
-        // template as index 0 but works for all sites including staging).
-        assert_eq!(dd_cfg.server_index, 2);
+        // Verify unstable ops are enabled (server_index should be default 0)
+        assert_eq!(dd_cfg.server_index, 0);
         std::env::remove_var("DD_API_KEY");
         std::env::remove_var("DD_APP_KEY");
     }

--- a/src/commands/acp.rs
+++ b/src/commands/acp.rs
@@ -27,7 +27,7 @@ const LASSIE_BASE: &str = "/api/unstable/lassie-ng/v1";
 pub async fn serve(cfg: &Config, port: u16, host: &str, agent_id: Option<String>) -> Result<()> {
     cfg.validate_auth()?;
 
-    let app_base = format!("https://{}", cfg.auth_host());
+    let app_base = format!("https://app.{}", cfg.site);
     let access_token = cfg.access_token.clone();
     let api_key = cfg.api_key.clone();
     let app_key = cfg.app_key.clone();

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -35,6 +35,7 @@ fn org_suffix(org: Option<&str>) -> String {
 pub async fn login(
     cfg: &Config,
     scopes: Vec<String>,
+    subdomain: Option<&str>,
     callback_port: Option<u16>,
     org_uuid: Option<&str>,
 ) -> Result<()> {
@@ -57,8 +58,13 @@ pub async fn login(
     let mut server = crate::auth::callback::CallbackServer::new(callback_port).await?;
     let redirect_uri = server.redirect_uri();
     let org_label = org_suffix(org);
-    let auth_host = cfg.auth_host();
-    eprintln!("\n🔐 Starting OAuth2 login for site: {site} (auth host: {auth_host}){org_label}\n");
+    eprintln!("\n🔐 Starting OAuth2 login for site: {site}{org_label}\n");
+    if let Some(sub) = subdomain {
+        // Compose against the actual site, not a hardcoded prod host. Mirrors
+        // the URL-construction fix in dcr::build_authorization_url so the log
+        // line and the URL the browser opens stay in agreement on staging.
+        eprintln!("🏢 Using SAML/SSO subdomain: {sub}.{site}");
+    }
     eprintln!("📡 Callback server started on: {redirect_uri}");
 
     let scope_strs: Vec<&str> = scopes.iter().map(String::as_str).collect();
@@ -113,6 +119,7 @@ pub async fn login(
         &state,
         &challenge,
         &scope_strs,
+        subdomain,
         effective_org_uuid.as_deref(),
     );
     if let Some(uuid) = effective_org_uuid.as_deref() {
@@ -318,6 +325,7 @@ fn resolve_save_target(
 pub async fn login(
     _cfg: &Config,
     _scopes: Vec<String>,
+    _subdomain: Option<&str>,
     _callback_port: Option<u16>,
     _org_uuid: Option<&str>,
 ) -> Result<()> {

--- a/src/commands/bits.rs
+++ b/src/commands/bits.rs
@@ -23,7 +23,7 @@ pub async fn ask(
         anyhow::bail!("a query is required (or use --interactive for a conversation)");
     }
 
-    let app_base = format!("https://{}", cfg.auth_host());
+    let app_base = format!("https://app.{}", cfg.site);
 
     let agent_id = match agent_id {
         Some(id) if !id.is_empty() => id,

--- a/src/config.rs
+++ b/src/config.rs
@@ -96,17 +96,6 @@ impl Config {
         let site_explicit = explicit_site.is_some();
         let org = env_or("DD_ORG", file_cfg.org); // flag override applied in main_inner
 
-        // Reject a whitespace-only explicit site before normalize_site can silently
-        // convert it to "datadoghq.com". `env_or` filters empty strings but not
-        // whitespace-only ones; without this check, DD_SITE="  " would result in
-        // site="datadoghq.com" with site_explicit=true, blocking --org from correcting
-        // the site and silently routing to the wrong endpoint.
-        if let Some(ref raw) = explicit_site {
-            if raw.trim().is_empty() {
-                bail!("--site / DD_SITE must not be empty or whitespace-only");
-            }
-        }
-
         // Resolve site: explicit env/file > saved session for this org > default.
         // Custom-site logins record their site in the session registry, so a
         // bare `--org foo` (or DD_ORG=foo) should pick up that site automatically.
@@ -124,12 +113,6 @@ impl Config {
             })
             .unwrap_or_else(|| "datadoghq.com".into());
         let site = normalize_site(&raw_site);
-        // Validate all sources — explicit DD_SITE/config-file and session-derived —
-        // to catch URL-smuggling values before they reach URL construction.
-        // Session data is pup-written and should always be valid, but we validate
-        // unconditionally so a tampered sessions file is rejected loudly rather than
-        // silently routing to an attacker-controlled host.
-        validate_site(&site)?;
 
         // If no token from env/file, try loading from keychain/storage (where `pup auth login` saves)
         #[cfg(not(target_arch = "wasm32"))]
@@ -173,11 +156,6 @@ impl Config {
 
     /// Create configuration from explicit parameters (no env vars or filesystem).
     /// Used by the browser WASM build where `std::env` is unavailable.
-    ///
-    /// Callers are the pup browser extension (trusted internal code). The `site`
-    /// value originates from pup's own stored session data or from an in-extension
-    /// UI — it is never passed directly from untrusted browser content. Validation
-    /// at this layer is therefore omitted; the value is normalized and used as-is.
     #[cfg(feature = "browser")]
     pub fn from_params(
         site: String,
@@ -200,22 +178,12 @@ impl Config {
     }
 
     /// Override the site as if the user passed it via DD_SITE / `--site` /
-    /// config file. Validates the raw input *before* normalization so that an
-    /// empty `--site ""` is rejected rather than silently converted to
-    /// `"datadoghq.com"` by `normalize_site`'s empty-string fallback.
-    /// Keeps `site` and `site_explicit` in lockstep so a later
+    /// config file. Keeps `site` and `site_explicit` in lockstep so a later
     /// `apply_org_override` does not silently swap a user-pinned site for a
     /// session-derived one.
-    pub fn set_site_explicit(&mut self, site: String) -> Result<()> {
-        let raw = site.trim();
-        if raw.is_empty() {
-            bail!("--site / DD_SITE must not be empty");
-        }
-        let normalized = normalize_site(raw);
-        validate_site(&normalized)?;
-        self.site = normalized;
+    pub fn set_site_explicit(&mut self, site: String) {
+        self.site = normalize_site(&site);
         self.site_explicit = true;
-        Ok(())
     }
 
     /// Validate that sufficient auth credentials are configured.
@@ -257,18 +225,7 @@ impl Config {
         self.access_token.is_some()
     }
 
-    /// Returns `true` when `site` is a literal host (not a canonical Datadog site).
-    ///
-    /// Literal hosts are used verbatim in API requests and OAuth flows, enabling
-    /// vanity-domain SSO (`--site mycompany.datadoghq.com`) and custom gateway
-    /// routing (`DD_SITE=mygateway.example.com`).
-    pub fn is_literal_host(&self) -> bool {
-        !is_canonical_site(&self.site)
-    }
-
-    /// Returns the API host (e.g., `api.datadoghq.com`).
-    ///
-    /// Delegates to [`api_host_for`] after handling the `PUP_MOCK_SERVER` override.
+    /// Returns the API host (e.g., "api.datadoghq.com").
     pub fn api_host(&self) -> String {
         #[cfg(not(feature = "browser"))]
         {
@@ -279,26 +236,15 @@ impl Config {
                 return host.to_string();
             }
         }
-        api_host_for(&self.site)
+        if self.site.contains("oncall") {
+            self.site.clone()
+        } else {
+            format!("api.{}", self.site)
+        }
     }
 
-    /// Returns the OAuth authorization host (e.g., `app.datadoghq.com`).
-    ///
-    /// Canonical sites get an `app.` prefix; literal hosts are used verbatim.
-    pub fn auth_host(&self) -> String {
-        auth_host_for(&self.site)
-    }
-
-    /// Returns the full API base URL (e.g., `https://api.datadoghq.com`).
-    /// Respects `PUP_MOCK_SERVER` for testing (native/WASI only).
-    ///
-    /// Note: `api_base_url` and `api_host` handle `PUP_MOCK_SERVER` with
-    /// intentionally different semantics. `api_host` strips the scheme and
-    /// returns a bare host (e.g. `127.0.0.1:9999`), while `api_base_url`
-    /// returns the raw value including `http://` so the mock server can use
-    /// plain HTTP. Callers that need a full URL should use `api_base_url`;
-    /// callers that need only the host (e.g. for SDK `server_variables["name"]`)
-    /// should use `api_host`.
+    /// Returns the full API base URL (e.g., "https://api.datadoghq.com").
+    /// Respects PUP_MOCK_SERVER for testing (native/WASI only).
     pub fn api_base_url(&self) -> String {
         #[cfg(not(feature = "browser"))]
         {
@@ -419,14 +365,10 @@ pub fn parse_scopes(s: &str) -> Vec<String> {
 /// the environment. May leave `cfg.access_token` at `None` if no token is
 /// stored for the new pair.
 ///
-/// Returns an error if the stored session site fails validation (tampered
-/// session file). Consistent with `from_env`, which bails on an invalid site
-/// rather than routing silently to the wrong endpoint.
-///
 /// Centralized so the binary entry point and the extension dispatcher share
 /// one resolution path.
 #[cfg(all(not(feature = "browser"), not(target_arch = "wasm32")))]
-pub fn apply_org_override(cfg: &mut Config, org: String) -> Result<()> {
+pub fn apply_org_override(cfg: &mut Config, org: String) {
     cfg.org = Some(org);
     if !cfg.site_explicit {
         if let Some(saved_site) = cfg
@@ -434,22 +376,7 @@ pub fn apply_org_override(cfg: &mut Config, org: String) -> Result<()> {
             .as_deref()
             .and_then(crate::auth::storage::find_session_site)
         {
-            let normalized = normalize_site(&saved_site);
-            // Session data is pup-written and should always be valid, but bail
-            // on an invalid value so a tampered sessions file is rejected loudly
-            // rather than silently routing to the wrong (or attacker-controlled) host.
-            // Wrap with context so the user knows how to recover.
-            validate_site(&normalized).map_err(|e| {
-                anyhow::anyhow!(
-                    "session for org {:?} contains an invalid site {:?}: {}. \
-                     Run 'pup auth login --org {}' to replace the corrupted session.",
-                    cfg.org.as_deref().unwrap_or("(unknown)"),
-                    saved_site,
-                    e,
-                    cfg.org.as_deref().unwrap_or("")
-                )
-            })?;
-            cfg.site = normalized;
+            cfg.site = normalize_site(&saved_site);
         }
     }
     if std::env::var("DD_ACCESS_TOKEN")
@@ -459,7 +386,6 @@ pub fn apply_org_override(cfg: &mut Config, org: String) -> Result<()> {
     {
         cfg.access_token = load_token_from_storage(&cfg.site, cfg.org.as_deref());
     }
-    Ok(())
 }
 
 /// Try to load a valid (non-expired) access token from keychain/file storage.
@@ -550,138 +476,33 @@ where
     }
 }
 
-/// Canonical Datadog sites that use `api.{site}` for API calls and `app.{site}` for
-/// OAuth. Any other site value is treated as a **literal host** and used verbatim for
-/// both API requests and OAuth flows (enables vanity-domain and gateway use cases).
-pub const KNOWN_SITES: &[&str] = &[
-    "datadoghq.com",
-    "us3.datadoghq.com",
-    "us5.datadoghq.com",
-    "ap1.datadoghq.com",
-    "ap2.datadoghq.com",
-    "datadoghq.eu",
-    "ddog-gov.com",
-    "datad0g.com", // staging
-];
-
-/// Returns `true` when `site` is a known canonical Datadog site (applies `api.`/`app.`
-/// prefixes at request time) or an oncall passthrough. Everything else is a literal host.
+/// Normalize a raw site value from user input into a canonical form.
 ///
-/// Note: oncall hosts match by substring (`contains("oncall")`), which is a pre-existing
-/// convention. Both `api_host_for` and `auth_host_for` treat them as verbatim regardless
-/// (the `!site.contains("oncall")` guard cancels the canonical prefix), so any
-/// hostname that happens to contain "oncall" routes verbatim — the same outcome as a
-/// literal host. The practical difference is only in `normalize_site`, which skips
-/// prefix stripping for oncall hosts so the full subdomain is preserved.
-pub fn is_canonical_site(site: &str) -> bool {
-    site.contains("oncall") || KNOWN_SITES.contains(&site)
-}
-
-/// Derive the API request host from a normalized site value.
+/// Strips leading UI prefixes (`www`, `api`, `app`) and passes everything else
+/// through unchanged — including custom subdomains and regional prefixes like
+/// `us3`, `ap1`, etc.
 ///
-/// - Canonical sites → `api.{site}` (e.g. `api.datadoghq.com`).
-/// - Oncall passthroughs and literal hosts → verbatim (e.g. `mygateway.example.com`).
-pub fn api_host_for(site: &str) -> String {
-    if is_canonical_site(site) && !site.contains("oncall") {
-        format!("api.{site}")
-    } else {
-        site.to_string()
-    }
-}
-
-/// Derive the OAuth authorization host from a normalized site value.
-///
-/// - Canonical sites → `app.{site}` (e.g. `app.datadoghq.com`).
-/// - Oncall passthroughs and literal hosts → verbatim (e.g. `mycompany.datadoghq.com`).
-pub fn auth_host_for(site: &str) -> String {
-    if is_canonical_site(site) && !site.contains("oncall") {
-        format!("app.{site}")
-    } else {
-        site.to_string()
-    }
-}
-
-/// Validate a site or host string to prevent URL smuggling.
-///
-/// Allows ASCII alphanumeric, `.`, `-`, and an optional single `:port` suffix (1–65535).
-/// Rejects `/`, `#`, `?`, `@`, whitespace, `_`, embedded schemes, consecutive dots,
-/// and leading/trailing dots. An empty string is also rejected.
-pub fn validate_site(s: &str) -> Result<()> {
-    if s.is_empty() {
-        bail!("--site / DD_SITE must not be empty");
-    }
-    // Split off an optional trailing :port.
-    let (host_part, port_part) = match s.rfind(':') {
-        Some(idx) => {
-            let port = &s[idx + 1..];
-            if !port.is_empty() && port.chars().all(|c| c.is_ascii_digit()) {
-                (&s[..idx], Some(port))
-            } else {
-                (s, None)
-            }
-        }
-        None => (s, None),
-    };
-    if let Some(p) = port_part {
-        let n: u32 = p.parse().unwrap_or(0);
-        if n == 0 || n > 65535 {
-            bail!("--site / DD_SITE port {p} is out of range (1–65535)");
-        }
-    }
-    // Host part: DNS label chars only (alphanumeric, hyphen, dot).
-    if !host_part
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '.')
-    {
-        bail!(
-            "--site / DD_SITE {s:?} contains invalid characters; \
-             expected a DNS hostname (letters, digits, `.`, `-`) with an optional `:port`"
-        );
-    }
-    if host_part.starts_with('.') || host_part.ends_with('.') || host_part.contains("..") {
-        bail!(
-            "--site / DD_SITE {s:?} has invalid dot structure \
-             (leading, trailing, or consecutive dots)"
-        );
-    }
-    Ok(())
-}
-
-/// Normalize a raw site value from user input into a canonical storage form.
-///
-/// Strips any `https://` / `http://` scheme and trailing `/`, then removes a single
-/// leading `www.`, `app.`, or `api.` label. Oncall sites are passed through unchanged.
-///
-/// The stored value is then interpreted at request time via [`is_canonical_site`]:
-/// known sites get `api.`/`app.` prefixed; everything else is used verbatim as a
-/// literal host, which enables both vanity-domain SSO and custom gateway routing.
+/// Oncall sites (containing `oncall`) are always passed through unchanged.
 ///
 /// Examples:
-///   `app.datadoghq.com`           → `datadoghq.com`   (canonical)
-///   `www.datadoghq.com`           → `datadoghq.com`   (canonical)
-///   `api.datadoghq.com`           → `datadoghq.com`   (canonical)
-///   `app.us3.datadoghq.com`       → `us3.datadoghq.com` (canonical)
-///   `us3.datadoghq.com`           → `us3.datadoghq.com` (canonical)
-///   `mycompany.datadoghq.com`     → `mycompany.datadoghq.com` (literal)
-///   `mygateway.example.com:8443`  → `mygateway.example.com:8443` (literal)
+///   `app.datadoghq.com`        → `datadoghq.com`
+///   `www.datadoghq.com`        → `datadoghq.com`
+///   `api.datadoghq.com`        → `datadoghq.com`
+///   `app.us3.datadoghq.com`    → `us3.datadoghq.com`
+///   `us3.datadoghq.com`        → `us3.datadoghq.com`
+///   `custom.datadoghq.com`     → `custom.datadoghq.com`
+///   `datadoghq.com`            → `datadoghq.com`
 pub fn normalize_site(site: &str) -> String {
-    let trimmed = site
-        .trim()
-        .trim_start_matches("https://")
-        .trim_start_matches("http://")
-        .trim_end_matches('/');
-    if trimmed.is_empty() {
-        return "datadoghq.com".into();
+    if site.contains("oncall") {
+        return site.to_string();
     }
-    if trimmed.contains("oncall") {
-        return trimmed.to_string();
-    }
-    // Strip a single leading www./app./api. label.
     const STRIP_PREFIXES: &[&str] = &["www", "api", "app"];
-    match trimmed.split_once('.') {
-        Some((first, rest)) if STRIP_PREFIXES.contains(&first) => rest.to_string(),
-        _ => trimmed.to_string(),
-    }
+    let parts: Vec<&str> = site.split('.').collect();
+    let start = parts
+        .iter()
+        .position(|p| !STRIP_PREFIXES.contains(p))
+        .unwrap_or(0);
+    parts[start..].join(".")
 }
 
 #[cfg(not(feature = "browser"))]
@@ -907,11 +728,10 @@ mod tests {
         );
     }
 
-    // --- normalize_site literal-host passthrough tests ---
+    // --- normalize_site custom subdomain passthrough tests ---
 
     #[test]
     fn test_normalize_site_custom_subdomain_preserved() {
-        // Non-canonical host: stored verbatim as a literal.
         assert_eq!(
             normalize_site("customname.datadoghq.com"),
             "customname.datadoghq.com"
@@ -920,162 +740,10 @@ mod tests {
 
     #[test]
     fn test_normalize_site_app_then_custom_subdomain() {
-        // Strip leading app. to get the literal host.
         assert_eq!(
             normalize_site("app.customname.datadoghq.com"),
             "customname.datadoghq.com"
         );
-    }
-
-    #[test]
-    fn test_normalize_site_gateway_host_preserved() {
-        assert_eq!(
-            normalize_site("mygateway.example.com"),
-            "mygateway.example.com"
-        );
-    }
-
-    #[test]
-    fn test_normalize_site_gateway_host_with_port() {
-        assert_eq!(
-            normalize_site("mygateway.example.com:8443"),
-            "mygateway.example.com:8443"
-        );
-    }
-
-    #[test]
-    fn test_normalize_site_strips_https_scheme() {
-        assert_eq!(
-            normalize_site("https://mygateway.example.com/"),
-            "mygateway.example.com"
-        );
-    }
-
-    // --- is_canonical_site tests ---
-
-    #[test]
-    fn test_is_canonical_site_known_sites() {
-        for site in crate::config::KNOWN_SITES {
-            assert!(is_canonical_site(site), "{site} should be canonical");
-        }
-    }
-
-    #[test]
-    fn test_is_canonical_site_oncall() {
-        assert!(is_canonical_site("navy.oncall.datadoghq.com"));
-    }
-
-    #[test]
-    fn test_is_canonical_site_vanity_is_not_canonical() {
-        assert!(!is_canonical_site("mycompany.datadoghq.com"));
-    }
-
-    #[test]
-    fn test_is_canonical_site_gateway_is_not_canonical() {
-        assert!(!is_canonical_site("mygateway.example.com"));
-    }
-
-    // --- auth_host tests ---
-
-    #[test]
-    fn test_auth_host_canonical() {
-        let cfg = make_cfg(None, None, Some("t"));
-        assert_eq!(cfg.auth_host(), "app.datadoghq.com");
-    }
-
-    #[test]
-    fn test_auth_host_eu() {
-        let mut cfg = make_cfg(None, None, Some("t"));
-        cfg.site = "datadoghq.eu".into();
-        assert_eq!(cfg.auth_host(), "app.datadoghq.eu");
-    }
-
-    #[test]
-    fn test_auth_host_literal() {
-        let mut cfg = make_cfg(None, None, Some("t"));
-        cfg.site = "mycompany.datadoghq.com".into();
-        assert_eq!(cfg.auth_host(), "mycompany.datadoghq.com");
-    }
-
-    #[test]
-    fn test_auth_host_gateway() {
-        let mut cfg = make_cfg(None, None, Some("t"));
-        cfg.site = "mygateway.example.com".into();
-        assert_eq!(cfg.auth_host(), "mygateway.example.com");
-    }
-
-    #[test]
-    fn test_auth_host_oncall_verbatim() {
-        let mut cfg = make_cfg(None, None, Some("t"));
-        cfg.site = "navy.oncall.datadoghq.com".into();
-        assert_eq!(cfg.auth_host(), "navy.oncall.datadoghq.com");
-    }
-
-    // --- api_host literal-host tests ---
-
-    #[test]
-    fn test_api_host_literal_vanity() {
-        let _guard = ENV_LOCK.blocking_lock();
-        std::env::remove_var("PUP_MOCK_SERVER");
-        let mut cfg = make_cfg(None, None, Some("t"));
-        cfg.site = "mycompany.datadoghq.com".into();
-        assert_eq!(cfg.api_host(), "mycompany.datadoghq.com");
-    }
-
-    #[test]
-    fn test_api_host_literal_gateway() {
-        let _guard = ENV_LOCK.blocking_lock();
-        std::env::remove_var("PUP_MOCK_SERVER");
-        let mut cfg = make_cfg(None, None, Some("t"));
-        cfg.site = "mygateway.example.com:8443".into();
-        assert_eq!(cfg.api_host(), "mygateway.example.com:8443");
-    }
-
-    // --- validate_site tests ---
-
-    #[test]
-    fn test_validate_site_accepts_known_sites() {
-        for site in crate::config::KNOWN_SITES {
-            validate_site(site).unwrap_or_else(|e| panic!("{site} should be valid: {e}"));
-        }
-    }
-
-    #[test]
-    fn test_validate_site_accepts_regional_and_custom() {
-        for s in [
-            "mygateway.example.com",
-            "mycompany.datadoghq.com",
-            "gw.example.com:8443",
-            "host-1.example.com",
-        ] {
-            validate_site(s).unwrap_or_else(|e| panic!("{s:?} should be valid: {e}"));
-        }
-    }
-
-    #[test]
-    fn test_validate_site_rejects_smuggling() {
-        for bad in [
-            "evil.com/path",
-            "a#b",
-            "user@host",
-            "a b",
-            "../../etc",
-            "dd_staging",
-            "",
-        ] {
-            let err = validate_site(bad).unwrap_err();
-            let msg = format!("{err}");
-            assert!(
-                msg.contains("invalid characters") || msg.contains("empty") || msg.contains("dot"),
-                "{bad:?} should be rejected, got: {msg}"
-            );
-        }
-    }
-
-    #[test]
-    fn test_validate_site_rejects_bad_port() {
-        assert!(validate_site("host.example.com:0").is_err());
-        assert!(validate_site("host.example.com:99999").is_err());
     }
 
     #[test]
@@ -1529,7 +1197,7 @@ mod tests {
             read_only: false,
         };
 
-        super::apply_org_override(&mut cfg, "org-b".into()).unwrap();
+        super::apply_org_override(&mut cfg, "org-b".into());
 
         std::env::remove_var("PUP_CONFIG_DIR");
         let _ = std::fs::remove_dir_all(&tmp);
@@ -1573,7 +1241,7 @@ mod tests {
             read_only: false,
         };
 
-        super::apply_org_override(&mut cfg, "org-a".into()).unwrap();
+        super::apply_org_override(&mut cfg, "org-a".into());
 
         std::env::remove_var("PUP_CONFIG_DIR");
         let _ = std::fs::remove_dir_all(&tmp);
@@ -1610,7 +1278,7 @@ mod tests {
             read_only: false,
         };
 
-        super::apply_org_override(&mut cfg, "unknown-org".into()).unwrap();
+        super::apply_org_override(&mut cfg, "unknown-org".into());
 
         std::env::remove_var("PUP_CONFIG_DIR");
         let _ = std::fs::remove_dir_all(&tmp);
@@ -1647,63 +1315,13 @@ mod tests {
             read_only: false,
         };
 
-        super::apply_org_override(&mut cfg, "any-org".into()).unwrap();
+        super::apply_org_override(&mut cfg, "any-org".into());
 
         std::env::remove_var("DD_ACCESS_TOKEN");
         std::env::remove_var("PUP_CONFIG_DIR");
         let _ = std::fs::remove_dir_all(&tmp);
 
         assert_eq!(cfg.access_token.as_deref(), Some("env-supplied-token"));
-    }
-
-    /// An invalid session site must cause `apply_org_override` to bail rather
-    /// than silently leaving `cfg.site` at its pre-override value and routing
-    /// to the wrong endpoint. Consistent with `from_env` which also bails.
-    #[test]
-    fn test_apply_org_override_rejects_invalid_session_site() {
-        let _guard = ENV_LOCK.blocking_lock();
-        std::env::remove_var("DD_ACCESS_TOKEN");
-
-        let nanos = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.subsec_nanos())
-            .unwrap_or(0);
-        let tmp = std::env::temp_dir().join(format!("pup_cfg_invalid_site_{nanos}"));
-        std::fs::create_dir_all(&tmp).unwrap();
-        std::env::set_var("PUP_CONFIG_DIR", &tmp);
-
-        crate::auth::storage::save_session(&SessionEntry {
-            // Deliberately malformed — simulate a tampered sessions file.
-            site: "evil.com/path".into(),
-            org: Some("bad-org".into()),
-            org_uuid: None,
-        })
-        .unwrap();
-
-        let mut cfg = Config {
-            api_key: None,
-            app_key: None,
-            access_token: None,
-            site: "datadoghq.com".into(),
-            site_explicit: false,
-            org: None,
-            output_format: OutputFormat::Json,
-            auto_approve: false,
-            agent_mode: false,
-            read_only: false,
-        };
-
-        let result = super::apply_org_override(&mut cfg, "bad-org".into());
-
-        std::env::remove_var("PUP_CONFIG_DIR");
-        let _ = std::fs::remove_dir_all(&tmp);
-
-        assert!(
-            result.is_err(),
-            "apply_org_override must bail on an invalid session site"
-        );
-        // cfg.site must not have been updated to the invalid value.
-        assert_eq!(cfg.site, "datadoghq.com");
     }
 
     /// `set_site_explicit` keeps `site` and `site_explicit` in lockstep so a
@@ -1723,51 +1341,10 @@ mod tests {
             read_only: false,
         };
 
-        cfg.set_site_explicit("app.datadoghq.eu".into()).unwrap();
+        cfg.set_site_explicit("app.datadoghq.eu".into());
 
         assert_eq!(cfg.site, "datadoghq.eu");
         assert!(cfg.site_explicit);
-    }
-
-    #[test]
-    fn test_set_site_explicit_rejects_smuggling_value() {
-        let mut cfg = Config {
-            api_key: None,
-            app_key: None,
-            access_token: None,
-            site: "datadoghq.com".into(),
-            site_explicit: false,
-            org: None,
-            output_format: OutputFormat::Json,
-            auto_approve: false,
-            agent_mode: false,
-            read_only: false,
-        };
-        // site and site_explicit must remain unchanged on failure.
-        assert!(cfg.set_site_explicit("evil.com/path".into()).is_err());
-        assert_eq!(cfg.site, "datadoghq.com");
-        assert!(!cfg.site_explicit);
-    }
-
-    #[test]
-    fn test_set_site_explicit_rejects_empty_string() {
-        let mut cfg = Config {
-            api_key: None,
-            app_key: None,
-            access_token: None,
-            site: "datadoghq.com".into(),
-            site_explicit: false,
-            org: None,
-            output_format: OutputFormat::Json,
-            auto_approve: false,
-            agent_mode: false,
-            read_only: false,
-        };
-        // An empty --site must not silently route to datadoghq.com via
-        // normalize_site's empty-string fallback.
-        assert!(cfg.set_site_explicit("".into()).is_err());
-        assert_eq!(cfg.site, "datadoghq.com");
-        assert!(!cfg.site_explicit);
     }
 
     /// With no org, no env site, and no session, we fall back to the default
@@ -1788,44 +1365,6 @@ mod tests {
 
         assert_eq!(cfg.site, "datadoghq.com");
         assert!(!cfg.site_explicit);
-    }
-
-    /// Whitespace-only DD_SITE passes env_or's `!is_empty()` filter but must be
-    /// rejected with an error. Without this check, normalize_site would silently
-    /// reduce it to "datadoghq.com" and set site_explicit=true, blocking --org from
-    /// correcting the site and routing commands to the wrong endpoint.
-    #[test]
-    fn test_from_env_rejects_whitespace_only_dd_site() {
-        let _guard = ENV_LOCK.blocking_lock();
-        std::env::set_var("DD_SITE", "   ");
-        std::env::set_var("PUP_CONFIG_DIR", "/tmp/pup_test_nonexistent");
-        let result = Config::from_env();
-        std::env::remove_var("DD_SITE");
-        std::env::remove_var("PUP_CONFIG_DIR");
-        let err_msg = result.err().map(|e| e.to_string());
-        assert!(
-            err_msg
-                .as_deref()
-                .is_some_and(|m| m.contains("empty") || m.contains("whitespace")),
-            "expected error for whitespace-only DD_SITE, got: {err_msg:?}"
-        );
-    }
-
-    #[test]
-    fn test_from_env_rejects_invalid_dd_site() {
-        let _guard = ENV_LOCK.blocking_lock();
-        std::env::set_var("DD_SITE", "evil.com/path");
-        std::env::set_var("PUP_CONFIG_DIR", "/tmp/pup_test_nonexistent");
-        let result = Config::from_env();
-        std::env::remove_var("DD_SITE");
-        std::env::remove_var("PUP_CONFIG_DIR");
-        let err_msg = result.err().map(|e| e.to_string());
-        assert!(
-            err_msg
-                .as_deref()
-                .is_some_and(|m| m.contains("invalid characters")),
-            "expected 'invalid characters' error from from_env with bad DD_SITE, got: {err_msg:?}"
-        );
     }
 
     #[test]

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -107,14 +107,11 @@ pub(crate) fn is_builtin_command(name: &str) -> bool {
 }
 
 impl PreParsedGlobals {
-    pub fn apply_to(&self, cfg: &mut config::Config) -> anyhow::Result<()> {
+    pub fn apply_to(&self, cfg: &mut config::Config) {
         if let Some(ref fmt) = self.output {
-            // Mirror the main-path behaviour: reject unrecognised format strings loudly
-            // rather than silently falling back to JSON (which is the deliberate
-            // degradation for *ambient* config, not for an explicit --output flag).
-            cfg.output_format = fmt
-                .parse()
-                .map_err(|e| anyhow::anyhow!("invalid --output value {:?}: {}", fmt, e))?;
+            if let Ok(f) = fmt.parse() {
+                cfg.output_format = f;
+            }
         }
         if self.yes {
             cfg.auto_approve = true;
@@ -128,13 +125,12 @@ impl PreParsedGlobals {
         }
         if let Some(ref org) = self.org {
             #[cfg(all(not(feature = "browser"), not(target_arch = "wasm32")))]
-            config::apply_org_override(cfg, org.clone())?;
+            config::apply_org_override(cfg, org.clone());
             #[cfg(any(feature = "browser", target_arch = "wasm32"))]
             {
                 cfg.org = Some(org.clone());
             }
         }
-        Ok(())
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9668,13 +9668,16 @@ enum AuthActions {
         /// Shorthand: --ro
         #[arg(long, alias = "ro", visible_alias = "ro")]
         read_only: bool,
-        /// Datadog site or literal host to authenticate against.
-        /// Standard sites: datadoghq.eu, us3.datadoghq.com, etc.
-        /// Vanity/SAML SSO host: mycompany.datadoghq.com (replaces the old --subdomain flag).
-        /// Custom gateway: mygateway.example.com or mygateway.example.com:8443.
+        /// Datadog site to authenticate against (e.g. datadoghq.eu, us3.datadoghq.com).
         /// Overrides DD_SITE env var and config file. Defaults to datadoghq.com.
         #[arg(long, value_name = "SITE")]
         site: Option<String>,
+        /// Organization subdomain for SAML/SSO login (e.g. mycompany for mycompany.datadoghq.com).
+        /// Composed against --site, so `--site datad0g.com --subdomain dd` routes to dd.datad0g.com.
+        /// Whether the consent page narrows to a single org depends on per-tenant SAML routing on
+        /// the Datadog side; some subdomains still show the org switcher.
+        #[arg(long, value_name = "SUBDOMAIN")]
+        subdomain: Option<String>,
         /// Pin the OAuth callback to one specific port from the DCR redirect allowlist
         /// [8000, 8080, 8888, 9000] instead of scanning. Useful when forwarding a single port
         /// over SSH. If the chosen port is busy login fails — no fallback. Other values are
@@ -10703,6 +10706,24 @@ fn validate_callback_port(port: u16, source: &str) -> anyhow::Result<u16> {
     Ok(port)
 }
 
+/// Validate a SAML/SSO subdomain string before it's composed into the auth URL.
+/// Non-empty input must be alphanumeric plus `-` so that a value like `evil.com#`
+/// can't smuggle a different host into the URL via fragment/path tricks. The
+/// empty case is accepted because `build_authorization_url` already coerces it
+/// to "fall back to app.{site}".
+fn validate_subdomain(s: &str) -> anyhow::Result<()> {
+    if s.is_empty() {
+        return Ok(());
+    }
+    if !s.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+        anyhow::bail!(
+            "--subdomain {s:?} contains invalid characters; \
+             expected ASCII letters, digits, and `-` only"
+        );
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod resolve_callback_port_tests {
     use super::resolve_callback_port;
@@ -10802,39 +10823,34 @@ mod resolve_callback_port_tests {
     }
 
     #[test]
-    fn site_flag_accepts_valid_hosts() {
-        use crate::config::validate_site;
-        for good in [
-            "datadoghq.com",
-            "us3.datadoghq.com",
-            "mycompany.datadoghq.com",
-            "mygateway.example.com",
-            "gw.example.com:8443",
-            "host-1.example.com",
-        ] {
-            assert!(validate_site(good).is_ok(), "{good:?} should be accepted");
-        }
+    fn subdomain_accepts_alphanumeric_and_hyphen() {
+        use super::validate_subdomain;
+        assert!(validate_subdomain("").is_ok());
+        assert!(validate_subdomain("acme").is_ok());
+        assert!(validate_subdomain("dd-staging").is_ok());
+        assert!(validate_subdomain("ab123").is_ok());
     }
 
     #[test]
-    fn site_flag_rejects_url_smuggling_attempts() {
-        use crate::config::validate_site;
-        // These values would redirect API or OAuth calls to an attacker-controlled
-        // host if allowed through URL construction unchecked.
+    fn subdomain_rejects_url_smuggling_attempts() {
+        use super::validate_subdomain;
+        // The hash/dot/slash/at/space cases would each let a hand-crafted
+        // value redirect the OAuth flow to an attacker-controlled host. Pin
+        // them all as rejections rather than relying on the URL builder.
         for bad in [
-            "evil.com/path",
-            "a#b",
-            "user@host",
+            "evil.com#",
+            "evil.com",
+            "evil/path",
+            "user@evil",
             "dd staging",
             "dd_staging", // underscore not in DNS label charset
             "../../etc",
-            "",
         ] {
-            let err = validate_site(bad).unwrap_err();
+            let err = validate_subdomain(bad).unwrap_err();
             let msg = format!("{err}");
             assert!(
-                msg.contains("invalid characters") || msg.contains("empty") || msg.contains("dot"),
-                "{bad:?} should be rejected, got: {msg}"
+                msg.contains("invalid characters"),
+                "{bad:?} should be rejected with invalid-characters error, got: {msg}"
             );
         }
     }
@@ -10945,7 +10961,7 @@ async fn main_inner() -> anyhow::Result<()> {
             if !extensions::is_builtin_command(candidate) {
                 if let Some(ext_path) = extensions::extension_path(candidate) {
                     let mut cfg = config::Config::from_env()?;
-                    parsed.globals.apply_to(&mut cfg)?;
+                    parsed.globals.apply_to(&mut cfg);
                     let exit_code = extensions::exec_extension(&ext_path, &parsed.ext_args, &cfg)?;
                     std::process::exit(exit_code);
                 }
@@ -11022,7 +11038,7 @@ async fn main_inner() -> anyhow::Result<()> {
     // Site for this org and access token are also resolved here.
     if let Some(org) = cli.org {
         #[cfg(all(not(feature = "browser"), not(target_arch = "wasm32")))]
-        config::apply_org_override(&mut cfg, org)?;
+        config::apply_org_override(&mut cfg, org);
         #[cfg(any(feature = "browser", target_arch = "wasm32"))]
         {
             cfg.org = Some(org);
@@ -14796,11 +14812,15 @@ async fn main_inner() -> anyhow::Result<()> {
                 scopes,
                 read_only,
                 site,
+                subdomain,
                 callback_port,
                 org_uuid,
             } => {
                 if let Some(s) = site {
-                    cfg.set_site_explicit(s)?;
+                    cfg.set_site_explicit(s);
+                }
+                if let Some(sub) = subdomain.as_deref() {
+                    validate_subdomain(sub)?;
                 }
                 let is_read_only = read_only || cfg.read_only;
                 let resolved =
@@ -14809,12 +14829,19 @@ async fn main_inner() -> anyhow::Result<()> {
                 // Coerce empty `--org-uuid ""` to no-hint so callees treat
                 // it the same as omitting the flag, not as `dd_oid=`.
                 let org_uuid_hint = org_uuid.as_deref().filter(|s| !s.is_empty());
-                commands::auth::login(&cfg, resolved, resolved_port, org_uuid_hint).await?
+                commands::auth::login(
+                    &cfg,
+                    resolved,
+                    subdomain.as_deref(),
+                    resolved_port,
+                    org_uuid_hint,
+                )
+                .await?
             }
             AuthActions::Logout => commands::auth::logout(&cfg).await?,
             AuthActions::Status { site } => {
                 if let Some(s) = site {
-                    cfg.set_site_explicit(s)?;
+                    cfg.set_site_explicit(s);
                 }
                 commands::auth::status(&cfg)?
             }


### PR DESCRIPTION
## Summary
Commits `3175d29..3907bdc` (the `--site`/`DD_SITE` literal-host rework) were pushed **directly to `main`**, bypassing review. This PR reverts all five, returning `main` to the `v1.0.0` (`841588c`) state. Merging this restores `main` to a reviewed state.

The reverted work is re-submitted for proper review in 576 — **merge this PR first**, then 576 retargets onto `main` automatically.

## Changes
- Single revert commit undoing all five direct-to-main commits. The resulting tree is **byte-identical to the `v1.0.0` tag**.

Reverted commits:
- `3907bdc` fix(review): output validation, error message polish, debug_assert comment
- `c2b6def` fix(review): harden site validation consistency and add DD_SITE bleed test
- `d1c15c7` fix(review): close validate_site gaps and fix literal-host site variable bleed
- `6d67668` fix(review): address code review findings
- `3175d29` feat(auth): remove --subdomain, support literal hosts in --site/DD_SITE

## Testing
Tree verified identical to `v1.0.0` via `git diff 841588c` (empty).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)