### PR TITLE
fix(idp): surface error when migrate-schema path not found

### DIFF
--- a/src/commands/idp/migrate.rs
+++ b/src/commands/idp/migrate.rs
@@ -1311,6 +1311,9 @@ pub async fn migrate_schema(_cfg: &Config, file: Option<String>) -> Result<()> {
                     }
                 }
             } else {
+                if !p.exists() {
+                    anyhow::bail!("path not found: '{}'", p.display());
+                }
                 vec![p]
             }
         }
@@ -1395,7 +1398,10 @@ pub async fn migrate_schema(_cfg: &Config, file: Option<String>) -> Result<()> {
 
         print_summary(&outcomes, start.elapsed());
     } else {
-        migrate_one(&paths[0], false, &schemas);
+        let outcome = migrate_one(&paths[0], false, &schemas);
+        if let MigrateStatus::Failed(msg) = outcome.status {
+            anyhow::bail!("{msg}");
+        }
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
Two silent failure modes in \`pup idp migrate-schema\` where a missing path would produce no error output.

## Changes
- **Existence check on explicit file path** (`src/commands/idp/migrate.rs`): when a file argument is provided and it is not a directory, bail early with \`path not found: '<path>'\` instead of passing a non-existent path downstream
- **Propagate single-file failure** (`src/commands/idp/migrate.rs`): capture the return value of \`migrate_one\` in the single-file branch and surface a \`Failed\` status as an error (previously the return value was discarded, so a \`NotFound\` I/O error would silently become a \`Skipped\` outcome with no output)

## Testing
- Ran \`pup idp migrate-schema /tmp/nonexistent.datadog.yaml\` → \`Error: path not found: '/tmp/nonexistent.datadog.yaml'\` (exit 1)
- Ran \`pup idp migrate-schema /tmp/empty-test-dir\` (empty dir) → \`Error: No *.datadog.yaml files found in '/tmp/empty-test-dir'\` (exit 1, pre-existing behaviour confirmed still works)
- All 26 existing migrate unit tests pass (\`cargo test migrate\`)

---
🤖 Generated with [Claude Sonnet 4.5](https://claude.ai)