### PR TITLE
feat(cli): promote --site to a global flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,18 +242,16 @@ pup auth logout
 Pup persists each login as a separate session, so you can authenticate against multiple Datadog sites and orgs and switch between them with `--org <name>` (or `DD_ORG=<name>`) on any subcommand.
 
 ```bash
-# Login to a non-default site. --site is only accepted by `pup auth login`
-# and `pup auth status`. For other commands, select the site via DD_SITE
-# (or use a named session and pass --org on every subsequent command; see
-# the Named session examples below).
+# Login to a non-default site. --site is a global flag (the inline form of
+# DD_SITE) accepted on any command, so you can also select the site per-command.
 pup auth login --site datadoghq.eu
-DD_SITE=datadoghq.eu pup monitors list
+pup monitors list --site datadoghq.eu     # or: DD_SITE=datadoghq.eu pup monitors list
 
 # Named session for a parent/child sub-org on the same site.
 pup auth login --org staging-child
-pup monitors list --org staging-child     # site recalled from the session, no DD_SITE needed
+pup monitors list --org staging-child     # site recalled from the session, no --site needed
 
-# Named session on another site. DD_SITE / --site is only needed at login.
+# Named session on another site. --site / DD_SITE is only needed at login.
 pup auth login --site ap2.datadoghq.com --org ap2-prod
 pup monitors list --org ap2-prod          # site recalled
 
@@ -278,12 +276,13 @@ pup auth logout --org staging-child       # clears only that named session
 
 Note: `pup auth logout` (default session) also deletes the shared DCR client credentials for that site. Named-org sessions on the same site keep their access tokens but will fail to refresh until the shared credentials are re-registered, which happens automatically on the next `pup auth login` on that site (any org, named or default). Logging out a named session (`--org <name>`) does not touch the shared client credentials.
 
-**Site selection rules** (when pup resolves a site for a non-auth command):
-1. `DD_SITE` env var (or `site:` in `~/.config/pup/config.yaml`), if set.
-2. The site recorded in `~/.config/pup/sessions.json` for the named `--org` / `DD_ORG`, when the lookup is unambiguous.
-3. Default: `datadoghq.com`.
+**Site selection rules** (when pup resolves a site for a command):
+1. `--site` flag (the inline form of `DD_SITE`, accepted on any command), if set.
+2. `DD_SITE` env var (or `site:` in `~/.config/pup/config.yaml`), if set.
+3. The site recorded in `~/.config/pup/sessions.json` for the named `--org` / `DD_ORG`, when the lookup is unambiguous.
+4. Default: `datadoghq.com`.
 
-`pup auth login` and `pup auth status` additionally accept `--site`, which wins over the above for those two commands.
+`--site` is the highest-priority source and applies before `--org`, so an explicit site is never moved by the session lookup an `--org` would otherwise trigger.
 
 If multiple sessions share the same org name on different sites, step 2 is skipped (ambiguous) and pup warns to stderr; pass `DD_SITE` to disambiguate. An unnamed (default) session can't be selected by `--org` at all -- if you have multiple unnamed sessions on different sites, set `DD_SITE` to pick one.
 
@@ -425,7 +424,7 @@ pup incidents get abc-123-def
 - `DD_ACCESS_TOKEN`: Bearer token for stateless auth (highest priority)
 - `DD_API_KEY`: Datadog API key (optional if using OAuth2 or DD_ACCESS_TOKEN)
 - `DD_APP_KEY`: Datadog Application key (optional if using OAuth2 or DD_ACCESS_TOKEN)
-- `DD_SITE`: Datadog site (default: datadoghq.com)
+- `DD_SITE`: Datadog site (default: datadoghq.com). The `--site` flag is the inline form and works on any command.
 - `PUP_TRUST_SITE`: Trust a non-Datadog `--site`/`DD_SITE` host for this invocation without a prompt (true/1). For durable trust, add the host to `trusted_sites` in the config file. See [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md#override-api-endpoint).
 - `DD_AUTO_APPROVE`: Auto-approve destructive operations (true/false)
 - `DD_TOKEN_STORAGE`: Token storage backend (keychain or file, default: auto-detect)

--- a/README.md
+++ b/README.md
@@ -242,10 +242,10 @@ pup auth logout
 Pup persists each login as a separate session, so you can authenticate against multiple Datadog sites and orgs and switch between them with `--org <name>` (or `DD_ORG=<name>`) on any subcommand.
 
 ```bash
