### PR TITLE
feat(auth): gate credential dispatch to non-Datadog hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,7 @@ pup incidents get abc-123-def
 - `DD_API_KEY`: Datadog API key (optional if using OAuth2 or DD_ACCESS_TOKEN)
 - `DD_APP_KEY`: Datadog Application key (optional if using OAuth2 or DD_ACCESS_TOKEN)
 - `DD_SITE`: Datadog site (default: datadoghq.com)
+- `PUP_TRUST_SITE`: Trust a non-Datadog `--site`/`DD_SITE` host for this invocation without a prompt (true/1). For durable trust, add the host to `trusted_sites` in the config file. See [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md#override-api-endpoint).
 - `DD_AUTO_APPROVE`: Auto-approve destructive operations (true/false)
 - `DD_TOKEN_STORAGE`: Token storage backend (keychain or file, default: auto-detect)
 

--- a/docs/OAUTH2.md
+++ b/docs/OAUTH2.md
@@ -358,6 +358,12 @@ pup auth login --site ap2.datadoghq.com --org ap2-prod
 # removed.
 pup auth login --org acme-prod --site acme.datadoghq.com
 
+# A non-Datadog host (an API gateway or proxy) is used verbatim too, but
+# because it is not a Datadog-owned domain pup confirms before sending
+# credentials. Answer the prompt, pass --trust-site, set PUP_TRUST_SITE=1, or
+# add the host to trusted_sites in the config file. See docs/TROUBLESHOOTING.md.
+pup auth login --site mygateway.example.com --trust-site
+
 # Pre-target a specific org by UUID (sent as `dd_oid`). Skips the org
 # switcher when the existing browser session matches, and pre-routes
 # SAML/SSO routing for first-time logins. The UUID is persisted with the

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -608,6 +608,31 @@ export DD_SITE=mygateway.example.com:8443
 pup <command>
 ```
 
+Because a custom host is not a Datadog-owned domain, pup confirms before sending
+credentials there, which guards against a typo'd host silently receiving your
+tokens or API keys. On an interactive terminal you are prompted once; in
+non-interactive contexts (CI, agent mode) pup fails closed unless you opt in.
+Opt-in follows pup's flag > env > config precedence:
+
+```bash
+# This invocation only, via flag (pass it alongside --site)
+pup --site mygateway.example.com --trust-site monitors list
+
+# This invocation only, via env
+PUP_TRUST_SITE=1 DD_SITE=mygateway.example.com pup monitors list
+```
+
+For durable trust, list the host in `~/.config/pup/config.yaml` so it is never
+prompted again:
+
+```yaml
+trusted_sites:
+  - mygateway.example.com
+```
+
+Datadog-owned hosts, including the canonical sites and the vanity
+`*.datadoghq.com` domains below, are always trusted and never prompt.
+
 For SAML/SSO vanity domain logins (replaces the removed `--subdomain` flag):
 
 ```bash

--- a/src/config.rs
+++ b/src/config.rs
@@ -2264,7 +2264,7 @@ profiles:
     #[test]
     fn test_ensure_site_trusted_trust_site_flag_ok() {
         let mut cfg = make_cfg(None, None, None);
-        cfg.site = "datadog-proxy.tyrell.internal".into();
+        cfg.site = "datadog-proxy.weyland-yutani.internal".into();
         assert!(cfg.ensure_site_trusted(true, false, &[]).is_ok());
     }
 
@@ -2272,8 +2272,8 @@ profiles:
     #[test]
     fn test_ensure_site_trusted_trusted_sites_config_ok() {
         let mut cfg = make_cfg(None, None, None);
-        cfg.site = normalize_site("datadog-proxy.tyrell.internal");
-        let trusted = vec!["datadog-proxy.tyrell.internal".into()];
+        cfg.site = normalize_site("datadog-proxy.weyland-yutani.internal");
+        let trusted = vec!["datadog-proxy.weyland-yutani.internal".into()];
         assert!(cfg.ensure_site_trusted(false, false, &trusted).is_ok());
     }
 
@@ -2295,7 +2295,7 @@ profiles:
         std::env::set_var("PUP_TRUST_SITE", "1");
 
         let mut cfg = make_cfg(None, None, None);
-        cfg.site = "datadog-proxy.tyrell.internal".into();
+        cfg.site = "datadog-proxy.weyland-yutani.internal".into();
         let result = cfg.ensure_site_trusted(false, false, &[]);
 
         std::env::remove_var("PUP_TRUST_SITE");
@@ -2309,7 +2309,7 @@ profiles:
         std::env::remove_var("PUP_TRUST_SITE");
 
         let mut cfg = make_cfg(None, None, None);
-        cfg.site = "datadog-proxy.tyrell.internal".into();
+        cfg.site = "datadog-proxy.weyland-yutani.internal".into();
 
         let err = cfg
             .ensure_site_trusted(false, false, &[])
@@ -2345,19 +2345,20 @@ profiles:
         ));
         // Foreign host, no opt-in: not trusted (would otherwise refresh silently).
         assert!(!super::site_trusted_without_prompt(
-            "datadog-proxy.tyrell.internal",
+            "datadog-proxy.weyland-yutani.internal",
             &[]
         ));
         // Foreign host listed in trusted_sites (normalized): trusted.
