### PR TITLE
docs: remove stale multi-session guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Note: `pup auth logout` (default session) also deletes the shared DCR client cre
 
 `pup auth login` and `pup auth status` additionally accept `--site`, which wins over the above for those two commands.
 
-If multiple sessions share the same org name on different sites, step 2 is skipped (ambiguous) and pup warns to stderr; pass `DD_SITE` to disambiguate. An unnamed (default) session can't be selected by `--org` at all -- if you have multiple unnamed sessions on different sites, set `DD_SITE` to pick one.
+If multiple sessions share the same org name on different sites, step 2 is skipped (ambiguous) and pup warns to stderr; pass `DD_SITE` to disambiguate. An unnamed (default) session can't be selected by `--org` at all -- it has no name to look up.
 
 **Token Storage**: By default, OAuth tokens and DCR client credentials are stored in your platform's secure store: macOS Keychain (via Apple's Security framework, with Touch ID prompts), Linux Secret Service (via the `keyring` crate), or Windows Credential Manager (via the `keyring` crate; sharded across multiple WinCred entries to stay within WinCred's per-record size limit). When no secure store is available, pup falls back to JSON files under `~/.config/pup/` with `0600` permissions; in file mode tokens and client credentials are kept in separate files (`tokens_<site>.json`, `client_<site>.json`). Set `DD_TOKEN_STORAGE=file` to force file storage. In either mode, all tokens for a given site share one tokens entry, keyed internally by org name.
 

--- a/docs/OAUTH2.md
+++ b/docs/OAUTH2.md
@@ -66,13 +66,9 @@ Manually refresh your access token using the refresh token. This happens automat
 ### 4. Logout
 
 ```bash
-pup auth logout                                # default session for the current site
-DD_SITE=datadoghq.eu pup auth logout           # default session for a non-default site
+pup auth logout                                # default session
 pup auth logout --org staging-child            # one named session, leaves others intact
 ```
-
-`pup auth logout` itself doesn't accept a `--site` flag; use `DD_SITE` to
-pick which default session to clear.
 
 **Side effect on sibling sessions:** logging out the default (unnamed)
 session for a site also deletes that site's shared DCR client
@@ -415,8 +411,7 @@ accepts `--site`.
 If multiple sessions share the same org name on different sites, step 2
 is skipped (ambiguous) and pup warns to stderr; pass `DD_SITE` to
 disambiguate. An unnamed (default) session can't be selected by `--org`
-at all (it has no name to look up), so if you have multiple unnamed
-sessions on different sites, set `DD_SITE` to pick one.
+at all -- it has no name to look up.
 
 ### Session registry
 


### PR DESCRIPTION
## Summary

PR #596 enforced a single-slot invariant for unnamed (default) sessions -- `prune_other_default_sessions` ensures a bare `pup auth login` always overwrites the existing default. The docs had two sections that still described the now-impossible case of multiple unnamed sessions coexisting.

Changes:
- **docs/OAUTH2.md** (logout section): remove the `DD_SITE=datadoghq.eu pup auth logout` example and the note that `pup auth logout` doesn't accept `--site`
- **docs/OAUTH2.md** (site selection): drop the "if you have multiple unnamed sessions on different sites, set `DD_SITE` to pick one" sentence
- **README.md** (site selection): same sentence removed; replace with the accurate invariant ("it has no name to look up")

The first sentence of each site-selection paragraph -- about named sessions on multiple sites -- is still accurate and untouched.