### PR TITLE
chore: not really Go based

### DIFF
--- a/skills/dd-code-generation/SKILL.md
+++ b/skills/dd-code-generation/SKILL.md
@@ -20,7 +20,7 @@ Use this skill when the user:
 
 ## Pup CLI Tool
 
-The `pup` CLI is a Go-based command-line wrapper for Datadog APIs. It provides:
+The `pup` CLI is a command-line wrapper for Datadog APIs written in Rust. It provides:
 - OAuth2 authentication (preferred) or API key authentication
 - 28 command groups covering 33+ API domains
 - JSON, YAML, and table output formats


### PR DESCRIPTION
Looking at the announcement [blog post](https://www.datadoghq.com/blog/give-your-ai-agents-live-datadog-access-from-the-command-line/) I noticed that the screenshot showed "The pup CLI is a Go-based command-line wrapper..." which stood out to me.

The earliest versions of pup were in Go, but it was rewritten to Rust well before GA.