-# Login to a non-default site. --site is a global flag (the inline form of
-# DD_SITE) accepted on any command, so you can also select the site per-command.
+# Login to a non-default site. The site is stored in the session and
+# recalled automatically -- no --site or DD_SITE needed afterwards.
 pup auth login --site datadoghq.eu
-pup monitors list --site datadoghq.eu     # or: DD_SITE=datadoghq.eu pup monitors list
+pup monitors list                             # site recalled automatically
 
 # Named session for a parent/child sub-org on the same site.
 pup auth login --org staging-child
@@ -284,7 +284,7 @@ Note: `pup auth logout` (default session) also deletes the shared DCR client cre
 
 `--site` is the highest-priority source and applies before `--org`, so an explicit site is never moved by the session lookup an `--org` would otherwise trigger.
 
-If multiple sessions share the same org name on different sites, step 2 is skipped (ambiguous) and pup warns to stderr; pass `DD_SITE` to disambiguate. An unnamed (default) session can't be selected by `--org` at all -- if you have multiple unnamed sessions on different sites, set `DD_SITE` to pick one.
+If multiple sessions share the same org name on different sites, step 3 is skipped (ambiguous) and pup warns to stderr; pass `--site` or `DD_SITE` to disambiguate.
 
 **Token Storage**: By default, OAuth tokens and DCR client credentials are stored in your platform's secure store: macOS Keychain (via Apple's Security framework, with Touch ID prompts), Linux Secret Service (via the `keyring` crate), or Windows Credential Manager (via the `keyring` crate; sharded across multiple WinCred entries to stay within WinCred's per-record size limit). When no secure store is available, pup falls back to JSON files under `~/.config/pup/` with `0600` permissions; in file mode tokens and client credentials are kept in separate files (`tokens_<site>.json`, `client_<site>.json`). Set `DD_TOKEN_STORAGE=file` to force file storage. In either mode, all tokens for a given site share one tokens entry, keyed internally by org name.
 

--- a/docs/OAUTH2.md
+++ b/docs/OAUTH2.md
@@ -66,12 +66,9 @@ Manually refresh your access token using the refresh token. This happens automat
 ### 4. Logout
 
 ```bash
-pup auth logout                                # default session for the current site
-pup auth logout --site datadoghq.eu            # default session for a non-default site
-pup auth logout --org staging-child            # one named session, leaves others intact
+pup auth logout                    # default session (site resolved from stored session)
+pup auth logout --org staging-child  # one named session, leaves others intact
 ```
-
-Use `--site` to target the default session when it lives on a non-`datadoghq.com` site.
 
 **Side effect on sibling sessions:** logging out the default (unnamed)
 session for a site also deletes that site's shared DCR client

--- a/docs/OAUTH2.md
+++ b/docs/OAUTH2.md
@@ -67,12 +67,12 @@ Manually refresh your access token using the refresh token. This happens automat
 
 ```bash
 pup auth logout                                # default session for the current site
-DD_SITE=datadoghq.eu pup auth logout           # default session for a non-default site
+pup auth logout --site datadoghq.eu            # default session for a non-default site
 pup auth logout --org staging-child            # one named session, leaves others intact
 ```
 
-`pup auth logout` itself doesn't accept a `--site` flag; use `DD_SITE` to
-pick which default session to clear.
+Use `--site` (the global flag, equivalent to `DD_SITE`) to pick which default
+session to clear when it isn't on `datadoghq.com`.
 
 **Side effect on sibling sessions:** logging out the default (unnamed)
 session for a site also deletes that site's shared DCR client

--- a/docs/OAUTH2.md
+++ b/docs/OAUTH2.md
@@ -71,8 +71,7 @@ pup auth logout --site datadoghq.eu            # default session for a non-defau
 pup auth logout --org staging-child            # one named session, leaves others intact
 ```
 
-Use `--site` (the global flag, equivalent to `DD_SITE`) to pick which default
-session to clear when it isn't on `datadoghq.com`.
+Use `--site` to target the default session when it lives on a non-`datadoghq.com` site.
 
 **Side effect on sibling sessions:** logging out the default (unnamed)
 session for a site also deletes that site's shared DCR client

--- a/src/config.rs
+++ b/src/config.rs
@@ -603,6 +603,46 @@ pub fn apply_org_override(cfg: &mut Config, org: String) -> Result<()> {
     Ok(())
 }
 
+/// Apply an explicit `--site` / `DD_SITE` override (the inline flag form). Sets
+/// `site` + `site_explicit` and then re-keys the access token for the new site,
+/// the same way [`apply_org_override`] does for a new org.
+///
+/// The token reload is the whole point of routing through this function rather
+/// than calling [`Config::set_site_explicit`] directly: `set_site_explicit`
+/// only swaps `site`/`site_explicit`, but `from_env` already loaded
+/// `access_token` for the *previous* site. Without the reload, `--site` would
+/// keep the old site's token — shipping it to the new host and making
+/// `auth status --site <other>` misreport authentication using a stale token.
+///
+/// Only re-keys an OAuth-storage token, which is site-specific. An explicitly
+/// configured *static* bearer — `DD_ACCESS_TOKEN` env or a config-file
+/// `access_token` — is site-agnostic and outranks storage (the `from_env`
+/// precedence is env > file > keychain), so it must survive a `--site` switch.
+/// Otherwise `pup --site X ...` would drop a config-file bearer that
+/// `DD_SITE=X` keeps, breaking the "`--site` is the inline form of `DD_SITE`"
+/// guarantee. May leave `cfg.access_token` at `None` if there is no static
+/// bearer and no token is stored for the new site.
+///
+/// (Unlike [`apply_org_override`], which re-keys to the session's token because
+/// `--org` switches identity, `--site` only changes the host, so the static
+/// bearer is preserved.)
+///
+/// Apply this before [`apply_org_override`]: it sets `site_explicit`, which that
+/// function honors (it won't move an explicitly pinned site), and the `--org`
+/// reload then re-keys the token for the final `(site, org)` pair.
+#[cfg(all(not(feature = "browser"), not(target_arch = "wasm32")))]
+pub fn apply_site_override(cfg: &mut Config, site: String) -> Result<()> {
+    cfg.set_site_explicit(site)?;
+    let static_bearer = env_or(
+        "DD_ACCESS_TOKEN",
+        load_config_file().and_then(|c| c.access_token),
+    );
+    if static_bearer.is_none() {
+        cfg.access_token = load_token_from_storage(&cfg.site, cfg.org.as_deref());
+    }
+    Ok(())
+}
+
 /// Try to load a valid (non-expired) access token from keychain/file storage.
 /// If the token is expired, attempts an automatic refresh using the stored refresh token.
 /// Returns None silently on any error — callers fall through to other auth methods.
@@ -1938,6 +1978,182 @@ mod tests {
         assert_eq!(cfg.org.as_deref(), Some("unknown-org"));
         // Reset to default, NOT left at the inherited datadoghq.eu.
         assert_eq!(cfg.site, "datadoghq.com");
+    }
+
+    /// Regression: `--site <site-with-no-stored-token>` must re-key the access
+    /// token, not keep the previous site's token. Before `apply_site_override`,
+    /// the in-arm `set_site_explicit` only swapped the site, so an EU session
+    /// (EU token loaded by `from_env`) followed by `auth status --site us3...`
+    /// reported "authenticated" using the stale EU token.
+    #[test]
+    fn test_apply_site_override_reloads_token_for_new_site() {
+        let _guard = ENV_LOCK.blocking_lock();
+        std::env::remove_var("DD_ACCESS_TOKEN");
+
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.subsec_nanos())
+            .unwrap_or(0);
+        let tmp = std::env::temp_dir().join(format!("pup_cfg_apply_site_{nanos}"));
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::env::set_var("PUP_CONFIG_DIR", &tmp);
+
+        // Post-from_env state: a bare EU login left an EU token loaded.
+        let mut cfg = Config {
+            api_key: None,
+            app_key: None,
+            access_token: Some("eu-token".into()),
+            site: "datadoghq.eu".into(),
+            site_explicit: false,
+            org: None,
+            output_format: OutputFormat::Json,
+            auto_approve: false,
+            agent_mode: false,
+            read_only: false,
+        };
+
+        super::apply_site_override(&mut cfg, "us3.datadoghq.com".into()).unwrap();
+
+        std::env::remove_var("PUP_CONFIG_DIR");
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        assert_eq!(cfg.site, "us3.datadoghq.com");
+        assert!(cfg.site_explicit);
+        // No us3 token in storage → the stale EU token must be cleared.
+        assert_eq!(cfg.access_token, None);
+    }
+
+    /// `--site` then `--org` (main_inner ordering): the explicit site is pinned
+    /// (apply_org_override honors site_explicit), the org is applied, and the
+    /// token is re-keyed for the final (site, org) pair.
+    #[test]
+    fn test_apply_site_then_org_pins_site_and_applies_org() {
+        let _guard = ENV_LOCK.blocking_lock();
+        std::env::remove_var("DD_ACCESS_TOKEN");
+
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.subsec_nanos())
+            .unwrap_or(0);
+        let tmp = std::env::temp_dir().join(format!("pup_cfg_apply_site_org_{nanos}"));
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::env::set_var("PUP_CONFIG_DIR", &tmp);
+
+        // org-x has a saved session on a *different* site; the explicit --site
+        // must win over it.
+        crate::auth::storage::save_session(&SessionEntry {
+            site: "session.datadoghq.com".into(),
+            org: Some("org-x".into()),
+            org_uuid: None,
+        })
+        .unwrap();
+
+        let mut cfg = Config {
+            api_key: None,
+            app_key: None,
+            access_token: None,
+            site: "datadoghq.com".into(),
+            site_explicit: false,
+            org: None,
+            output_format: OutputFormat::Json,
+            auto_approve: false,
+            agent_mode: false,
+            read_only: false,
+        };
+
+        super::apply_site_override(&mut cfg, "datadoghq.eu".into()).unwrap();
+        super::apply_org_override(&mut cfg, "org-x".into()).unwrap();
+
+        std::env::remove_var("PUP_CONFIG_DIR");
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        assert_eq!(cfg.site, "datadoghq.eu");
+        assert!(cfg.site_explicit);
+        assert_eq!(cfg.org.as_deref(), Some("org-x"));
+        // No token stored for (datadoghq.eu, org-x).
+        assert_eq!(cfg.access_token, None);
+    }
+
+    /// A config-file `access_token` is a site-agnostic static bearer and outranks
+    /// keychain storage (from_env precedence env > file > keychain). It must
+    /// survive a `--site` switch — otherwise `pup --site X` would drop a bearer
+    /// that `DD_SITE=X` keeps, breaking the inline-form equivalence.
+    #[test]
+    fn test_apply_site_override_preserves_config_file_bearer() {
+        let _guard = ENV_LOCK.blocking_lock();
+        std::env::remove_var("DD_ACCESS_TOKEN");
+
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.subsec_nanos())
+            .unwrap_or(0);
+        let tmp = std::env::temp_dir().join(format!("pup_cfg_apply_site_filebearer_{nanos}"));
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::fs::write(tmp.join("config.yaml"), "access_token: file-bearer-token\n").unwrap();
+        std::env::set_var("PUP_CONFIG_DIR", &tmp);
+
+        // Post-from_env state for a config that carries a static bearer: from_env
+        // loads it (and never consults storage), so cfg.access_token is the file
+        // bearer and the site is the default.
+        let mut cfg = Config {
+            api_key: None,
+            app_key: None,
+            access_token: Some("file-bearer-token".into()),
+            site: "datadoghq.com".into(),
+            site_explicit: false,
+            org: None,
+            output_format: OutputFormat::Json,
+            auto_approve: false,
+            agent_mode: false,
+            read_only: false,
+        };
+
+        super::apply_site_override(&mut cfg, "datadoghq.eu".into()).unwrap();
+
+        std::env::remove_var("PUP_CONFIG_DIR");
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        assert_eq!(cfg.site, "datadoghq.eu");
+        // The static bearer must NOT be dropped to a (missing) storage token.
+        assert_eq!(cfg.access_token.as_deref(), Some("file-bearer-token"));
+    }
+
+    /// When DD_ACCESS_TOKEN is set, `--site` must not overwrite the caller-supplied
+    /// bearer with whatever happens to be in keychain storage. Mirrors
+    /// `test_apply_org_override_respects_env_access_token`.
+    #[test]
+    fn test_apply_site_override_respects_env_access_token() {
+        let _guard = ENV_LOCK.blocking_lock();
+
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.subsec_nanos())
+            .unwrap_or(0);
+        let tmp = std::env::temp_dir().join(format!("pup_cfg_apply_site_envtoken_{nanos}"));
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::env::set_var("PUP_CONFIG_DIR", &tmp);
+        std::env::set_var("DD_ACCESS_TOKEN", "env-supplied-token");
+
+        let mut cfg = Config {
+            api_key: None,
+            app_key: None,
+            access_token: Some("env-supplied-token".into()),
+            site: "datadoghq.com".into(),
+            site_explicit: false,
+            org: None,
+            output_format: OutputFormat::Json,
+            auto_approve: false,
+            agent_mode: false,
+            read_only: false,
+        };
+
+        super::apply_site_override(&mut cfg, "datadoghq.eu".into()).unwrap();
+
+        std::env::remove_var("DD_ACCESS_TOKEN");
+        std::env::remove_var("PUP_CONFIG_DIR");
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        assert_eq!(cfg.access_token.as_deref(), Some("env-supplied-token"));
     }
 
     /// When DD_ACCESS_TOKEN is set in the env, `--org` must not overwrite the

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -28,6 +28,8 @@ pub(crate) struct PreParsedGlobals {
     pub agent: bool,
     pub read_only: bool,
     pub org: Option<String>,
+    pub site: Option<String>,
+    pub trust_site: bool,
 }
 
 /// Parse the CLI arguments in a single left-to-right pass.
@@ -39,6 +41,8 @@ pub(crate) fn parse_extension_args(args: &[String]) -> ParsedArgs {
         agent: false,
         read_only: false,
         org: None,
+        site: None,
+        trust_site: false,
     };
     let mut candidate: Option<String> = None;
     let mut ext_args: Vec<String> = Vec::new();
@@ -63,16 +67,25 @@ pub(crate) fn parse_extension_args(args: &[String]) -> ParsedArgs {
                     globals.org = Some(val.clone());
                 }
             }
+            "--site" => {
+                if let Some(val) = iter.next() {
+                    globals.site = Some(val.clone());
+                }
+            }
             // Boolean flags
             "--yes" | "-y" => globals.yes = true,
             "--agent" => globals.agent = true,
             "--read-only" => globals.read_only = true,
-            // Equals-syntax value flags: --output=table, --org=prod
+            "--trust-site" => globals.trust_site = true,
+            // Equals-syntax value flags: --output=table, --org=prod, --site=datadoghq.eu
             s if s.starts_with("--output=") => {
                 globals.output = Some(s["--output=".len()..].to_string());
             }
             s if s.starts_with("--org=") => {
                 globals.org = Some(s["--org=".len()..].to_string());
+            }
+            s if s.starts_with("--site=") => {
+                globals.site = Some(s["--site=".len()..].to_string());
             }
             // Short flag with attached value: -ojson, -otable
             s if s.starts_with("-o") && s.len() > 2 => {
@@ -125,6 +138,15 @@ impl PreParsedGlobals {
         }
         if self.read_only {
             cfg.read_only = true;
+        }
+        // Apply --site before --org so an explicit site survives apply_org_override
+        // (which honors site_explicit) and the --org reload re-keys the token for
+        // the final (site, org) pair. Mirrors main_inner.
+        if let Some(ref site) = self.site {
+            #[cfg(all(not(feature = "browser"), not(target_arch = "wasm32")))]
+            config::apply_site_override(cfg, site.clone())?;
+            #[cfg(any(feature = "browser", target_arch = "wasm32"))]
+            cfg.set_site_explicit(site.clone())?;
         }
         if let Some(ref org) = self.org {
             #[cfg(all(not(feature = "browser"), not(target_arch = "wasm32")))]
@@ -194,6 +216,29 @@ mod tests {
         let parsed = parse_extension_args(&args("pup --org=staging terraform"));
         assert_eq!(parsed.candidate.as_deref(), Some("terraform"));
         assert_eq!(parsed.globals.org.as_deref(), Some("staging"));
+    }
+
+    #[test]
+    fn test_parse_site_space() {
+        let parsed = parse_extension_args(&args("pup --site datadoghq.eu terraform"));
+        assert_eq!(parsed.candidate.as_deref(), Some("terraform"));
+        assert_eq!(parsed.globals.site.as_deref(), Some("datadoghq.eu"));
+    }
+
+    #[test]
+    fn test_parse_site_equals() {
+        let parsed = parse_extension_args(&args("pup --site=us3.datadoghq.com terraform"));
+        assert_eq!(parsed.candidate.as_deref(), Some("terraform"));
+        assert_eq!(parsed.globals.site.as_deref(), Some("us3.datadoghq.com"));
+    }
+
+    #[test]
+    fn test_parse_trust_site_flag() {
+        let parsed =
+            parse_extension_args(&args("pup --site gw.example.com --trust-site terraform"));
+        assert_eq!(parsed.candidate.as_deref(), Some("terraform"));
+        assert_eq!(parsed.globals.site.as_deref(), Some("gw.example.com"));
+        assert!(parsed.globals.trust_site);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,13 @@ pub(crate) struct Cli {
     /// Named org session (see 'pup auth login --org')
     #[arg(long, global = true)]
     org: Option<String>,
+    /// Datadog site or literal host. The inline form of $DD_SITE; overrides
+    /// DD_SITE / config file. Defaults to datadoghq.com.
+    /// Standard sites: datadoghq.eu, us3.datadoghq.com, etc.
+    /// Vanity/SAML SSO host (at login): mycompany.datadoghq.com (replaces the old --subdomain flag).
+    /// Custom gateway: mygateway.example.com or mygateway.example.com:8443.
+    #[arg(long, global = true, value_name = "SITE")]
+    site: Option<String>,
     /// Trust a non-Datadog `--site`/`DD_SITE` host for this invocation (skip the
     /// trust prompt). For durable trust, use `trusted_sites` in config instead.
     #[arg(long, global = true)]
@@ -9674,13 +9681,6 @@ enum AuthActions {
         /// Shorthand: --ro
         #[arg(long, alias = "ro", visible_alias = "ro")]
         read_only: bool,
-        /// Datadog site or literal host to authenticate against.
-        /// Standard sites: datadoghq.eu, us3.datadoghq.com, etc.
-        /// Vanity/SAML SSO host: mycompany.datadoghq.com (replaces the old --subdomain flag).
-        /// Custom gateway: mygateway.example.com or mygateway.example.com:8443.
-        /// Overrides DD_SITE env var and config file. Defaults to datadoghq.com.
-        #[arg(long, value_name = "SITE")]
-        site: Option<String>,
         /// Pin the OAuth callback to one specific port from the DCR redirect allowlist
         /// [8000, 8080, 8888, 9000] instead of scanning. Useful when forwarding a single port
         /// over SSH. If the chosen port is busy login fails — no fallback. Other values are
@@ -9700,12 +9700,7 @@ enum AuthActions {
     /// Logout and clear tokens
     Logout,
     /// Check authentication status
-    Status {
-        /// Datadog site to check status for (e.g. datadoghq.eu, us3.datadoghq.com).
-        /// Overrides DD_SITE env var and config file. Defaults to datadoghq.com.
-        #[arg(long, value_name = "SITE")]
-        site: Option<String>,
-    },
+    Status,
     /// Print access token (debug builds only)
     #[cfg(debug_assertions)]
     Token,
@@ -9797,6 +9792,12 @@ fn build_agent_schema_scoped(
                 "type": "string",
                 "default": null,
                 "description": "Named org session for multi-org support (see 'pup auth login --org')"
+            },
+            {
+                "name": "--site",
+                "type": "string",
+                "default": null,
+                "description": "Datadog site or literal host (inline form of $DD_SITE); defaults to datadoghq.com"
             },
             {
                 "name": "--output",
@@ -9926,6 +9927,12 @@ fn build_agent_schema(cmd: &clap::Command) -> serde_json::Value {
                 "type": "string",
                 "default": null,
                 "description": "Named org session for multi-org support (see 'pup auth login --org')"
+            },
+            {
+                "name": "--site",
+                "type": "string",
+                "default": null,
+                "description": "Datadog site or literal host (inline form of $DD_SITE); defaults to datadoghq.com"
             },
             {
                 "name": "--output",
@@ -10952,6 +10959,20 @@ async fn main_inner() -> anyhow::Result<()> {
                 if let Some(ext_path) = extensions::extension_path(candidate) {
                     let mut cfg = config::Config::from_env()?;
                     parsed.globals.apply_to(&mut cfg)?;
+                    // This fast-path bypasses main_inner's central trust gate, so
+                    // gate here too: an extension inherits DD_API_KEY/DD_APP_KEY,
+                    // and `--site`/`DD_SITE` could otherwise ship them to a
+                    // non-Datadog host with no prompt.
+                    #[cfg(not(feature = "browser"))]
+                    {
+                        let interactive = std::io::stdin().is_terminal() && !cfg.agent_mode;
+                        let trusted_sites = config::configured_trusted_sites();
+                        cfg.ensure_site_trusted(
+                            parsed.globals.trust_site,
+                            interactive,
+                            &trusted_sites,
+                        )?;
+                    }
                     let exit_code = extensions::exec_extension(&ext_path, &parsed.ext_args, &cfg)?;
                     std::process::exit(exit_code);
                 }
@@ -11024,6 +11045,15 @@ async fn main_inner() -> anyhow::Result<()> {
     if cfg.agent_mode {
         cfg.auto_approve = true;
     }
+    // Apply --site flag (the inline form of DD_SITE). Done before --org so an
+    // explicit site survives apply_org_override (which honors site_explicit) and
+    // the subsequent --org reload re-keys the token for the final (site, org) pair.
+    if let Some(site) = cli.site.clone() {
+        #[cfg(all(not(feature = "browser"), not(target_arch = "wasm32")))]
+        config::apply_site_override(&mut cfg, site)?;
+        #[cfg(any(feature = "browser", target_arch = "wasm32"))]
+        cfg.set_site_explicit(site)?;
+    }
     // Apply --org flag (higher priority than DD_ORG env var / config file).
     // Site for this org and access token are also resolved here.
     if let Some(org) = cli.org {
@@ -11069,8 +11099,9 @@ async fn main_inner() -> anyhow::Result<()> {
     let trusted_sites = config::configured_trusted_sites();
 
     // Gate credential dispatch to non-Datadog hosts before any command dispatches.
-    // Auth subcommands resolve their own site late (after --site is applied in-arm),
-    // so they gate themselves; skip here to avoid a double prompt.
+    // Auth subcommands gate themselves in-arm (login/status/refresh each call
+    // ensure_site_trusted), so skip here to avoid a double prompt. --site is
+    // already resolved globally above, before this gate.
     #[cfg(not(feature = "browser"))]
     if !matches!(cli.command, Commands::Auth { .. }) {
         cfg.ensure_site_trusted(cli.trust_site, interactive, &trusted_sites)?;
@@ -14819,14 +14850,12 @@ async fn main_inner() -> anyhow::Result<()> {
             AuthActions::Login {
                 scopes,
                 read_only,
-                site,
                 callback_port,
                 org_uuid,
             } => {
-                if let Some(s) = site {
-                    cfg.set_site_explicit(s)?;
-                }
-                // Gate here rather than pre-match: --site is applied above and
+                // --site is resolved globally in main_inner (see apply_site_override),
+                // so cfg.site already reflects it here.
+                // Gate here rather than pre-match: the central gate skips Auth, and
                 // login opens a browser carrying the real SSO cookie plus DCR
                 // client credentials to this host, so it must be checked even
                 // when --site was not passed (the from_env site is still the target).
@@ -14842,10 +14871,9 @@ async fn main_inner() -> anyhow::Result<()> {
                 commands::auth::login(&cfg, resolved, resolved_port, org_uuid_hint).await?
             }
             AuthActions::Logout => commands::auth::logout(&cfg).await?,
-            AuthActions::Status { site } => {
-                if let Some(s) = site {
-                    cfg.set_site_explicit(s)?;
-                }
+            AuthActions::Status => {
+                // --site is resolved globally in main_inner (see apply_site_override),
+                // so cfg.site already reflects it here.
                 #[cfg(not(feature = "browser"))]
                 cfg.ensure_site_trusted(cli.trust_site, interactive, &trusted_sites)?;
                 commands::auth::status(&cfg)?

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -123,23 +123,23 @@ fn test_read_only_guard_exempts_auth() {
 }
 
 // -------------------------------------------------------------------------
-// Auth status --site flag
+// Global --site flag
 // -------------------------------------------------------------------------
 
 #[test]
-fn test_auth_status_accepts_site_flag() {
+fn test_auth_status_accepts_global_site_flag() {
     use clap::Parser;
 
+    // --site is now a global flag; clap accepts it after the subcommand and
+    // stores it on the top-level Cli, not on AuthActions::Status.
     let cli = crate::Cli::try_parse_from(["pup", "auth", "status", "--site", "datadoghq.eu"])
         .expect("auth status --site should parse");
 
+    assert_eq!(cli.site.as_deref(), Some("datadoghq.eu"));
     match cli.command {
-        crate::Commands::Auth { action } => match action {
-            crate::AuthActions::Status { site } => {
-                assert_eq!(site, Some("datadoghq.eu".to_string()));
-            }
-            _ => panic!("expected AuthActions::Status"),
-        },
+        crate::Commands::Auth { action } => {
+            assert!(matches!(action, crate::AuthActions::Status));
+        }
         _ => panic!("expected Commands::Auth"),
     }
 }
@@ -151,15 +151,29 @@ fn test_auth_status_site_flag_is_optional() {
     let cli = crate::Cli::try_parse_from(["pup", "auth", "status"])
         .expect("auth status without --site should parse");
 
+    assert_eq!(cli.site, None);
     match cli.command {
-        crate::Commands::Auth { action } => match action {
-            crate::AuthActions::Status { site } => {
-                assert_eq!(site, None);
-            }
-            _ => panic!("expected AuthActions::Status"),
-        },
+        crate::Commands::Auth { action } => {
+            assert!(matches!(action, crate::AuthActions::Status));
+        }
         _ => panic!("expected Commands::Auth"),
     }
+}
+
+#[test]
+fn test_global_site_flag_on_non_auth_command() {
+    use clap::Parser;
+
+    // Regression for the original bug: `--site` on a non-auth command used to
+    // error with "unexpected argument '--site'". As a global flag it now parses
+    // both before and after the subcommand.
+    let cli = crate::Cli::try_parse_from(["pup", "--site", "datadoghq.eu", "monitors", "list"])
+        .expect("--site before a non-auth subcommand should parse");
+    assert_eq!(cli.site.as_deref(), Some("datadoghq.eu"));
+
+    let cli = crate::Cli::try_parse_from(["pup", "monitors", "list", "--site=us3.datadoghq.com"])
+        .expect("--site after a non-auth subcommand should parse");
+    assert_eq!(cli.site.as_deref(), Some("us3.datadoghq.com"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`--site` was previously accepted only by `auth login` and `auth status`, so `pup logs list --site datadoghq.eu` failed with _unexpected argument_. This makes it a global flag -- the inline form of `$DD_SITE` -- symmetric with `$DD_ORG`/`--org`.

**Who benefits:** Primarily API key users (`DD_API_KEY` + `DD_APP_KEY`). They have no stored session so the site isn't implied; `--site` is the per-command alternative to setting `DD_SITE` in the environment. OAuth users rarely need `--site` on non-login commands -- post-#596, the site is stored at login and recalled automatically for every subsequent command.

**Changes:**
- Add `--site` to the top-level `Cli` struct (`global = true`), remove it from `AuthActions::Login` and `AuthActions::Status`
- New `apply_site_override` in `config.rs` sets `site`+`site_explicit` and re-keys `cfg.access_token` for the new site. Fixes a stale-token bug: `auth status --site <other-site>` previously reported authenticated using a token loaded for a different site
- Extension fast-path: add `ensure_site_trusted` before `exec_extension`; without it, `pup <ext> --site evil.com` (or `DD_SITE=evil.com pup <ext>`) would ship API keys to a non-Datadog host with no prompt
- Update README and `docs/OAUTH2.md` to reflect that OAuth users don't need `--site` after login

## Test plan

- `test_global_site_flag_on_non_auth_command` -- `pup monitors list --site datadoghq.eu` now parses (regression guard)
- `test_apply_site_override_reloads_token_for_new_site` -- stale EU token is cleared when switching to a site with no stored token
- `test_apply_site_then_org_pins_site_and_applies_org` -- explicit `--site` survives `apply_org_override`
- `test_apply_site_override_preserves_config_file_bearer` / `test_apply_site_override_respects_env_access_token` -- static bearers are not dropped on a site switch
- Manual binary checks: `--site` on a non-auth command is recognized; non-Datadog host rejected by trust gate; `--site` advertised in help as a global option