### PR TITLE
fix(ddsql): correct broken DDSQL time-series help example

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1080,7 +1080,7 @@ enum Commands {
     ///   pup ddsql table --query "SELECT * FROM reference_tables.offices_ips LIMIT 5"
     ///   pup ddsql table --query "SELECT * FROM reference_tables.offices_ips" -o csv > results.csv
     ///   cat query.sql | pup ddsql table --query - -o table
-    ///   pup ddsql time-series --query "SELECT avg(system.cpu.user) FROM metrics GROUP BY host" --from 1h --interval 300000
+    ///   pup ddsql time-series --query "SELECT timestamp, value, tags->'host' AS host FROM dd.metrics_timeseries('avg:system.cpu.user{*} by {host}')" --from 1h
     ///   pup ddsql spec
     ///   pup ddsql schema tables --query ec2 --limit 100
     ///   pup ddsql schema columns --table-id public.aws.ec2_instance


### PR DESCRIPTION
## Summary
Cherry-pick of #599 (authored by @roippi) with a signed commit to satisfy the merge gate.

Fixes the `pup ddsql time-series` help example, which referenced a non-existent `metrics` dataset and caused HTTP 400 errors for anyone (or any agent) copying it verbatim.

## Changes
- `src/main.rs:1083`: replace `SELECT avg(system.cpu.user) FROM metrics GROUP BY host` (invalid) with `SELECT timestamp, value, tags->'host' AS host FROM dd.metrics_timeseries('avg:system.cpu.user{*} by {host}')` (spec-correct)
- Drops the misleading `--interval 300000` flag from the example

## Testing
Verified by original author in #599 against the live API — broken query returns HTTP 400, corrected query returns real per-host timeseries data.

Closes #599

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)