-        let trusted = vec!["https://datadog-proxy.tyrell.internal/".into()];
+        let trusted = vec!["https://datadog-proxy.weyland-yutani.internal/".into()];
         assert!(super::site_trusted_without_prompt(
-            "datadog-proxy.tyrell.internal",
+            "datadog-proxy.weyland-yutani.internal",
             &trusted
         ));
 
         // Foreign host trusted via env.
         std::env::set_var("PUP_TRUST_SITE", "1");
-        let env_ok = super::site_trusted_without_prompt("datadog-proxy.tyrell.internal", &[]);
+        let env_ok =
+            super::site_trusted_without_prompt("datadog-proxy.weyland-yutani.internal", &[]);
         std::env::remove_var("PUP_TRUST_SITE");
         assert!(env_ok);
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2264,7 +2264,7 @@ profiles:
     #[test]
     fn test_ensure_site_trusted_trust_site_flag_ok() {
         let mut cfg = make_cfg(None, None, None);
-        cfg.site = "datadog-proxy.figma.internal".into();
+        cfg.site = "datadog-proxy.tyrell.internal".into();
         assert!(cfg.ensure_site_trusted(true, false, &[]).is_ok());
     }
 
@@ -2272,8 +2272,8 @@ profiles:
     #[test]
     fn test_ensure_site_trusted_trusted_sites_config_ok() {
         let mut cfg = make_cfg(None, None, None);
-        cfg.site = normalize_site("datadog-proxy.figma.internal");
-        let trusted = vec!["datadog-proxy.figma.internal".into()];
+        cfg.site = normalize_site("datadog-proxy.tyrell.internal");
+        let trusted = vec!["datadog-proxy.tyrell.internal".into()];
         assert!(cfg.ensure_site_trusted(false, false, &trusted).is_ok());
     }
 
@@ -2295,7 +2295,7 @@ profiles:
         std::env::set_var("PUP_TRUST_SITE", "1");
 
         let mut cfg = make_cfg(None, None, None);
-        cfg.site = "datadog-proxy.figma.internal".into();
+        cfg.site = "datadog-proxy.tyrell.internal".into();
         let result = cfg.ensure_site_trusted(false, false, &[]);
 
         std::env::remove_var("PUP_TRUST_SITE");
@@ -2309,7 +2309,7 @@ profiles:
         std::env::remove_var("PUP_TRUST_SITE");
 
         let mut cfg = make_cfg(None, None, None);
-        cfg.site = "datadog-proxy.figma.internal".into();
+        cfg.site = "datadog-proxy.tyrell.internal".into();
 
         let err = cfg
             .ensure_site_trusted(false, false, &[])
