### PR TITLE
fix(ddsql): correct wrong DDSQL time-series help example

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1080,7 +1080,7 @@ enum Commands {
     ///   pup ddsql table --query "SELECT * FROM reference_tables.offices_ips LIMIT 5"
     ///   pup ddsql table --query "SELECT * FROM reference_tables.offices_ips" -o csv > results.csv
     ///   cat query.sql | pup ddsql table --query - -o table
-    ///   pup ddsql time-series --query "SELECT avg(system.cpu.user) FROM metrics GROUP BY host" --from 1h --interval 300000
+    ///   pup ddsql time-series --query "SELECT timestamp, value, tags->'host' AS host FROM dd.metrics_timeseries('avg:system.cpu.user{*} by {host}')" --from 1h
     ///   pup ddsql spec
     ///   pup ddsql schema tables --query ec2 --limit 100
     ///   pup ddsql schema columns --table-id public.aws.ec2_instance


### PR DESCRIPTION
## Summary
The `pup ddsql time-series` example in `--help` queried a bare `metrics` table, which is not a valid DDSQL dataset. Anyone (or more likely anyone's agent) copying the example verbatim hits an HTTP 400. This swaps it for a verified `dd.metrics_timeseries(...)` query, the spec-correct way to read metrics via DDSQL.

## Changes
- Fixed the `time-series` example in the `ddsql` command help (src/main.rs:1083):
  - Before: `SELECT avg(system.cpu.user) FROM metrics GROUP BY host`
  - After: `SELECT timestamp, value, tags->'host' AS host FROM dd.metrics_timeseries('avg:system.cpu.user{*} by {host}')`
- Dropped the misleading `--interval 300000` flag from the example — metric resolution comes from the `dd.metrics_timeseries(...)` call, not that flag.

## Testing
- Reproduced the original failure against the live API:
```bash
$ pup ddsql time-series --query "SELECT avg(system.cpu.user) FROM metrics GROUP BY host" --from 1h
#Error: ... (HTTP 400): {"errors":[{"title":"Bad Request","detail":"depends on non-existent dataset "metrics""}]}
```
- Verified the replacement returns real per-host timeseries:
```bash
$ pup ddsql time-series --query "SELECT timestamp, value, tags->'host' AS host FROM dd.metrics_timeseries('avg:system.cpu.user{*} by {host}')" --from 1h
#[ { "host": "dd-agent7", "timestamp": 1781725600000, "value": 0.1668... }, ... ]
```
- `cargo check` passes (the doc comment feeds clap's `verbatim_doc_comment` derive).