### PR TITLE
fix(auth): resolve default-session site for bare commands (#592)

### DIFF
--- a/src/auth/storage.rs
+++ b/src/auth/storage.rs
@@ -961,9 +961,10 @@ pub fn find_default_session_site() -> Option<String> {
         1 => sites.pop(),
         0 => None,
         _ => {
-            // Legacy: multiple no-org rows on different sites. New logins enforce
-            // the single-slot invariant (see prune_other_default_sessions), so this
-            // path only fires for pre-existing data and self-heals on next login.
+            // Legacy: multiple no-org rows on different sites. A bare login
+            // enforces the single-slot invariant (see prune_other_default_sessions),
+            // so this path only fires for pre-existing data and self-heals on the
+            // next bare login (a named `--org` login does not prune).
             eprintln!(
                 "Warning: multiple default (no-org) sessions on different \
                  sites ({}); not auto-selecting. Set DD_SITE or re-run \
@@ -993,21 +994,25 @@ pub fn prune_other_default_sessions(keep_site: &str) -> Result<()> {
     if to_prune.is_empty() {
         return Ok(());
     }
-    // Best-effort token deletion: initialise the storage backend only now
-    // that we know there is work to do.
+    // Remove the session rows FIRST: rows are the authoritative source of truth
+    // for resolution, so the only residue a later failure can leave is an orphan
+    // token (never read — tokens are only loaded by an explicit (site, org) key).
+    // Doing token deletion first would risk the opposite: a failed write_sessions
+    // leaving a tokenless extra no-org row, which find_default_session_site treats
+    // as ambiguous and falls back to datadoghq.com — the exact #592 failure.
+    let mut sessions = list_sessions()?;
+    sessions.retain(|s| !(s.org.is_none() && to_prune.contains(&s.site)));
+    write_sessions(&sessions)?;
+    // Best-effort token cleanup: initialise the storage backend only now that the
+    // rows are gone. delete_tokens(site, None) removes only the no-org token slot
+    // for that site; named-org tokens on the same site are untouched.
     let guard = get_storage()?;
     let mut lock = guard.lock().unwrap();
     let store = lock.as_mut().unwrap();
     for site in &to_prune {
-        // Ignore errors — orphan tokens are harmless; session rows are the
-        // authoritative source of truth for resolution.
         let _ = store.delete_tokens(site, None);
     }
-    drop(lock);
-    // Remove the session rows from the registry.
-    let mut sessions = list_sessions()?;
-    sessions.retain(|s| !(s.org.is_none() && to_prune.contains(&s.site)));
-    write_sessions(&sessions)
+    Ok(())
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -1717,6 +1722,99 @@ mod tests {
         assert!(sessions
             .iter()
             .any(|s| s.site == "datadoghq.eu" && s.org.as_deref() == Some("staging")));
+    }
+
+    #[test]
+    fn test_prune_self_heals_legacy_multiple_no_org_rows() {
+        // The central migration promise: legacy data with two no-org rows is
+        // ambiguous (find_default_session_site warns + returns None), but a bare
+        // login's prune collapses it to one, after which resolution recovers.
+        let _lock = crate::test_utils::ENV_LOCK.blocking_lock();
+        let tmp = TempDir::new("prune_self_heal");
+        std::env::set_var("PUP_CONFIG_DIR", tmp.path());
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+
+        save_session(&SessionEntry {
+            site: "datadoghq.com".into(),
+            org: None,
+            org_uuid: None,
+        })
+        .unwrap();
+        save_session(&SessionEntry {
+            site: "datadoghq.eu".into(),
+            org: None,
+            org_uuid: None,
+        })
+        .unwrap();
+
+        // Ambiguous before: two no-org rows → None.
+        assert!(find_default_session_site().is_none());
+
+        // A bare login to .eu prunes the .com no-org row.
+        prune_other_default_sessions("datadoghq.eu").unwrap();
+
+        // Recovered: exactly one no-org row, resolution returns it.
+        let healed = find_default_session_site();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+        std::env::remove_var("PUP_CONFIG_DIR");
+        assert_eq!(healed.as_deref(), Some("datadoghq.eu"));
+    }
+
+    #[test]
+    fn test_prune_deletes_only_other_no_org_token() {
+        // Token hygiene + safety: prune deletes the displaced site's no-org token
+        // but leaves the kept site's no-org token and any named-org token intact.
+        let _lock = crate::test_utils::ENV_LOCK.blocking_lock();
+        let tmp = TempDir::new("prune_tokens");
+        std::env::set_var("PUP_CONFIG_DIR", tmp.path());
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+
+        let guard = get_storage().unwrap();
+        {
+            let lock = guard.lock().unwrap();
+            let store = lock.as_ref().unwrap();
+            store
+                .save_tokens("datadoghq.com", None, &make_token("com-default"))
+                .unwrap();
+            store
+                .save_tokens("datadoghq.com", Some("prod"), &make_token("com-prod"))
+                .unwrap();
+            store
+                .save_tokens("datadoghq.eu", None, &make_token("eu-default"))
+                .unwrap();
+        }
+        save_session(&SessionEntry {
+            site: "datadoghq.com".into(),
+            org: None,
+            org_uuid: None,
+        })
+        .unwrap();
+        save_session(&SessionEntry {
+            site: "datadoghq.eu".into(),
+            org: None,
+            org_uuid: None,
+        })
+        .unwrap();
+
+        prune_other_default_sessions("datadoghq.eu").unwrap();
+
+        let lock = guard.lock().unwrap();
+        let store = lock.as_ref().unwrap();
+        let com_default = store.load_tokens("datadoghq.com", None).unwrap();
+        let com_prod = store.load_tokens("datadoghq.com", Some("prod")).unwrap();
+        let eu_default = store.load_tokens("datadoghq.eu", None).unwrap();
+        drop(lock);
+        std::env::remove_var("DD_TOKEN_STORAGE");
+        std::env::remove_var("PUP_CONFIG_DIR");
+
+        // Displaced no-org token gone; named-org token on the same site and the
+        // kept site's no-org token both survive.
+        assert!(
+            com_default.is_none(),
+            "displaced no-org .com token should be deleted"
+        );
+        assert!(com_prod.is_some(), "named-org .com token must survive");
+        assert!(eu_default.is_some(), "kept-site no-org token must survive");
     }
 
     // --- detect_backend ---------------------------------------------------------

--- a/src/auth/storage.rs
+++ b/src/auth/storage.rs
@@ -943,6 +943,73 @@ pub fn find_session_site(org: &str) -> Option<String> {
     }
 }
 
+/// Return the site for the single no-org ("default") session, if there is
+/// exactly one. Zero → None. Multiple (legacy data before the single-slot
+/// invariant was enforced) → warns and returns None so the caller falls
+/// through to `datadoghq.com`; the next bare login self-heals to one entry.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn find_default_session_site() -> Option<String> {
+    let mut sites: Vec<String> = list_sessions()
+        .ok()?
+        .into_iter()
+        .filter(|s| s.org.is_none())
+        .map(|s| s.site)
+        .collect();
+    sites.sort();
+    sites.dedup();
+    match sites.len() {
+        1 => sites.pop(),
+        0 => None,
+        _ => {
+            // Legacy: multiple no-org rows on different sites. New logins enforce
+            // the single-slot invariant (see prune_other_default_sessions), so this
+            // path only fires for pre-existing data and self-heals on next login.
+            eprintln!(
+                "Warning: multiple default (no-org) sessions on different \
+                 sites ({}); not auto-selecting. Set DD_SITE or re-run \
+                 pup auth login.",
+                sites.join(", ")
+            );
+            None
+        }
+    }
+}
+
+/// Remove session registry rows for `(site != keep_site, org=None)` and
+/// best-effort delete their stored tokens, enforcing the single-slot
+/// invariant for the no-org ("default") session. Called after a bare login
+/// so that switching regions replaces the previous unnamed default rather
+/// than accumulating ambiguous entries that confuse `find_default_session_site`.
+///
+/// Named-org sessions on any site are never touched.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn prune_other_default_sessions(keep_site: &str) -> Result<()> {
+    let sessions = list_sessions()?;
+    let to_prune: Vec<String> = sessions
+        .into_iter()
+        .filter(|s| s.org.is_none() && s.site != keep_site)
+        .map(|s| s.site)
+        .collect();
+    if to_prune.is_empty() {
+        return Ok(());
+    }
+    // Best-effort token deletion: initialise the storage backend only now
+    // that we know there is work to do.
+    let guard = get_storage()?;
+    let mut lock = guard.lock().unwrap();
+    let store = lock.as_mut().unwrap();
+    for site in &to_prune {
+        // Ignore errors — orphan tokens are harmless; session rows are the
+        // authoritative source of truth for resolution.
+        let _ = store.delete_tokens(site, None);
+    }
+    drop(lock);
+    // Remove the session rows from the registry.
+    let mut sessions = list_sessions()?;
+    sessions.retain(|s| !(s.org.is_none() && to_prune.contains(&s.site)));
+    write_sessions(&sessions)
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 fn write_sessions(sessions: &[SessionEntry]) -> Result<()> {
     let path = match sessions_path() {
@@ -1477,6 +1544,179 @@ mod tests {
         std::env::remove_var("PUP_CONFIG_DIR");
 
         assert!(result.is_none());
+    }
+
+    // --- find_default_session_site -----------------------------------------------
+
+    #[test]
+    fn test_find_default_session_site_no_sessions() {
+        let _lock = crate::test_utils::ENV_LOCK.blocking_lock();
+        let tmp = TempDir::new("fds_none");
+        std::env::set_var("PUP_CONFIG_DIR", tmp.path());
+        let result = find_default_session_site();
+        std::env::remove_var("PUP_CONFIG_DIR");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_find_default_session_site_one_no_org_row() {
+        let _lock = crate::test_utils::ENV_LOCK.blocking_lock();
+        let tmp = TempDir::new("fds_one");
+        std::env::set_var("PUP_CONFIG_DIR", tmp.path());
+        save_session(&SessionEntry {
+            site: "datadoghq.eu".into(),
+            org: None,
+            org_uuid: None,
+        })
+        .unwrap();
+        // Named-org sessions on other sites must not interfere.
+        save_session(&SessionEntry {
+            site: "datadoghq.com".into(),
+            org: Some("prod".into()),
+            org_uuid: None,
+        })
+        .unwrap();
+        let result = find_default_session_site();
+        std::env::remove_var("PUP_CONFIG_DIR");
+        assert_eq!(result.as_deref(), Some("datadoghq.eu"));
+    }
+
+    #[test]
+    fn test_find_default_session_site_multiple_no_org_rows_returns_none() {
+        // Legacy data: two no-org rows → ambiguous; warn + return None.
+        let _lock = crate::test_utils::ENV_LOCK.blocking_lock();
+        let tmp = TempDir::new("fds_multi");
+        std::env::set_var("PUP_CONFIG_DIR", tmp.path());
+        save_session(&SessionEntry {
+            site: "datadoghq.com".into(),
+            org: None,
+            org_uuid: None,
+        })
+        .unwrap();
+        save_session(&SessionEntry {
+            site: "datadoghq.eu".into(),
+            org: None,
+            org_uuid: None,
+        })
+        .unwrap();
+        let result = find_default_session_site();
+        std::env::remove_var("PUP_CONFIG_DIR");
+        assert!(result.is_none());
+    }
+
+    // --- prune_other_default_sessions -------------------------------------------
+
+    #[test]
+    fn test_prune_removes_other_no_org_sites() {
+        let _lock = crate::test_utils::ENV_LOCK.blocking_lock();
+        let tmp = TempDir::new("prune_removes");
+        std::env::set_var("PUP_CONFIG_DIR", tmp.path());
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+
+        // Old default session on .com; we are now logging into .eu.
+        save_session(&SessionEntry {
+            site: "datadoghq.com".into(),
+            org: None,
+            org_uuid: None,
+        })
+        .unwrap();
+        // Named-org session on .com — must survive.
+        save_session(&SessionEntry {
+            site: "datadoghq.com".into(),
+            org: Some("prod".into()),
+            org_uuid: None,
+        })
+        .unwrap();
+        // New default session we are keeping.
+        save_session(&SessionEntry {
+            site: "datadoghq.eu".into(),
+            org: None,
+            org_uuid: None,
+        })
+        .unwrap();
+
+        prune_other_default_sessions("datadoghq.eu").unwrap();
+
+        let sessions = list_sessions().unwrap();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+        std::env::remove_var("PUP_CONFIG_DIR");
+
+        // No-org .com row is gone.
+        assert!(!sessions
+            .iter()
+            .any(|s| s.site == "datadoghq.com" && s.org.is_none()));
+        // Keep-site no-org row survives.
+        assert!(sessions
+            .iter()
+            .any(|s| s.site == "datadoghq.eu" && s.org.is_none()));
+        // Named-org row on .com survives.
+        assert!(sessions
+            .iter()
+            .any(|s| s.site == "datadoghq.com" && s.org.as_deref() == Some("prod")));
+    }
+
+    #[test]
+    fn test_prune_no_op_when_only_keep_site() {
+        let _lock = crate::test_utils::ENV_LOCK.blocking_lock();
+        let tmp = TempDir::new("prune_noop");
+        std::env::set_var("PUP_CONFIG_DIR", tmp.path());
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+
+        save_session(&SessionEntry {
+            site: "datadoghq.com".into(),
+            org: None,
+            org_uuid: None,
+        })
+        .unwrap();
+
+        // Pruning for the same site should be a no-op.
+        prune_other_default_sessions("datadoghq.com").unwrap();
+
+        let sessions = list_sessions().unwrap();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+        std::env::remove_var("PUP_CONFIG_DIR");
+
+        assert_eq!(sessions.len(), 1);
+        assert!(sessions[0].org.is_none());
+        assert_eq!(sessions[0].site, "datadoghq.com");
+    }
+
+    #[test]
+    fn test_prune_named_org_sessions_untouched() {
+        // prune_other_default_sessions must never remove named-org sessions
+        // on any site, including the kept site and other sites.
+        let _lock = crate::test_utils::ENV_LOCK.blocking_lock();
+        let tmp = TempDir::new("prune_named");
+        std::env::set_var("PUP_CONFIG_DIR", tmp.path());
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+
+        save_session(&SessionEntry {
+            site: "datadoghq.com".into(),
+            org: Some("prod".into()),
+            org_uuid: None,
+        })
+        .unwrap();
+        save_session(&SessionEntry {
+            site: "datadoghq.eu".into(),
+            org: Some("staging".into()),
+            org_uuid: None,
+        })
+        .unwrap();
+
+        prune_other_default_sessions("datadoghq.eu").unwrap();
+
+        let sessions = list_sessions().unwrap();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+        std::env::remove_var("PUP_CONFIG_DIR");
+
+        // Both named-org sessions survive.
+        assert_eq!(sessions.len(), 2);
+        assert!(sessions
+            .iter()
+            .any(|s| s.site == "datadoghq.com" && s.org.as_deref() == Some("prod")));
+        assert!(sessions
+            .iter()
+            .any(|s| s.site == "datadoghq.eu" && s.org.as_deref() == Some("staging")));
     }
 
     // --- detect_backend ---------------------------------------------------------

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -234,6 +234,13 @@ pub async fn login(
         org_uuid: saved_org_uuid,
     })?;
 
+    // Enforce the single-slot invariant: a bare login (no org) replaces any
+    // previous no-org session on a different site so that
+    // find_default_session_site() always sees at most one entry.
+    if saved_org.is_none() {
+        storage::prune_other_default_sessions(effective_site)?;
+    }
+
     let expires_at = chrono::DateTime::from_timestamp(tokens.issued_at + tokens.expires_in, 0)
         .map(|dt| dt.with_timezone(&chrono::Local).to_rfc3339())
         .unwrap_or_else(|| format!("in {} hours", tokens.expires_in / 3600));

--- a/src/config.rs
+++ b/src/config.rs
@@ -129,6 +129,26 @@ impl Config {
                     None
                 }
             })
+            .or_else(|| {
+                // When no org is set and no explicit site was given, fall back to
+                // the single no-org ("default") session's site. This fixes bare
+                // commands after a datacenter-switched login (e.g. datadoghq.eu):
+                // the token is stored under the switched site but the resolver
+                // previously hard-coded datadoghq.com. Named-org sessions are
+                // unaffected — this branch only fires when org.is_none().
+                #[cfg(not(target_arch = "wasm32"))]
+                {
+                    if org.is_none() {
+                        crate::auth::storage::find_default_session_site()
+                    } else {
+                        None
+                    }
+                }
+                #[cfg(target_arch = "wasm32")]
+                {
+                    None
+                }
+            })
             .unwrap_or_else(|| "datadoghq.com".into());
         let site = normalize_site(&raw_site);
         // Validate all sources — explicit DD_SITE/config-file and session-derived —
@@ -2361,5 +2381,119 @@ profiles:
             super::site_trusted_without_prompt("datadog-proxy.weyland-yutani.internal", &[]);
         std::env::remove_var("PUP_TRUST_SITE");
         assert!(env_ok);
+    }
+
+    // --- from_env: default-session fallback (pup#592) ---------------------------
+
+    /// Bare invocation with a no-org EU session resolves to datadoghq.eu, not
+    /// datadoghq.com. This is the core #592 regression test.
+    #[test]
+    fn test_from_env_bare_uses_default_session_site() {
+        let _guard = ENV_LOCK.blocking_lock();
+        std::env::remove_var("DD_SITE");
+        std::env::remove_var("DD_ORG");
+        std::env::remove_var("DD_ACCESS_TOKEN");
+        std::env::remove_var("DD_API_KEY");
+        std::env::remove_var("DD_APP_KEY");
+
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.subsec_nanos())
+            .unwrap_or(0);
+        let tmp = std::env::temp_dir().join(format!("pup_cfg_bare_eu_{nanos}"));
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::env::set_var("PUP_CONFIG_DIR", &tmp);
+
+        crate::auth::storage::save_session(&SessionEntry {
+            site: "datadoghq.eu".into(),
+            org: None,
+            org_uuid: None,
+        })
+        .unwrap();
+
+        let cfg = Config::from_env().unwrap();
+
+        std::env::remove_var("PUP_CONFIG_DIR");
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        assert_eq!(cfg.site, "datadoghq.eu");
+        // site_explicit must remain false — the source was a session, not DD_SITE.
+        assert!(!cfg.site_explicit);
+    }
+
+    /// When DD_SITE is set explicitly it always wins over the default-session
+    /// fallback.
+    #[test]
+    fn test_from_env_explicit_dd_site_wins_over_default_session() {
+        let _guard = ENV_LOCK.blocking_lock();
+        std::env::remove_var("DD_ORG");
+        std::env::remove_var("DD_ACCESS_TOKEN");
+        std::env::remove_var("DD_API_KEY");
+        std::env::remove_var("DD_APP_KEY");
+
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.subsec_nanos())
+            .unwrap_or(0);
+        let tmp = std::env::temp_dir().join(format!("pup_cfg_ddsite_wins_{nanos}"));
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::env::set_var("PUP_CONFIG_DIR", &tmp);
+
+        crate::auth::storage::save_session(&SessionEntry {
+            site: "datadoghq.eu".into(),
+            org: None,
+            org_uuid: None,
+        })
+        .unwrap();
+        std::env::set_var("DD_SITE", "us3.datadoghq.com");
+
+        let cfg = Config::from_env().unwrap();
+
+        std::env::remove_var("DD_SITE");
+        std::env::remove_var("PUP_CONFIG_DIR");
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        assert_eq!(cfg.site, "us3.datadoghq.com");
+        assert!(cfg.site_explicit);
+    }
+
+    /// When DD_ORG is set the no-org fallback must not fire — the org-session
+    /// resolution path handles site lookup instead.
+    #[test]
+    fn test_from_env_named_org_skips_default_session_fallback() {
+        let _guard = ENV_LOCK.blocking_lock();
+        std::env::remove_var("DD_SITE");
+        std::env::remove_var("DD_ACCESS_TOKEN");
+        std::env::remove_var("DD_API_KEY");
+        std::env::remove_var("DD_APP_KEY");
+
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.subsec_nanos())
+            .unwrap_or(0);
+        let tmp = std::env::temp_dir().join(format!("pup_cfg_named_org_skip_{nanos}"));
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::env::set_var("PUP_CONFIG_DIR", &tmp);
+
+        // Default session on EU.
+        crate::auth::storage::save_session(&SessionEntry {
+            site: "datadoghq.eu".into(),
+            org: None,
+            org_uuid: None,
+        })
+        .unwrap();
+        // DD_ORG is set to a name that has no saved session; the fallback must
+        // not adopt the no-org EU session's site.
+        std::env::set_var("DD_ORG", "unknown-org");
+
+        let cfg = Config::from_env().unwrap();
+
+        std::env::remove_var("DD_ORG");
+        std::env::remove_var("PUP_CONFIG_DIR");
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        // No session for unknown-org and the no-org fallback is blocked by
+        // org.is_some(), so we fall through to the hard-coded default.
+        assert_eq!(cfg.site, "datadoghq.com");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -134,8 +134,12 @@ impl Config {
                 // the single no-org ("default") session's site. This fixes bare
                 // commands after a datacenter-switched login (e.g. datadoghq.eu):
                 // the token is stored under the switched site but the resolver
-                // previously hard-coded datadoghq.com. Named-org sessions are
-                // unaffected — this branch only fires when org.is_none().
+                // previously hard-coded datadoghq.com. This fires whenever the
+                // DD_ORG/file org is unset, which includes `--org <flag>`
+                // invocations (the flag is applied later, in main_inner); for
+                // those, apply_org_override re-resolves the site from the named
+                // org's session (or resets to the default when it has none), so a
+                // named org never keeps the no-org session's site.
                 #[cfg(not(target_arch = "wasm32"))]
                 {
                     if org.is_none() {
@@ -578,6 +582,15 @@ pub fn apply_org_override(cfg: &mut Config, org: String) -> Result<()> {
                 )
             })?;
             cfg.site = normalized;
+        } else {
+            // The named org has no saved session. Reset to the default site so a
+            // `--org` flag behaves like `DD_ORG` and does not inherit the no-org
+            // default-session site that `from_env` may have adopted (it runs
+            // before this override and sees org.is_none()). Without this, e.g.
+            // `pup auth login --org new-org` with an existing datadoghq.eu default
+            // session would misroute the login to EU. Gated on !site_explicit, so
+            // an explicit DD_SITE/--site still wins.
+            cfg.site = normalize_site("datadoghq.com");
         }
     }
     if std::env::var("DD_ACCESS_TOKEN")