@@ -2345,19 +2345,19 @@ profiles:
         ));
         // Foreign host, no opt-in: not trusted (would otherwise refresh silently).
         assert!(!super::site_trusted_without_prompt(
-            "datadog-proxy.figma.internal",
+            "datadog-proxy.tyrell.internal",
             &[]
         ));
         // Foreign host listed in trusted_sites (normalized): trusted.
-        let trusted = vec!["https://datadog-proxy.figma.internal/".into()];
+        let trusted = vec!["https://datadog-proxy.tyrell.internal/".into()];
         assert!(super::site_trusted_without_prompt(
-            "datadog-proxy.figma.internal",
+            "datadog-proxy.tyrell.internal",
             &trusted
         ));
 
         // Foreign host trusted via env.
         std::env::set_var("PUP_TRUST_SITE", "1");
-        let env_ok = super::site_trusted_without_prompt("datadog-proxy.figma.internal", &[]);
+        let env_ok = super::site_trusted_without_prompt("datadog-proxy.tyrell.internal", &[]);
         std::env::remove_var("PUP_TRUST_SITE");
         assert!(env_ok);
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,8 @@ use anyhow::{bail, Result};
 use serde::Deserialize;
 #[cfg(not(feature = "browser"))]
 use std::collections::HashMap;
+#[cfg(all(not(feature = "browser"), not(target_arch = "wasm32")))]
+use std::io::Write;
 use std::path::PathBuf;
 
 /// Runtime configuration with precedence: flag > env > file > default.
@@ -82,6 +84,11 @@ struct FileConfig {
     scopes: Option<String>,
     /// Per-org profile settings. Profile key matches the --org value used at login.
     profiles: Option<HashMap<String, ProfileConfig>>,
+    /// Non-Datadog hosts trusted to receive credentials without a per-invocation
+    /// prompt. Mirrors `--trust-site` and `PUP_TRUST_SITE` but persists across
+    /// invocations. Each entry is normalized via `normalize_site` at comparison
+    /// time, so `app.foo.com` and `foo.com` both match `foo.com`.
+    trusted_sites: Option<Vec<String>>,
 }
 
 impl Config {
@@ -216,6 +223,90 @@ impl Config {
         self.site = normalized;
         self.site_explicit = true;
         Ok(())
+    }
+
+    /// Ensure credentials may be sent to `self.site`. Datadog-owned hosts are
+    /// always trusted. A non-Datadog host (vanity typo or enterprise proxy) must
+    /// be explicitly opted in, else — when a terminal is available — the user is
+    /// prompted once for this invocation; with no terminal and no opt-in we fail
+    /// closed rather than silently leak credentials.
+    ///
+    /// Opt-in precedence mirrors pup's flag > env > config ladder:
+    ///   --trust-site flag  >  PUP_TRUST_SITE=1 env  >  trusted_sites config.
+    ///
+    /// `trusted_sites` is sourced from the config file at the call site (see
+    /// [`configured_trusted_sites`]) rather than carried on `Config`, so this
+    /// security check stays self-contained.
+    #[cfg(not(feature = "browser"))]
+    pub fn ensure_site_trusted(
+        &self,
+        trust_site_flag: bool,
+        interactive: bool,
+        trusted_sites: &[String],
+    ) -> Result<()> {
+        // Zero friction for the common case: all Datadog-owned hosts are always trusted.
+        if is_datadog_owned_host(&self.site) {
+            return Ok(());
+        }
+
+        // --trust-site on this invocation.
+        if trust_site_flag {
+            return Ok(());
+        }
+
+        // PUP_TRUST_SITE=1 in the environment: emit one informational line (so a
+        // typo'd env value still surfaces) and proceed.
+        if env_bool("PUP_TRUST_SITE") {
+            eprintln!(
+                "Using non-Datadog host '{}' (trusted via PUP_TRUST_SITE)",
+                self.site
+            );
+            return Ok(());
+        }
+
+        // trusted_sites in config: any entry that normalizes to the current site is trusted.
+        if trusted_sites
+            .iter()
+            .any(|entry| normalize_site(entry) == self.site)
+        {
+            return Ok(());
+        }
+
+        // Interactive fallback: prompt the user once for this invocation.
+        #[cfg(not(target_arch = "wasm32"))]
+        if interactive {
+            eprintln!("⚠️  WARNING: '{}' is not a Datadog-owned host.", self.site);
+            eprintln!("    pup will send your credentials there.");
+            eprint!("    Trust this host for this command? [y/N]: ");
+            std::io::stderr().flush().ok();
+
+            let mut s = String::new();
+            std::io::stdin().read_line(&mut s)?;
+
+            if matches!(s.trim().to_lowercase().as_str(), "y" | "yes") {
+                eprintln!(
+                    "    To skip this prompt next time, add '{}' to trusted_sites in your \
+                     pup config, pass --trust-site, or set PUP_TRUST_SITE=1.",
+                    self.site
+                );
+                return Ok(());
+            }
+
+            bail!(
+                "aborted: credentials will not be sent to non-Datadog host '{}'",
+                self.site
+            );
+        }
+
+        // No terminal and no opt-in: fail closed and name every remediation.
+        bail!(
+            "'{}' is not a Datadog-owned host and no terminal was available to prompt. \
+             To send credentials there, use one of: \
+             --trust-site (this invocation), \
+             PUP_TRUST_SITE=1 (env, this invocation), \
+             or add it to trusted_sites in your pup config (durable).",
+            self.site
+        )
     }
 
     /// Validate that sufficient auth credentials are configured.
@@ -391,6 +482,32 @@ pub fn load_configured_scopes(org: Option<&str>) -> Option<Vec<String>> {
     }
 }
 
