### PR TITLE
feat(tls): switch to rustls to fix enterprise MITM proxy cert failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1173,12 +1173,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1659,22 +1653,6 @@ dependencies = [
  "rustls",
  "tokio",
  "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -2276,23 +2254,6 @@ dependencies = [
  "ctutils",
  "hybrid-array",
  "num-traits",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework 3.7.0",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -3224,13 +3185,11 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -3242,7 +3201,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -4167,19 +4125,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
-dependencies = [
- "fastrand",
- "getrandom 0.4.2",
- "once_cell",
- "rustix",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4304,16 +4249,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4331,9 +4266,11 @@ checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
- "native-tls",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tungstenite",
 ]
 
@@ -4444,8 +4381,9 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "native-tls",
  "rand 0.9.4",
+ "rustls",
+ "rustls-pki-types",
  "sha1 0.10.6",
  "thiserror 2.0.18",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["native"]
 native = [
     "dep:datadog-api-client",
-    "datadog-api-client/native-tls",
+    "datadog-api-client/rustls-tls",
     "datadog-api-client/zstd",
     "datadog-api-client/retry",
     "dep:keyring",
@@ -120,7 +120,7 @@ aes-gcm = { version = "0.10", optional = true }
 # ---- Native-only dependencies ----
 
 # Synthetics tunnel
-tokio-tungstenite = { version = "0.29", features = ["native-tls"], optional = true }
+tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots"], optional = true }
 yamux = { version = "0.13", optional = true }
 russh = { version = "0.60", optional = true }
 ssh-key = { version = "0.6", features = ["p256", "std"], optional = true }

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -541,6 +541,42 @@ When opening a GitHub issue, include:
 
 ## Common Workarounds
 
+### Enterprise TLS Inspection / Custom CA Certificates
+
+Corporate environments often use TLS-inspecting proxies (MITM proxies, security
+appliances) that re-sign traffic with a custom CA certificate. pup uses
+`rustls-platform-verifier`, which delegates certificate trust to the OS:
+
+**macOS / Windows** — pup reads from the system trust store (macOS Keychain,
+Windows Certificate Store) automatically. Install your corporate CA certificate
+into the system store and pup will trust it without any additional configuration.
+
+```bash
+# macOS: add the corporate CA to the login keychain
+security add-trusted-cert -d -r trustRoot -k ~/Library/Keychains/login.keychain-db /path/to/corporate-ca.pem
+```
+
+> **Note:** `SSL_CERT_FILE` is not honored on macOS or Windows. Use the system
+> trust store instead.
+
+**Linux / other Unix** — Set the standard `SSL_CERT_FILE` or `SSL_CERT_DIR`
+environment variable pointing to your CA bundle. pup's TLS stack reads these
+automatically on startup.
+
+```bash
+# Single CA bundle
+SSL_CERT_FILE=/path/to/corporate-ca.pem pup logs search --query='service:api' --from=1h
+
+# Or export it for the session
+export SSL_CERT_FILE=/etc/ssl/certs/corporate-ca.pem
+pup <command>
+```
+
+> **Note:** If pup still fails after configuring the CA, the proxy certificate
+> may lack a Subject Alternative Name (SAN) extension. rustls enforces stricter
+> certificate validation than some older TLS stacks. Contact your network team
+> to re-issue the proxy cert with a SAN.
+
 ### Bypass SSL Verification (Not Recommended)
 
 Only for testing with self-signed certs:


### PR DESCRIPTION
## Summary

Switches pup's TLS backend from native-tls (Apple SecureTransport) to rustls via `rustls-platform-verifier`, fixing `errSSLBadCert` (-9808) failures in enterprise environments that use TLS-inspecting proxies with custom CA certificates.

## Changes

- `Cargo.toml`: `native` feature uses `datadog-api-client/rustls-tls` (was `native-tls`); `tokio-tungstenite` uses `rustls-tls-native-roots` (was `native-tls`)
- `docs/TROUBLESHOOTING.md`: new "Enterprise TLS Inspection / Custom CA Certificates" section with per-platform instructions

## How it works

`rustls-platform-verifier` delegates certificate trust to the OS:
- **macOS / Windows** — Keychain / CryptoAPI (modern SecTrust API, not the broken SecureTransport). Custom proxy CAs trusted in the system store are accepted automatically.
- **Linux** — `rustls-native-certs` honors `SSL_CERT_FILE` / `SSL_CERT_DIR` (verified in source: `rustls-native-certs` 0.8.3 `lib.rs:200-205`).

No per-call-site changes needed: removing native-tls from the feature tree automatically switches all reqwest client construction sites (including the synthetics tunnel WSS path).

## Testing

- `cargo tree -e features | grep native-tls` → empty (native-tls fully removed)
- `cargo tree -i rustls-platform-verifier` → present in all reqwest paths
- `cargo build` ✅ `cargo clippy -- -D warnings` ✅ `cargo fmt --check` ✅ `cargo test --bin pup -- --test-threads=1` ✅ (1284 passed)

> **Enterprise validation:** final confirmation depends on @EricRibeiro verifying in their environment. rustls enforces stricter cert validation than SecureTransport (e.g. requires a SAN), so if the proxy cert lacks a SAN it will still be rejected — network team would need to re-issue it.

Closes #578

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)