@@ -1881,6 +1894,49 @@ mod tests {
         let _ = std::fs::remove_dir_all(&tmp);
 
         assert_eq!(cfg.org.as_deref(), Some("unknown-org"));
+        assert_eq!(cfg.site, "datadoghq.com");
+    }
+
+    /// A `--org` flag for an org with no session must reset the site to the
+    /// default rather than inherit the no-org default-session site that
+    /// `from_env` adopted. Without this, `pup --org new-org ...` (or a
+    /// first-time `auth login --org new-org`) with an existing datadoghq.eu
+    /// default session would misroute to EU. Regression guard for the Codex
+    /// review finding on the #592 fix.
+    #[test]
+    fn test_apply_org_override_resets_default_session_site_for_unknown_org() {
+        let _guard = ENV_LOCK.blocking_lock();
+        std::env::remove_var("DD_ACCESS_TOKEN");
+
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.subsec_nanos())
+            .unwrap_or(0);
+        let tmp = std::env::temp_dir().join(format!("pup_cfg_apply_reset_{nanos}"));
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::env::set_var("PUP_CONFIG_DIR", &tmp);
+
+        // Simulate from_env having adopted the no-org default session's site.
+        let mut cfg = Config {
+            api_key: None,
+            app_key: None,
+            access_token: None,
+            site: "datadoghq.eu".into(),
+            site_explicit: false,
+            org: None,
+            output_format: OutputFormat::Json,
+            auto_approve: false,
+            agent_mode: false,
+            read_only: false,
+        };
+
+        super::apply_org_override(&mut cfg, "unknown-org".into()).unwrap();
+
+        std::env::remove_var("PUP_CONFIG_DIR");
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        assert_eq!(cfg.org.as_deref(), Some("unknown-org"));
+        // Reset to default, NOT left at the inherited datadoghq.eu.
         assert_eq!(cfg.site, "datadoghq.com");
     }
 