+/// Load the `trusted_sites` allowlist from the config file (empty if unset).
+/// Read at gate time rather than carried on [`Config`] so the trust feature
+/// stays self-contained; see [`Config::ensure_site_trusted`].
+#[cfg(not(feature = "browser"))]
+pub fn configured_trusted_sites() -> Vec<String> {
+    load_config_file()
+        .and_then(|c| c.trusted_sites)
+        .unwrap_or_default()
+}
+
+/// Returns `true` when `site` may receive credentials without an interactive
+/// prompt: it is Datadog-owned, or opted in via `PUP_TRUST_SITE` or the
+/// `trusted_sites` config list. This is the non-interactive subset of the
+/// [`Config::ensure_site_trusted`] ladder (it omits `--trust-site` and the
+/// prompt) — keep the two in sync. Used to gate background network calls that
+/// happen with no terminal context, such as the implicit token refresh in
+/// [`load_token_from_storage`].
+#[cfg(not(feature = "browser"))]
+pub fn site_trusted_without_prompt(site: &str, trusted_sites: &[String]) -> bool {
+    is_datadog_owned_host(site)
+        || env_bool("PUP_TRUST_SITE")
+        || trusted_sites
+            .iter()
+            .any(|entry| normalize_site(entry) == site)
+}
+
 /// Parse a comma-separated scope string into a Vec of trimmed, non-empty strings.
 #[cfg(not(feature = "browser"))]
 pub fn parse_scopes(s: &str) -> Vec<String> {
@@ -467,6 +584,14 @@ pub fn load_token_from_storage(site: &str, org: Option<&str>) -> Option<String> 
     drop(lock);
 
     let result = resolve_token(tokens, creds.as_ref(), |refresh_token, creds| {
+        // The implicit refresh runs during config load, before the command-level
+        // trust gate, and would POST the refresh token to `site`. Don't contact a
+        // non-Datadog host that hasn't been trusted non-interactively; treat the
+        // token as expired instead and let `ensure_site_trusted` prompt/fail closed
+        // at the command boundary.
+        if !site_trusted_without_prompt(site, &configured_trusted_sites()) {
+            return None;
+        }
         tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
                 let dcr_client = crate::auth::dcr::DcrClient::new(site);
@@ -2110,5 +2235,130 @@ profiles:
                 |_, _| Some(make_refreshed_token_set()),
             );
         assert!(matches!(result, super::ResolvedToken::Refreshed(_)));
+    }
+
+    // --- ensure_site_trusted tests ---
+
+    /// Datadog-owned hosts are always trusted: no flag, no env, no config needed.
+    #[test]
+    fn test_ensure_site_trusted_datadog_owned_hosts_always_ok() {
+        for site in [
+            "datadoghq.com",
+            "us3.datadoghq.com",
+            "mycompany.datadoghq.com",
+            "navy.oncall.datadoghq.com",
+            "datadoghq.eu",
+            "ddog-gov.com",
+            "datad0g.com",
+        ] {
+            let mut cfg = make_cfg(None, None, None);
+            cfg.site = site.into();
+            assert!(
+                cfg.ensure_site_trusted(false, false, &[]).is_ok(),
+                "{site} should always be trusted"
+            );
+        }
+    }
+
+    /// --trust-site flag on the invocation overrides the prompt for a foreign host.
+    #[test]
+    fn test_ensure_site_trusted_trust_site_flag_ok() {
+        let mut cfg = make_cfg(None, None, None);
+        cfg.site = "datadog-proxy.figma.internal".into();
+        assert!(cfg.ensure_site_trusted(true, false, &[]).is_ok());
+    }
+
+    /// A site listed in trusted_sites (after normalization) is trusted without a flag.
+    #[test]
+    fn test_ensure_site_trusted_trusted_sites_config_ok() {
+        let mut cfg = make_cfg(None, None, None);
+        cfg.site = normalize_site("datadog-proxy.figma.internal");
+        let trusted = vec!["datadog-proxy.figma.internal".into()];
+        assert!(cfg.ensure_site_trusted(false, false, &trusted).is_ok());
+    }
+
+    /// A trusted_sites entry is normalized before comparison, so an entry stored
+    /// with a scheme/prefix still matches the bare stored site.
+    #[test]
+    fn test_ensure_site_trusted_trusted_sites_normalized_entry_ok() {
+        let mut cfg = make_cfg(None, None, None);
+        cfg.site = "myproxy.example.com".into();
+        // Entry stored with https:// scheme — normalize_site strips it.
+        let trusted = vec!["https://myproxy.example.com/".into()];
+        assert!(cfg.ensure_site_trusted(false, false, &trusted).is_ok());
+    }
+
+    /// PUP_TRUST_SITE=1 in the environment trusts a foreign host non-interactively.
+    #[test]
+    fn test_ensure_site_trusted_env_var_ok() {
+        let _guard = ENV_LOCK.blocking_lock();
+        std::env::set_var("PUP_TRUST_SITE", "1");
+
+        let mut cfg = make_cfg(None, None, None);
+        cfg.site = "datadog-proxy.figma.internal".into();
+        let result = cfg.ensure_site_trusted(false, false, &[]);
+
+        std::env::remove_var("PUP_TRUST_SITE");
+        assert!(result.is_ok());
+    }
+
+    /// Foreign host + no opt-in + non-interactive → fail closed, message names remediations.
+    #[test]
+    fn test_ensure_site_trusted_foreign_host_no_opt_in_fails_closed() {
+        let _guard = ENV_LOCK.blocking_lock();
+        std::env::remove_var("PUP_TRUST_SITE");
+
+        let mut cfg = make_cfg(None, None, None);
+        cfg.site = "datadog-proxy.figma.internal".into();
+
+        let err = cfg
+            .ensure_site_trusted(false, false, &[])
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("trusted_sites"),
+            "error should mention trusted_sites: {err}"
+        );
+        assert!(
+            err.contains("--trust-site"),
+            "error should mention --trust-site: {err}"
+        );
+        assert!(
+            err.contains("PUP_TRUST_SITE"),
+            "error should mention PUP_TRUST_SITE: {err}"
+        );
+    }
+
+    /// The non-interactive predicate (used to gate the implicit token refresh in
+    /// `load_token_from_storage`) trusts owned hosts and config entries, and
+    /// rejects a foreign host with no opt-in.
+    #[test]
+    fn test_site_trusted_without_prompt() {
+        let _guard = ENV_LOCK.blocking_lock();
+        std::env::remove_var("PUP_TRUST_SITE");
+
+        // Datadog-owned: trusted with no opt-in.
+        assert!(super::site_trusted_without_prompt("us3.datadoghq.com", &[]));
+        assert!(super::site_trusted_without_prompt(
+            "mycompany.datadoghq.com",
+            &[]
+        ));
+        // Foreign host, no opt-in: not trusted (would otherwise refresh silently).
+        assert!(!super::site_trusted_without_prompt(
+            "datadog-proxy.figma.internal",
+            &[]
+        ));
+        // Foreign host listed in trusted_sites (normalized): trusted.
+        let trusted = vec!["https://datadog-proxy.figma.internal/".into()];
+        assert!(super::site_trusted_without_prompt(
+            "datadog-proxy.figma.internal",
+            &trusted
+        ));
+
+        // Foreign host trusted via env.
+        std::env::set_var("PUP_TRUST_SITE", "1");
+        let env_ok = super::site_trusted_without_prompt("datadog-proxy.figma.internal", &[]);
+        std::env::remove_var("PUP_TRUST_SITE");
+        assert!(env_ok);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,8 @@ pub(crate) mod test_utils {
 }
 
 use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
+#[cfg(not(target_arch = "wasm32"))]
+use std::io::IsTerminal;
 
 #[derive(Parser)]
 #[command(name = "pup", version = version::VERSION, about = "Datadog API CLI")]
@@ -59,6 +61,10 @@ pub(crate) struct Cli {
     /// Named org session (see 'pup auth login --org')
     #[arg(long, global = true)]
     org: Option<String>,
+    /// Trust a non-Datadog `--site`/`DD_SITE` host for this invocation (skip the
+    /// trust prompt). For durable trust, use `trusted_sites` in config instead.
+    #[arg(long, global = true)]
+    trust_site: bool,
     #[command(subcommand)]
     command: Commands,
 }
@@ -11052,6 +11058,24 @@ async fn main_inner() -> anyhow::Result<()> {
         }
     }
 
+    // Compute once, after agent_mode is resolved (agent mode is always non-interactive).
+    #[cfg(not(target_arch = "wasm32"))]
+    let interactive = std::io::stdin().is_terminal() && !cfg.agent_mode;
+    #[cfg(target_arch = "wasm32")]
+    let interactive = false;
+
+    // Durable trust allowlist from the config file, sourced once for all gate calls.
+    #[cfg(not(feature = "browser"))]
+    let trusted_sites = config::configured_trusted_sites();
+
+    // Gate credential dispatch to non-Datadog hosts before any command dispatches.
+    // Auth subcommands resolve their own site late (after --site is applied in-arm),
+    // so they gate themselves; skip here to avoid a double prompt.
+    #[cfg(not(feature = "browser"))]
+    if !matches!(cli.command, Commands::Auth { .. }) {
+        cfg.ensure_site_trusted(cli.trust_site, interactive, &trusted_sites)?;
+    }
+
     match cli.command {
         // --- Monitors ---
         Commands::Monitors { action } => {
@@ -14802,6 +14826,12 @@ async fn main_inner() -> anyhow::Result<()> {
                 if let Some(s) = site {
                     cfg.set_site_explicit(s)?;
                 }
+                // Gate here rather than pre-match: --site is applied above and
+                // login opens a browser carrying the real SSO cookie plus DCR
+                // client credentials to this host, so it must be checked even
+                // when --site was not passed (the from_env site is still the target).
+                #[cfg(not(feature = "browser"))]
+                cfg.ensure_site_trusted(cli.trust_site, interactive, &trusted_sites)?;
                 let is_read_only = read_only || cfg.read_only;
                 let resolved =
                     resolve_login_scopes(scopes.as_deref(), cfg.org.as_deref(), is_read_only);
@@ -14816,12 +14846,22 @@ async fn main_inner() -> anyhow::Result<()> {
                 if let Some(s) = site {
                     cfg.set_site_explicit(s)?;
                 }
+                #[cfg(not(feature = "browser"))]
+                cfg.ensure_site_trusted(cli.trust_site, interactive, &trusted_sites)?;
                 commands::auth::status(&cfg)?
             }
             #[cfg(debug_assertions)]
             AuthActions::Token => commands::auth::token(&cfg)?,
-            AuthActions::Refresh => commands::auth::refresh(&cfg).await?,
+            AuthActions::Refresh => {
+                // Refresh POSTs the stored refresh token to cfg.site; gate it like
+                // login/status (the pre-match gate skips all Auth subcommands).
+                #[cfg(not(feature = "browser"))]
+                cfg.ensure_site_trusted(cli.trust_site, interactive, &trusted_sites)?;
+                commands::auth::refresh(&cfg).await?
+            }
             AuthActions::List => commands::auth::list(&cfg)?,
+            // `auth test` only prints local config (masked keys, no network call),
+            // so it sends nothing to the host and needs no trust gate.
             AuthActions::Test => commands::test::run(&cfg)?,
         },
         // --- Workflows ---


### PR DESCRIPTION
## What

Adds a trust gate so pup does not silently send credentials to a non-Datadog host.

Builds on #576. With literal/gateway host support, a non-canonical `--site`/`DD_SITE` value (a vanity typo like `app.datadogqh.com`, or an enterprise proxy like `datadog-proxy.weyland-yutani.internal`) is used verbatim as the request host and receives the user's credentials (OAuth tokens, API+app keys, PATs). This change requires an explicit opt-in before that happens.

## Behavior

- Datadog-owned hosts (canonical sites, vanity `*.datadoghq.com` subdomains, oncall) are always trusted, zero friction. Uses the existing `is_datadog_owned_host` predicate.
- A non-Datadog host requires opt-in, following pup's existing flag > env > config precedence:
  - `--trust-site` flag (this invocation)
  - `PUP_TRUST_SITE=1` env (this invocation)
  - `trusted_sites: [...]` in the config file (durable)
- With no opt-in: prompt once on an interactive terminal; fail closed (clear error naming the remediations) when there is no terminal, so automation and agent mode never hang or silently leak. Agent mode is treated as non-interactive.

## Where it gates

- Once before non-Auth command dispatch (covers token-reuse and API+app-key paths).
- In-arm for `auth login`, `auth status`, and `auth refresh`, which resolve `--site` late or are skipped by the pre-match Auth gate. `login` must gate before browser-open and DCR registration, since the browser carries the real SSO session to the host.
- The implicit token refresh in `load_token_from_storage` (which runs during config load, before the command gate) is guarded by `site_trusted_without_prompt` so a stored foreign session does not leak its refresh token early. `auth test`/`list`/`logout`/`token` are local-only and are not gated.

## Notes

- `trusted_sites` is read at gate time rather than stored on `Config`, keeping the change self-contained (config.rs + main.rs, plus docs).
- Docs: the trust opt-in is documented in `docs/TROUBLESHOOTING.md` (custom-host section), the README env-var reference, and `docs/OAUTH2.md`.
- Known edge: when a foreign site is trusted only interactively (the prompt) or via `--trust-site`, and a stored OAuth token is already expired, the implicit refresh during config load is skipped (neither the prompt nor the flag is visible there). The command then reports "authentication expired" and routes the user to `pup auth refresh`, which gates and refreshes. Durable trust via `trusted_sites` or `PUP_TRUST_SITE` is unaffected (those refresh normally), as are API+app-key and `DD_ACCESS_TOKEN` flows (no refresh involved). The clean fix is to defer all token refresh until after the gate; left as a follow-up to keep this change's surface tight.

## Test plan

- [x] `cargo build` clean
- [x] Trust-gate unit tests pass: opt-in ladder (flag/env/config), fail-closed when non-interactive, owned-host short-circuit, and the non-interactive refresh predicate
- [x] End-to-end smoke test of the built binary (credentials via `DD_ACCESS_TOKEN`, no keychain): foreign host fails closed; `--trust-site` and `PUP_TRUST_SITE=1` let the request through (and the env path prints the audit line); owned `datadoghq.com` is never gated
- [x] CI "Check, Test & Coverage" green (full suite, including keychain-backed storage tests, runs headless) and WASM build green