### PR DESCRIPTION
## Summary

Fixes #592. A bare `pup auth login` that the datacenter switcher redirects to a non-default site (ex: `datadoghq.eu`) saved the OAuth token under that site, but subsequent bare commands resolved `datadoghq.com` and reported "not authenticated." The token was stored correctly; the resolver never consulted the no-org session on the switched site.

## Approach

The no-org ("default") session slot now holds exactly one session. A bare login sets it (and its site); site resolution falls back to that session's site before defaulting to `datadoghq.com`. To keep multiple regional sessions, name them with `--org` (unchanged).

## Changes

- `config.rs` `from_env`: when no org and no explicit site are set, fall back to the single no-org session's site before `datadoghq.com`. Because the extension fast-path and `logout` both read this resolved site, they pick up the fix without separate wiring.
- `storage.rs`: add `find_default_session_site` (returns the lone no-org site; warns and returns `None` on ambiguous legacy data) and `prune_other_default_sessions` (enforces the single-slot invariant; writes session rows before best-effort token cleanup so a write failure can only orphan a token, never a row).
- `auth.rs` `login`: a bare (no-org) login prunes other no-org sessions to keep the slot singular.
- `config.rs` `apply_org_override`: a `--org` flag naming an org with no session resets the site to the default rather than inheriting the no-org fallback site, so `--org` matches `DD_ORG`.

## Behavior change

A bare `pup auth login` to a new site replaces the previous unnamed default session, including deleting its stored token. This is the single-slot semantics; to keep multiple regional sessions, name them with `--org`.

## Out of scope / follow-up

- Making `--site` a global flag (it is currently only on `auth login`/`auth status`) is tracked separately and not in this PR.
- `pup auth status --site <other-site>` can report a stale token because `set_site_explicit` does not re-key the access token. This is a pre-existing bug in the `--site` path; its fix (token reload in `set_site_explicit`) belongs to the `--site`-globalization change.

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy` clean on changed code
- [x] `cargo test` unit tests pass (new: resolution matrix, `find_default_session_site`, prune row behavior + self-heal, unknown-`--org` reset). Pre-existing network-dependent command tests fail only under parallel execution and pass in isolation; untouched by this change.
- [x] Manual e2e: datacenter-switched bare login, then confirm a bare command authenticates against the switched site
